### PR TITLE
fix(fonts): register Vazirmatn in webfont catalog for JSON imports

### DIFF
--- a/packages/fonts/src/index.test.ts
+++ b/packages/fonts/src/index.test.ts
@@ -297,8 +297,12 @@ describe("locale coverage fonts (#3098)", () => {
 	});
 
 	it("returns a gstatic source for Vazirmatn regular so PDF registration can load it", () => {
+		const regularSource = getWebFont("Vazirmatn")?.files["400"];
+		expect(regularSource).toBeDefined();
+
 		const source = getWebFontSource("Vazirmatn", "400");
-		expect(source).toEqual(expect.stringContaining("vazirmatn"));
+		expect(source).toBe(regularSource);
+		expect(source).toEqual(expect.stringContaining("fonts.gstatic.com"));
 		expect(source).toEqual(expect.stringMatching(/\.ttf(\?|$)/));
 	});
 });

--- a/packages/fonts/src/index.test.ts
+++ b/packages/fonts/src/index.test.ts
@@ -289,3 +289,16 @@ describe("legacy font compatibility (#2989)", () => {
 		expect(getFontDisplayName("Times New Roman")).toBe("Times New Roman");
 	});
 });
+
+describe("locale coverage fonts (#3098)", () => {
+	it("resolves Vazirmatn from the webfont catalog", () => {
+		expect(getFont("Vazirmatn")?.family).toBe("Vazirmatn");
+		expect(getWebFont("Vazirmatn")?.category).toBe("sans-serif");
+	});
+
+	it("returns a gstatic source for Vazirmatn regular so PDF registration can load it", () => {
+		const source = getWebFontSource("Vazirmatn", "400");
+		expect(source).toEqual(expect.stringContaining("vazirmatn"));
+		expect(source).toEqual(expect.stringMatching(/\.ttf(\?|$)/));
+	});
+});

--- a/packages/fonts/src/webfontlist.json
+++ b/packages/fonts/src/webfontlist.json
@@ -7522,5 +7522,23 @@
 			"400italic": "https://fonts.gstatic.com/s/carlito/v4/3Jn_SDPw3m-pk039DDKxTl0F.ttf",
 			"700italic": "https://fonts.gstatic.com/s/carlito/v4/3Jn6SDPw3m-pk039DDK59XgVUcBD.ttf"
 		}
+	},
+	{
+		"type": "web",
+		"category": "sans-serif",
+		"family": "Vazirmatn",
+		"weights": ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+		"preview": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklWgzCRCT60LA7Qdazg.ttf",
+		"files": {
+			"100": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklWgyCRCT60LA7Qdazg.ttf",
+			"200": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklegzCRCT60LA7Qdazg.ttf",
+			"300": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklTYzCRCT60LA7Qdazg.ttf",
+			"400": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklWgzCRCT60LA7Qdazg.ttf",
+			"500": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklVozCRCT60LA7Qdazg.ttf",
+			"600": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklbY0CRCT60LA7Qdazg.ttf",
+			"700": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklY80CRCT60LA7Qdazg.ttf",
+			"800": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRkleg0CRCT60LA7Qdazg.ttf",
+			"900": "https://fonts.gstatic.com/s/vazirmatn/v16/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklcE0CRCT60LA7Qdazg.ttf"
+		}
 	}
 ]

--- a/packages/pdf/src/hooks/use-register-fonts.test.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.test.ts
@@ -299,6 +299,25 @@ describe("registerFonts", () => {
 		expect(registerSpy).not.toHaveBeenCalledWith(expect.objectContaining({ family: "Lato", fontWeight: 600 }));
 		expect(registerSpy).toHaveBeenCalledWith(expect.objectContaining({ family: "Lato", fontWeight: 700 }));
 	});
