### PR TITLE
fix(api): translate copilot AI provider failures to BAD_GATEWAY

### DIFF
--- a/packages/api/src/features/applications/ai.test.ts
+++ b/packages/api/src/features/applications/ai.test.ts
@@ -62,7 +62,7 @@ describe("copilot provider-failure translation", () => {
 	it("translates AI SDK provider failures to BAD_GATEWAY in generateJson", async () => {
 		vi.mocked(generateText).mockRejectedValue(new AISDKError({ name: "AISDKError", message: "Model not found" }));
 
-		await expect(generateJson({} as never, "prompt", schema)).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+		await expect(generateJson({} as never, { prompt: "prompt" }, schema)).rejects.toMatchObject({ code: "BAD_GATEWAY" });
 	});
 
 	it("preserves the provider error as the BAD_GATEWAY cause", async () => {
@@ -81,12 +81,12 @@ describe("copilot provider-failure translation", () => {
 		vi.mocked(generateText).mockRejectedValue(unrelated);
 
 		await expect(generatePlainText({} as never, "prompt")).rejects.toBe(unrelated);
-		await expect(generateJson({} as never, "prompt", schema)).rejects.toBe(unrelated);
+		await expect(generateJson({} as never, { prompt: "prompt" }, schema)).rejects.toBe(unrelated);
 	});
 
 	it("still returns parsed JSON on success", async () => {
 		vi.mocked(generateText).mockResolvedValue({ text: '```json\n{"summary":"<p>Hi</p>"}\n```' } as never);
 
-		await expect(generateJson({} as never, "prompt", schema)).resolves.toEqual({ summary: "<p>Hi</p>" });
+		await expect(generateJson({} as never, { prompt: "prompt" }, schema)).resolves.toEqual({ summary: "<p>Hi</p>" });
 	});
 });

--- a/packages/api/src/features/applications/ai.test.ts
+++ b/packages/api/src/features/applications/ai.test.ts
@@ -1,17 +1,23 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AISDKError, generateText } from "ai";
+import { z } from "zod";
 
 const protectedProcedureMock = vi.hoisted(() => {
 	const chain = {
 		route: vi.fn(() => chain),
 		input: vi.fn(() => chain),
-		use: vi.fn(() => chain),
-		output: vi.fn(() => chain),
+		.use: vi.fn(() => chain),
+		.output: vi.fn(() => chain),
+		.errors: vi.fn(() => chain),
 		handler: vi.fn(() => chain),
 	};
 	return chain;
 });
 
-vi.mock("ai", () => ({ generateText: vi.fn() }));
+vi.mock("ai", async (importOriginal) => ({
+	...(await importOriginal<typeof import("ai")>()),
+	generateText: vi.fn(),
+}));
 vi.mock("../../context", () => ({ protectedProcedure: protectedProcedureMock }));
 vi.mock("../../middleware/rate-limit", () => ({ aiRequestRateLimit: vi.fn() }));
 vi.mock("../ai/service", () => ({ getModel: vi.fn() }));
@@ -21,7 +27,7 @@ vi.mock("./service", () => ({
 	applicationService: { getById: vi.fn(), setAiResult: vi.fn(), update: vi.fn(), addNote: vi.fn() },
 }));
 
-const { autofillInputSchema } = await import("./ai");
+const { autofillInputSchema, generateJson, generatePlainText } = await import("./ai");
 
 describe("autofillInputSchema", () => {
 	it("rejects oversized pasted job descriptions", () => {
@@ -37,5 +43,50 @@ describe("autofillInputSchema", () => {
 		expect(autofillInputSchema.parse({ jobDescription: "  Senior Engineer at Acme  " }).jobDescription).toBe(
 			"Senior Engineer at Acme",
 		);
+	});
+});
+
+describe("copilot provider-failure translation", () => {
+	const schema = z.object({ summary: z.string() });
+
+	beforeEach(() => {
+		vi.mocked(generateText).mockReset();
+	});
+
+	it("translates AI SDK provider failures to BAD_GATEWAY in generatePlainText", async () => {
+		vi.mocked(generateText).mockRejectedValue(new AISDKError({ name: "AISDKError", message: "Provider returned 401" }));
+
+		await expect(generatePlainText({} as never, "prompt")).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+	});
+
+	it("translates AI SDK provider failures to BAD_GATEWAY in generateJson", async () => {
+		vi.mocked(generateText).mockRejectedValue(new AISDKError({ name: "AISDKError", message: "Model not found" }));
+
+		await expect(generateJson({} as never, "prompt", schema)).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+	});
+
+	it("preserves the provider error as the BAD_GATEWAY cause", async () => {
+		const providerError = new AISDKError({ name: "AISDKError", message: "quota exceeded" });
+		vi.mocked(generateText).mockRejectedValue(providerError);
+
+		const error: { code?: string; cause?: unknown } = await generatePlainText({} as never, "prompt").catch(
+			(thrown) => thrown,
+		);
+		expect(error.code).toBe("BAD_GATEWAY");
+		expect(error.cause).toBe(providerError);
+	});
+
+	it("rethrows non-provider errors unchanged", async () => {
+		const unrelated = new Error("network dropped mid-call");
+		vi.mocked(generateText).mockRejectedValue(unrelated);
+
+		await expect(generatePlainText({} as never, "prompt")).rejects.toBe(unrelated);
+		await expect(generateJson({} as never, "prompt", schema)).rejects.toBe(unrelated);
+	});
+
+	it("still returns parsed JSON on success", async () => {
+		vi.mocked(generateText).mockResolvedValue({ text: '```json\n{"summary":"<p>Hi</p>"}\n```' } as never);
+
+		await expect(generateJson({} as never, "prompt", schema)).resolves.toEqual({ summary: "<p>Hi</p>" });
 	});
 });

--- a/packages/api/src/features/applications/ai.test.ts
+++ b/packages/api/src/features/applications/ai.test.ts
@@ -6,9 +6,9 @@ const protectedProcedureMock = vi.hoisted(() => {
 	const chain = {
 		route: vi.fn(() => chain),
 		input: vi.fn(() => chain),
-		.use: vi.fn(() => chain),
-		.output: vi.fn(() => chain),
-		.errors: vi.fn(() => chain),
+		use: vi.fn(() => chain),
+		output: vi.fn(() => chain),
+		errors: vi.fn(() => chain),
 		handler: vi.fn(() => chain),
 	};
 	return chain;

--- a/packages/api/src/features/applications/ai.test.ts
+++ b/packages/api/src/features/applications/ai.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { AISDKError, generateText } from "ai";
+import { APICallError, generateText, LoadAPIKeyError, RetryError } from "ai";
 import { z } from "zod";
 
 const protectedProcedureMock = vi.hoisted(() => {
@@ -53,20 +53,59 @@ describe("copilot provider-failure translation", () => {
 		vi.mocked(generateText).mockReset();
 	});
 
-	it("translates AI SDK provider failures to BAD_GATEWAY in generatePlainText", async () => {
-		vi.mocked(generateText).mockRejectedValue(new AISDKError({ name: "AISDKError", message: "Provider returned 401" }));
+	it("translates APICallError provider failures to BAD_GATEWAY in generatePlainText", async () => {
+		vi.mocked(generateText).mockRejectedValue(
+			new APICallError({
+				message: "Provider returned 401",
+				url: "https://api.openai.com/v1/chat/completions",
+				requestBodyValues: undefined,
+				statusCode: 401,
+			}),
+		);
 
 		await expect(generatePlainText({} as never, "prompt")).rejects.toMatchObject({ code: "BAD_GATEWAY" });
 	});
 
-	it("translates AI SDK provider failures to BAD_GATEWAY in generateJson", async () => {
-		vi.mocked(generateText).mockRejectedValue(new AISDKError({ name: "AISDKError", message: "Model not found" }));
+	it("translates APICallError provider failures to BAD_GATEWAY in generateJson", async () => {
+		vi.mocked(generateText).mockRejectedValue(
+			new APICallError({
+				message: "Model not found",
+				url: "https://api.openai.com/v1/chat/completions",
+				requestBodyValues: undefined,
+				statusCode: 404,
+			}),
+		);
 
-		await expect(generateJson({} as never, { prompt: "prompt" }, schema)).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+		await expect(generateJson({} as never, { prompt: "prompt" }, schema)).rejects.toMatchObject({
+			code: "BAD_GATEWAY",
+		});
+	});
+
+	it("translates RetryError with maxRetriesExceeded to BAD_GATEWAY", async () => {
+		const providerError = new APICallError({
+			message: "Provider returned 500",
+			url: "https://api.openai.com/v1/chat/completions",
+			requestBodyValues: undefined,
+			statusCode: 500,
+		});
+		vi.mocked(generateText).mockRejectedValue(
+			new RetryError({
+				message: "Failed to generate text after 3 attempts",
+				reason: "maxRetriesExceeded",
+				errors: [providerError],
+			}),
+		);
+
+		await expect(generatePlainText({} as never, "prompt")).rejects.toMatchObject({ code: "BAD_GATEWAY" });
 	});
 
 	it("preserves the provider error as the BAD_GATEWAY cause", async () => {
-		const providerError = new AISDKError({ name: "AISDKError", message: "quota exceeded" });
+		const providerError = new APICallError({
+			message: "quota exceeded",
+			url: "https://api.openai.com/v1/chat/completions",
+			requestBodyValues: undefined,
+			statusCode: 429,
+		});
 		vi.mocked(generateText).mockRejectedValue(providerError);
 
 		const error: { code?: string; cause?: unknown } = await generatePlainText({} as never, "prompt").catch(
@@ -76,7 +115,15 @@ describe("copilot provider-failure translation", () => {
 		expect(error.cause).toBe(providerError);
 	});
 
-	it("rethrows non-provider errors unchanged", async () => {
+	it("rethrows non-provider SDK errors unchanged", async () => {
+		const credentialError = new LoadAPIKeyError({ message: "The OPENAI_API_KEY is not set" });
+		vi.mocked(generateText).mockRejectedValue(credentialError);
+
+		await expect(generatePlainText({} as never, "prompt")).rejects.toBe(credentialError);
+		await expect(generateJson({} as never, { prompt: "prompt" }, schema)).rejects.toBe(credentialError);
+	});
+
+	it("rethrows non-AI errors unchanged", async () => {
 		const unrelated = new Error("network dropped mid-call");
 		vi.mocked(generateText).mockRejectedValue(unrelated);
 

--- a/packages/api/src/features/applications/ai.test.ts
+++ b/packages/api/src/features/applications/ai.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AISDKError, generateText } from "ai";
+import { z } from "zod";
 
 const protectedProcedureMock = vi.hoisted(() => {
 	const chain = {
@@ -6,12 +8,16 @@ const protectedProcedureMock = vi.hoisted(() => {
 		input: vi.fn(() => chain),
 		use: vi.fn(() => chain),
 		output: vi.fn(() => chain),
+		errors: vi.fn(() => chain),
 		handler: vi.fn(() => chain),
 	};
 	return chain;
 });
 
-vi.mock("ai", () => ({ generateText: vi.fn() }));
+vi.mock("ai", async (importOriginal) => ({
+	...(await importOriginal<typeof import("ai")>()),
+	generateText: vi.fn(),
+}));
 vi.mock("../../context", () => ({ protectedProcedure: protectedProcedureMock }));
 vi.mock("../../middleware/rate-limit", () => ({ aiRequestRateLimit: vi.fn() }));
 vi.mock("../ai/service", () => ({ getModel: vi.fn() }));
@@ -21,7 +27,7 @@ vi.mock("./service", () => ({
 	applicationService: { getById: vi.fn(), setAiResult: vi.fn(), update: vi.fn(), addNote: vi.fn() },
 }));
 
-const { autofillInputSchema } = await import("./ai");
+const { autofillInputSchema, generateJson, generatePlainText } = await import("./ai");
 
 describe("autofillInputSchema", () => {
 	it("rejects oversized pasted job descriptions", () => {
@@ -37,5 +43,50 @@ describe("autofillInputSchema", () => {
 		expect(autofillInputSchema.parse({ jobDescription: "  Senior Engineer at Acme  " }).jobDescription).toBe(
 			"Senior Engineer at Acme",
 		);
+	});
+});
+
+describe("copilot provider-failure translation", () => {
+	const schema = z.object({ summary: z.string() });
+
+	beforeEach(() => {
+		vi.mocked(generateText).mockReset();
+	});
+
+	it("translates AI SDK provider failures to BAD_GATEWAY in generatePlainText", async () => {
+		vi.mocked(generateText).mockRejectedValue(new AISDKError({ name: "AISDKError", message: "Provider returned 401" }));
+
+		await expect(generatePlainText({} as never, "prompt")).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+	});
+
+	it("translates AI SDK provider failures to BAD_GATEWAY in generateJson", async () => {
+		vi.mocked(generateText).mockRejectedValue(new AISDKError({ name: "AISDKError", message: "Model not found" }));
+
+		await expect(generateJson({} as never, "prompt", schema)).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+	});
+
+	it("preserves the provider error as the BAD_GATEWAY cause", async () => {
+		const providerError = new AISDKError({ name: "AISDKError", message: "quota exceeded" });
+		vi.mocked(generateText).mockRejectedValue(providerError);
+
+		const error: { code?: string; cause?: unknown } = await generatePlainText({} as never, "prompt").catch(
+			(thrown) => thrown,
+		);
+		expect(error.code).toBe("BAD_GATEWAY");
+		expect(error.cause).toBe(providerError);
+	});
+
+	it("rethrows non-provider errors unchanged", async () => {
+		const unrelated = new Error("network dropped mid-call");
+		vi.mocked(generateText).mockRejectedValue(unrelated);
+
+		await expect(generatePlainText({} as never, "prompt")).rejects.toBe(unrelated);
+		await expect(generateJson({} as never, "prompt", schema)).rejects.toBe(unrelated);
+	});
+
+	it("still returns parsed JSON on success", async () => {
+		vi.mocked(generateText).mockResolvedValue({ text: '```json\n{"summary":"<p>Hi</p>"}\n```' } as never);
+
+		await expect(generateJson({} as never, "prompt", schema)).resolves.toEqual({ summary: "<p>Hi</p>" });
 	});
 });

--- a/packages/api/src/features/applications/ai.ts
+++ b/packages/api/src/features/applications/ai.ts
@@ -31,7 +31,7 @@ async function resolveModel(userId: string) {
 
 // --- AI provider failure translation ------------------------------------------
 // AI SDK throws `AISDKError` for provider-side failures (bad key, unknown model,
-// quota, 5xx).  Translating those to BAD_GATEWAY gives the client a actionable
+// quota, 5xx).  Translating those to BAD_GATEWAY gives the client an actionable
 // status code instead of an opaque 500.  Mirrors features/ai/router.ts.
 
 function isAiProviderGatewayError(error: unknown): boolean {

--- a/packages/api/src/features/applications/ai.ts
+++ b/packages/api/src/features/applications/ai.ts
@@ -1,10 +1,10 @@
 import { ORPCError } from "@orpc/client";
-import { generateText } from "ai";
+import { AISDKError, generateText } from "ai";
 import z from "zod";
 import { generateId, slugify } from "@reactive-resume/utils/string";
 import { protectedProcedure } from "../../context";
 import { aiRequestRateLimit } from "../../middleware/rate-limit";
-import { generateJson } from "../ai/generate-json";
+import { generateJson as sharedGenerateJson } from "../ai/generate-json";
 import { getModel } from "../ai/service";
 import { aiProvidersService } from "../ai-providers/service";
 import { resumeService } from "../resume/service";
@@ -29,10 +29,49 @@ async function resolveModel(userId: string) {
 	});
 }
 
-async function generatePlainText(model: Awaited<ReturnType<typeof resolveModel>>, prompt: string) {
-	const { text } = await generateText({ model, messages: [{ role: "user", content: prompt }] });
-	return text.trim();
+// --- AI provider failure translation ------------------------------------------
+// AI SDK throws `AISDKError` for provider-side failures (bad key, unknown model,
+// quota, 5xx).  Translating those to BAD_GATEWAY gives the client a actionable
+// status code instead of an opaque 500.  Mirrors features/ai/router.ts.
+
+function isAiProviderGatewayError(error: unknown): boolean {
+	return error instanceof AISDKError;
 }
+
+/** Throws a BAD_GATEWAY ORPCError, preserving the original cause for upstream error reporters. */
+function throwAiProviderGatewayError(cause?: unknown): never {
+	throw new ORPCError("BAD_GATEWAY", { message: "Could not reach the AI provider.", cause });
+}
+
+/**
+ * Wrapper around the shared `generateJson` that translates AI provider failures
+ * to BAD_GATEWAY.  Exported for tests.
+ */
+export async function generateJson<T>(
+	model: Awaited<ReturnType<typeof resolveModel>>,
+	prompt: string,
+	schema: z.ZodType<T>,
+) {
+	try {
+		return await sharedGenerateJson(model, { prompt }, schema);
+	} catch (error) {
+		if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
+		throw error;
+	}
+}
+
+/** Exported for tests: provider-failure translation shared by every copilot procedure. */
+export async function generatePlainText(model: Awaited<ReturnType<typeof resolveModel>>, prompt: string) {
+	try {
+		const { text } = await generateText({ model, messages: [{ role: "user", content: prompt }] });
+		return text.trim();
+	} catch (error) {
+		if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
+		throw error;
+	}
+}
+
+// --- Schema & router -----------------------------------------------------------
 
 const autofillOutput = z.object({
 	company: z.string(),
@@ -61,6 +100,11 @@ const matchScoreOutput = z.object({
 		.transform((a) => a.slice(0, 8)),
 });
 
+const aiErrors = {
+	BAD_GATEWAY: { message: "The AI provider returned an error or is unreachable.", status: 502 },
+	BAD_REQUEST: { message: "Invalid application or AI request.", status: 400 },
+};
+
 export const aiRouter = {
 	// Extract structured fields from a pasted job description. The posting text itself is stored
 	// verbatim on the application, so nothing here fetches or scrapes a URL.
@@ -69,6 +113,7 @@ export const aiRouter = {
 		.input(autofillInputSchema)
 		.use(aiRequestRateLimit)
 		.output(autofillOutput)
+		.errors(aiErrors)
 		.handler(async ({ context, input }) => {
 			const model = await resolveModel(context.user.id);
 
@@ -92,6 +137,7 @@ export const aiRouter = {
 		.input(z.object({ id: z.string() }))
 		.use(aiRequestRateLimit)
 		.output(matchScoreOutput)
+		.errors(aiErrors)
 		.handler(async ({ context, input }) => {
 			const application = await applicationService.getById({ id: input.id, userId: context.user.id });
 			if (!application.resumeId)
@@ -134,6 +180,7 @@ export const aiRouter = {
 		.input(z.object({ id: z.string(), kind: z.enum(["cover-letter", "follow-up"]) }))
 		.use(aiRequestRateLimit)
 		.output(z.object({ text: z.string() }))
+		.errors(aiErrors)
 		.handler(async ({ context, input }) => {
 			const application = await applicationService.getById({ id: input.id, userId: context.user.id });
 			const model = await resolveModel(context.user.id);
@@ -162,6 +209,7 @@ export const aiRouter = {
 		.input(z.object({ id: z.string() }))
 		.use(aiRequestRateLimit)
 		.output(z.object({ resumeId: z.string(), name: z.string() }))
+		.errors(aiErrors)
 		.handler(async ({ context, input }) => {
 			const application = await applicationService.getById({ id: input.id, userId: context.user.id });
 			if (!application.resumeId)

--- a/packages/api/src/features/applications/ai.ts
+++ b/packages/api/src/features/applications/ai.ts
@@ -1,5 +1,5 @@
 import { ORPCError } from "@orpc/client";
-import { generateText } from "ai";
+import { AISDKError, generateText } from "ai";
 import z from "zod";
 import { generateId, slugify } from "@reactive-resume/utils/string";
 import { protectedProcedure } from "../../context";
@@ -28,10 +28,32 @@ async function resolveModel(userId: string) {
 	});
 }
 
+function isAiProviderGatewayError(error: unknown): boolean {
+	return error instanceof AISDKError;
+}
+
+/** Throws a BAD_GATEWAY ORPCError, preserving the original cause for upstream error reporters. */
+function throwAiProviderGatewayError(cause?: unknown): never {
+	throw new ORPCError("BAD_GATEWAY", { message: "Could not reach the AI provider.", cause });
+}
+
 // generateText + tolerant JSON extraction + Zod validation. Mirrors the resume-analysis pattern
 // (the SDK's generateObject isn't wired for every provider here, so we parse defensively).
-async function generateJson<T>(model: Awaited<ReturnType<typeof resolveModel>>, prompt: string, schema: z.ZodType<T>) {
-	const { text } = await generateText({ model, messages: [{ role: "user", content: prompt }] });
+// Provider failures (bad key, unknown model, quota, 5xx) are translated to BAD_GATEWAY instead of
+// bubbling out as an opaque INTERNAL_SERVER_ERROR, matching features/ai/router.ts.
+/** Exported for tests: provider-failure translation shared by every copilot procedure. */
+export async function generateJson<T>(
+	model: Awaited<ReturnType<typeof resolveModel>>,
+	prompt: string,
+	schema: z.ZodType<T>,
+) {
+	let text: string;
+	try {
+		({ text } = await generateText({ model, messages: [{ role: "user", content: prompt }] }));
+	} catch (error) {
+		if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
+		throw error;
+	}
 	const fenced = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
 	const candidate = fenced?.[1] ?? text;
 	const start = candidate.indexOf("{");
@@ -42,9 +64,15 @@ async function generateJson<T>(model: Awaited<ReturnType<typeof resolveModel>>, 
 	return schema.parse(JSON.parse(candidate.slice(start, end + 1)));
 }
 
-async function generatePlainText(model: Awaited<ReturnType<typeof resolveModel>>, prompt: string) {
-	const { text } = await generateText({ model, messages: [{ role: "user", content: prompt }] });
-	return text.trim();
+/** Exported for tests: provider-failure translation shared by every copilot procedure. */
+export async function generatePlainText(model: Awaited<ReturnType<typeof resolveModel>>, prompt: string) {
+	try {
+		const { text } = await generateText({ model, messages: [{ role: "user", content: prompt }] });
+		return text.trim();
+	} catch (error) {
+		if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
+		throw error;
+	}
 }
 
 const autofillOutput = z.object({
@@ -82,6 +110,10 @@ export const aiRouter = {
 		.input(autofillInputSchema)
 		.use(aiRequestRateLimit)
 		.output(autofillOutput)
+		.errors({
+			BAD_GATEWAY: { message: "The AI provider returned an error or is unreachable.", status: 502 },
+			BAD_REQUEST: { message: "Invalid application or AI request.", status: 400 },
+		})
 		.handler(async ({ context, input }) => {
 			const model = await resolveModel(context.user.id);
 
@@ -103,6 +135,10 @@ export const aiRouter = {
 		.input(z.object({ id: z.string() }))
 		.use(aiRequestRateLimit)
 		.output(matchScoreOutput)
+		.errors({
+			BAD_GATEWAY: { message: "The AI provider returned an error or is unreachable.", status: 502 },
+			BAD_REQUEST: { message: "Invalid application or AI request.", status: 400 },
+		})
 		.handler(async ({ context, input }) => {
 			const application = await applicationService.getById({ id: input.id, userId: context.user.id });
 			if (!application.resumeId)
@@ -143,6 +179,10 @@ export const aiRouter = {
 		.input(z.object({ id: z.string(), kind: z.enum(["cover-letter", "follow-up"]) }))
 		.use(aiRequestRateLimit)
 		.output(z.object({ text: z.string() }))
+		.errors({
+			BAD_GATEWAY: { message: "The AI provider returned an error or is unreachable.", status: 502 },
+			BAD_REQUEST: { message: "Invalid application or AI request.", status: 400 },
+		})
 		.handler(async ({ context, input }) => {
 			const application = await applicationService.getById({ id: input.id, userId: context.user.id });
 			const model = await resolveModel(context.user.id);
@@ -171,6 +211,10 @@ export const aiRouter = {
 		.input(z.object({ id: z.string() }))
 		.use(aiRequestRateLimit)
 		.output(z.object({ resumeId: z.string(), name: z.string() }))
+		.errors({
+			BAD_GATEWAY: { message: "The AI provider returned an error or is unreachable.", status: 502 },
+			BAD_REQUEST: { message: "Invalid application or AI request.", status: 400 },
+		})
 		.handler(async ({ context, input }) => {
 			const application = await applicationService.getById({ id: input.id, userId: context.user.id });
 			if (!application.resumeId)

--- a/packages/api/src/features/applications/ai.ts
+++ b/packages/api/src/features/applications/ai.ts
@@ -45,15 +45,16 @@ function throwAiProviderGatewayError(cause?: unknown): never {
 
 /**
  * Wrapper around the shared `generateJson` that translates AI provider failures
- * to BAD_GATEWAY.  Exported for tests.
+ * to BAD_GATEWAY.  Accepts the same prompt shape as the shared module.
+ * Exported for tests.
  */
 export async function generateJson<T>(
 	model: Awaited<ReturnType<typeof resolveModel>>,
-	prompt: string,
+	prompt: { system?: string; prompt: string },
 	schema: z.ZodType<T>,
 ) {
 	try {
-		return await sharedGenerateJson(model, { prompt }, schema);
+		return await sharedGenerateJson(model, prompt, schema);
 	} catch (error) {
 		if (isAiProviderGatewayError(error)) throwAiProviderGatewayError(error);
 		throw error;

--- a/packages/api/src/features/applications/ai.ts
+++ b/packages/api/src/features/applications/ai.ts
@@ -1,5 +1,5 @@
 import { ORPCError } from "@orpc/client";
-import { AISDKError, generateText } from "ai";
+import { APICallError, generateText, RetryError } from "ai";
 import z from "zod";
 import { generateId, slugify } from "@reactive-resume/utils/string";
 import { protectedProcedure } from "../../context";
@@ -30,12 +30,16 @@ async function resolveModel(userId: string) {
 }
 
 // --- AI provider failure translation ------------------------------------------
-// AI SDK throws `AISDKError` for provider-side failures (bad key, unknown model,
-// quota, 5xx).  Translating those to BAD_GATEWAY gives the client an actionable
-// status code instead of an opaque 500.  Mirrors features/ai/router.ts.
+// The AI SDK surfaces provider-side failures as `APICallError` (HTTP 4xx/5xx from
+// the provider) or `RetryError` with `reason: "maxRetriesExceeded"`.  Translating
+// only those to BAD_GATEWAY gives the client an actionable status code instead of
+// an opaque 500.  Validation, credential, model-resolution, and response-parsing
+// errors rethrow unchanged.
 
 function isAiProviderGatewayError(error: unknown): boolean {
-	return error instanceof AISDKError;
+	if (APICallError.isInstance(error)) return true;
+	if (RetryError.isInstance(error) && error.reason === "maxRetriesExceeded") return true;
+	return false;
 }
 
 /** Throws a BAD_GATEWAY ORPCError, preserving the original cause for upstream error reporters. */


### PR DESCRIPTION
## Summary

Fixes #3312.

The Application Copilot procedures (autofill, matchScore, draftMessage, tailorResume) call `generateText` through `generateJson`/`generatePlainText` with no error translation. When the saved AI provider call fails (`AISDKError`: invalid/expired key, unknown model, quota, provider 5xx), the error bubbles out of the oRPC handler as an opaque `INTERNAL_SERVER_ERROR` — the exact response reported in the issue, with zero actionable signal for the user.

This wraps both helpers' `generateText` calls in try/catch and translates provider failures to `BAD_GATEWAY` (preserving the original error as `cause` for upstream reporters), mirroring the existing idiom in `features/ai/router.ts` (`isAiProviderGatewayError` / `throwAiProviderGatewayError`). All four copilot procedures now also declare `.errors({ BAD_GATEWAY, BAD_REQUEST })`, keeping the OpenAPI output consistent with the rest of the AI surface. Non-provider errors are rethrown unchanged.

## Test plan

- [x] `pnpm vitest run src/features/applications/ai.test.ts` — 15/15 pass (5 new behavior tests: translation in both helpers, cause preservation, non-AI errors rethrown, happy path)
- [x] `pnpm typecheck` — clean
- [x] `biome check` — clean
- [x] commitlint — pass

## AI disclosure

AI-assisted: implementation and tests drafted with Cursor Composer; verified locally before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of AI provider outages, retry exhaustion, and gateway failures.
  * Preserved provider error details for troubleshooting while continuing to propagate unrelated errors normally.
  * Improved reliability of AI-generated JSON responses and parsing.

* **API Improvements**
  * AI application operations now consistently report bad-request and provider-gateway errors.
  * Enhanced support for structured prompts and plain-text AI responses across application workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->















<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR translates AI provider failures in Application Copilot operations into explicit gateway errors while preserving their original causes.
- Wraps structured and plain-text generation with provider-error translation.
- Declares gateway and request errors across all four Copilot procedures.
- Adds coverage for translated failures, cause preservation, unrelated errors, and successful JSON parsing.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/api/src/features/applications/ai.ts | Adds shared provider-failure translation and declares the corresponding procedure error contracts without an identified blocking defect. |
| packages/api/src/features/applications/ai.test.ts | Adds focused error-translation tests and resolves the previously reported line-width issue. |

</details>

<sub>Reviews (10): Last reviewed commit: ["fix(api): narrow copilot AI BAD\_GATEWAY ..."](https://github.com/amruthpillai/reactive-resume/commit/5a29dadf85a25afc0bc734af20604f5dcf139029) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53889762)</sub>

<!-- /greptile_comment -->