+
+	it("keeps Vazirmatn as the primary PDF family instead of substituting IBM Plex Serif (#3098)", async () => {
+		const registerSpy = vi.spyOn(Font, "register").mockImplementation(() => {});
+		vi.spyOn(Font, "registerHyphenationCallback").mockImplementation(() => {});
+		const { registerFonts } = await import("./use-register-fonts");
+
+		const vazirTypography = {
+			...typography,
+			body: { ...typography.body, fontFamily: "Vazirmatn", fontWeights: ["400"] },
+			heading: { ...typography.heading, fontFamily: "Vazirmatn", fontWeights: ["700"] },
+		} satisfies Typography;
+
+		const pdfTypography = registerFonts(vazirTypography, "fa-IR");
+
+		expect(pdfTypography.body.fontFamily).toEqual(["Vazirmatn", "Noto Sans Arabic", "Noto Sans"]);
+		expect(pdfTypography.heading.fontFamily).toEqual(["Vazirmatn", "Noto Sans Arabic", "Noto Sans"]);
+		expect(registerSpy).toHaveBeenCalledWith(expect.objectContaining({ family: "Vazirmatn", fontWeight: 400 }));
+		expect(registerSpy).toHaveBeenCalledWith(expect.objectContaining({ family: "Vazirmatn", fontWeight: 700 }));
+	});
 });
 
 describe("resumeContentContainsCJK", () => {

--- a/tooling/fonts/generate.ts
+++ b/tooling/fonts/generate.ts
@@ -241,9 +241,13 @@ async function generateFonts() {
 		...filteredLocaleCoverage,
 	];
 
-	console.log(
-		`Added ${computerModernFonts.length} Computer Modern Web Fonts, ${filteredMetricCompat.length} metric-compatible fonts, and ${filteredLocaleCoverage.length} locale-coverage fonts. Total output: ${allWebFonts.length} web fonts.`,
-	);
+	const manualFontSummary = [
+		`${computerModernFonts.length} Computer Modern Web Fonts`,
+		`${filteredMetricCompat.length} metric-compatible fonts`,
+		`and ${filteredLocaleCoverage.length} locale-coverage fonts`,
+	].join(", ");
+
+	console.log(`Added ${manualFontSummary}. Total output: ${allWebFonts.length} web fonts.`);
 
 	const jsonString = argCompress ? JSON.stringify(allWebFonts) : JSON.stringify(allWebFonts, null, 2);
 	await mkdir(FONTS_DIR, { recursive: true });

--- a/tooling/fonts/generate.ts
+++ b/tooling/fonts/generate.ts
@@ -160,6 +160,37 @@ function getMetricCompatibleFonts(): WebFont[] {
 	];
 }
 
+/**
+ * Helper: locale-coverage web fonts that aren't in the popularity-sorted
+ * Google Fonts slice but are stored as `typography.*.fontFamily` in imported
+ * resume JSON. Without a catalog entry, PDF registration silently substitutes
+ * IBM Plex Serif and Persian/Arabic glyphs stack or tofu (#3098).
+ */
+function getLocaleCoverageFonts(): WebFont[] {
+	const CDN = "https://fonts.gstatic.com/s/vazirmatn/v16";
+
+	return [
+		{
+			type: "web",
+			category: "sans-serif",
+			family: "Vazirmatn",
+			weights: ["100", "200", "300", "400", "500", "600", "700", "800", "900"],
+			preview: `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklWgzCRCT60LA7Qdazg.ttf`,
+			files: {
+				"100": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklWgyCRCT60LA7Qdazg.ttf`,
+				"200": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklegzCRCT60LA7Qdazg.ttf`,
+				"300": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklTYzCRCT60LA7Qdazg.ttf`,
+				"400": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklWgzCRCT60LA7Qdazg.ttf`,
+				"500": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklVozCRCT60LA7Qdazg.ttf`,
+				"600": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklbY0CRCT60LA7Qdazg.ttf`,
+				"700": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklY80CRCT60LA7Qdazg.ttf`,
+				"800": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRkleg0CRCT60LA7Qdazg.ttf`,
+				"900": `${CDN}/Dxx78j6PP2D_kU2muijPEe1n2vVbfJRklcE0CRCT60LA7Qdazg.ttf`,
+			},
+		},
+	];
+}
+
 async function generateFonts() {
 	const response = await getGoogleFontsJSON();
 	console.log(`Found ${response.items.length} fonts in total (Google Fonts).`);
@@ -196,15 +227,22 @@ async function generateFonts() {
 	const computerModernFonts = getComputerModernWebFonts();
 	// Manually append metric-compatible fonts not covered by the popularity slice
 	const metricCompatFonts = getMetricCompatibleFonts();
+	const localeCoverageFonts = getLocaleCoverageFonts();
 	// De-duplicate against the Google Fonts slice in case a manual entry
 	// later enters the popularity top-N.
 	const googleFontFamilies = new Set(googleFontResults.map((f) => f.family));
 	const filteredMetricCompat = metricCompatFonts.filter((f) => !googleFontFamilies.has(f.family));
+	const filteredLocaleCoverage = localeCoverageFonts.filter((f) => !googleFontFamilies.has(f.family));
 
-	const allWebFonts: WebFont[] = [...computerModernFonts, ...googleFontResults, ...filteredMetricCompat];
+	const allWebFonts: WebFont[] = [
+		...computerModernFonts,
+		...googleFontResults,
+		...filteredMetricCompat,
+		...filteredLocaleCoverage,
+	];
 
 	console.log(
-		`Added ${computerModernFonts.length} Computer Modern Web Fonts and ${filteredMetricCompat.length} metric-compatible fonts. Total output: ${allWebFonts.length} web fonts.`,
+		`Added ${computerModernFonts.length} Computer Modern Web Fonts, ${filteredMetricCompat.length} metric-compatible fonts, and ${filteredLocaleCoverage.length} locale-coverage fonts. Total output: ${allWebFonts.length} web fonts.`,
 	);
 
 	const jsonString = argCompress ? JSON.stringify(allWebFonts) : JSON.stringify(allWebFonts, null, 2);


### PR DESCRIPTION
## Summary

Fixes #3098.

Imported Reactive Resume JSON can set `metadata.typography.*.fontFamily` to `Vazirmatn`, but the popularity-sorted Google Fonts slice does not include it. PDF/font registration then falls back to IBM Plex Serif, so Persian/Arabic text stacks or shows tofu.

This adds `Vazirmatn` as a locale-coverage manual webfont entry (same pattern as Carlito for #2989) and extends the font catalog tests.

## Test plan

- [x] `pnpm --filter @reactive-resume/fonts test` — 47/47 pass
- [x] Verified gstatic URLs for Vazirmatn weights return HTTP 200

## AI disclosure

AI-assisted: implementation and tests drafted with Cursor Composer; verified locally before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vazirmatn to the font catalog with weights 100–900, preview support, and downloadable font files.
  * Added Vazirmatn support for Persian PDF documents, including Arabic fallback fonts and configured font weights.
* **Tests**
  * Added coverage for catalog availability, sans-serif classification, regular-weight access, and Persian PDF font selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds Vazirmatn to the generated and checked-in webfont catalog so imported Persian and Arabic resumes retain their selected family during PDF rendering.
- Adds explicit Vazirmatn sources for weights 100–900.
- Preserves the manual entry when regenerating the popularity-limited catalog.
- Tests catalog lookup, regular source resolution, PDF fallback ordering, and registration of representative weights.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tooling/fonts/generate.ts | Adds a de-duplicated locale-coverage font group containing Vazirmatn to generated catalog output. |
| packages/fonts/src/webfontlist.json | Registers Vazirmatn as a sans-serif webfont with explicit sources for weights 100–900. |
| packages/fonts/src/index.test.ts | Verifies Vazirmatn catalog resolution, classification, and regular-weight source lookup. |
| packages/pdf/src/hooks/use-register-fonts.test.ts | Verifies Persian PDF typography keeps Vazirmatn primary while retaining the Arabic and punctuation fallback stack. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(fonts): address CodeRabbit review on..."](https://github.com/amruthpillai/reactive-resume/commit/db02e0bd1723b309b664e4ddf22f13ac6146229a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53804980)</sub>

**Context used:**

- Knowledge Base — [Document export and fonts](https://app.greptile.com/reactive-resume/-/custom-context/knowledge-base/amruthpillai/reactive-resume/-/docs/document-export-and-fonts.md)

<!-- /greptile_comment -->