### PR TITLE
fix(pdf): render emoji via a Noto Emoji script fallback

### DIFF
--- a/packages/fonts/src/index.test.ts
+++ b/packages/fonts/src/index.test.ts
@@ -200,9 +200,15 @@ describe("getPdfFallbackFontFamilies", () => {
 		expect(getPdfFallbackFontFamilies("Helvetica", { locale: "th-TH" })).toEqual(["Noto Sans Thai", "Noto Sans"]);
 	});
 
+	it("uses Noto Emoji for detected emoji content, for serif and sans stacks alike (#3321)", () => {
+		expect(getPdfFallbackFontFamilies("Helvetica", { scripts: ["emoji"] })).toEqual(["Noto Emoji", "Noto Sans"]);
+		expect(getPdfFallbackFontFamilies("Times-Roman", { scripts: ["emoji"] })).toEqual(["Noto Emoji", "Noto Serif"]);
+	});
+
 	it("does not append the Simplified Chinese safety net for non-CJK scripts", () => {
 		expect(getPdfFallbackFontFamilies("Helvetica", { scripts: ["arabic"] })).toEqual(["Noto Sans Arabic", "Noto Sans"]);
 		expect(getPdfFallbackFontFamilies("Helvetica", { scripts: ["thai"] })).not.toContain("Noto Sans SC");
+		expect(getPdfFallbackFontFamilies("Helvetica", { scripts: ["emoji"] })).not.toContain("Noto Sans SC");
 	});
 
 	it("orders the locale script first, then content scripts (mixed RTL + CJK resume)", () => {

--- a/packages/fonts/src/index.ts
+++ b/packages/fonts/src/index.ts
@@ -82,6 +82,9 @@ const scriptFonts: Record<Script, { serif: string; sansSerif: string }> = {
 	arabic: { serif: "Noto Naskh Arabic", sansSerif: "Noto Sans Arabic" },
 	hebrew: { serif: "Noto Sans Hebrew", sansSerif: "Noto Sans Hebrew" },
 	thai: { serif: "Noto Sans Thai", sansSerif: "Noto Sans Thai" },
+	// Monochrome outlines (TrueType glyf, not CBDT bitmaps) so react-pdf can
+	// embed them; the serif/sans distinction is meaningless for emoji (#3321).
+	emoji: { serif: "Noto Emoji", sansSerif: "Noto Emoji" },
 };
 
 // Covers General Punctuation (U+2000–U+206F) and other symbols missing from

--- a/packages/fonts/src/webfontlist.json
+++ b/packages/fonts/src/webfontlist.json
@@ -5863,6 +5863,24 @@
 	},
 	{
 		"type": "web",
+		"category": "sans-serif",
+		"family": "Noto Emoji",
+		"weights": ["300", "400", "500", "600", "700"],
+		"preview": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0jwvS-dGJQ.ttf",
+		"files": {
+			"100": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob_10jwvS-dGJQ.ttf",
+			"200": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob_10jwvS-dGJQ.ttf",
+			"300": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob_10jwvS-dGJQ.ttf",
+			"400": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0jwvS-dGJQ.ttf",
+			"500": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-Z0jwvS-dGJQ.ttf",
+			"600": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob911TwvS-dGJQ.ttf",
+			"700": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob9M1TwvS-dGJQ.ttf",
+			"800": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob9M1TwvS-dGJQ.ttf",
+			"900": "https://fonts.gstatic.com/s/notoemoji/v62/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob9M1TwvS-dGJQ.ttf"
+		}
+	},
+	{
+		"type": "web",
 		"category": "handwriting",
 		"family": "Handlee",
 		"weights": ["400"],

--- a/packages/pdf/src/hooks/use-register-fonts.test.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.test.ts
@@ -394,6 +394,24 @@ describe("resumeContentScripts", () => {
 		expect(scripts.size).toBe(1);
 	});
 
+	it("detects keycap emoji without pictographs (#3321)", async () => {
+		const { resumeContentScripts } = await import("./use-register-fonts");
+		// "1\uFE0F\u20E3" (1\u20e3) and "#\uFE0F\u20E3" (#\u20e3) hold no regional
+		// indicator and no Extended_Pictographic codepoint, so the detector must
+		// catch the combining enclosing keycap on its own.
+		const data = {
+			...defaultResumeData,
+			basics: {
+				...defaultResumeData.basics,
+				location: "Steps \u0031\uFE0F\u20E3 and \u0023\uFE0F\u20E3",
+			},
+		} satisfies ResumeData;
+
+		const scripts = resumeContentScripts(data);
+		expect(scripts.has("emoji")).toBe(true);
+		expect(scripts.size).toBe(1);
+	});
+
 	it("detects multiple scripts in mixed content", async () => {
 		const { resumeContentScripts } = await import("./use-register-fonts");
 		const scripts = resumeContentScripts(withSummary("안녕 翠翠 سلام"));

--- a/packages/pdf/src/hooks/use-register-fonts.test.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.test.ts
@@ -165,6 +165,27 @@ describe("registerFonts", () => {
 		expect(registerSpy).toHaveBeenCalledWith(expect.objectContaining({ family: "Noto Sans Thai" }));
 	});
 
+	it("registers the Noto Emoji fallback when content contains emoji (#3321)", async () => {
+		const registerSpy = vi.spyOn(Font, "register").mockImplementation(() => {});
+		vi.spyOn(Font, "registerHyphenationCallback").mockImplementation(() => {});
+		const emojiSource = getWebFontSource("Noto Emoji", "400", false);
+		const { registerFonts } = await import("./use-register-fonts");
+
+		const pdfTypography = registerFonts(typography, "en-US", false, new Set(["emoji"]));
+
+		expect(pdfTypography.body.fontFamily).toEqual(["IBM Plex Serif", "Noto Emoji", "Noto Serif"]);
+		expect(registerSpy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				family: "Noto Emoji",
+				fontWeight: 400,
+				fontStyle: "normal",
+				src: emojiSource,
+			}),
+		);
+		// Emoji is not CJK: no Simplified-Chinese safety net, no per-character breaking.
+		expect(registerSpy).not.toHaveBeenCalledWith(expect.objectContaining({ family: "Noto Serif SC" }));
+	});
+
 	it("does NOT enable CJK per-character line breaking for non-CJK fallback scripts", async () => {
 		const registerHyphenationSpy = vi.spyOn(Font, "registerHyphenationCallback").mockImplementation(() => {});
 		vi.spyOn(Font, "register").mockImplementation(() => {});
@@ -357,6 +378,20 @@ describe("resumeContentScripts", () => {
 	it("detects Thai", async () => {
 		const { resumeContentScripts } = await import("./use-register-fonts");
 		expect([...resumeContentScripts(withSummary("สวัสดี"))]).toEqual(["thai"]);
+	});
+
+	it("detects emoji flags and pictographs (#3321)", async () => {
+		const { resumeContentScripts } = await import("./use-register-fonts");
+		const data = {
+			...defaultResumeData,
+			basics: { ...defaultResumeData.basics, location: "Berlin \u{1F1E9}\u{1F1EA} \u{1F310} \u{2B50}" },
+		} satisfies ResumeData;
+
+		const scripts = resumeContentScripts(data);
+		expect(scripts.has("emoji")).toBe(true);
+		// Regional indicators are not Extended_Pictographic and pictographs are
+		// not any other script — the emoji detector must catch both alone.
+		expect(scripts.size).toBe(1);
 	});
 
 	it("detects multiple scripts in mixed content", async () => {

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -160,8 +160,12 @@ const hebrewRegex = /[֐-׿יִ-ﭏ]/;
 const thaiRegex = /[฀-๿]/;
 
 // Emoji: regional indicators (flags) are NOT Extended_Pictographic, so union
-// them explicitly with the pictographic property (#3321).
-const emojiRegex = /[\u{1F1E6}-\u{1F1FF}]|\p{Extended_Pictographic}/u;
+// them explicitly with the pictographic property (#3321). Keycap sequences
+// (e.g. "1\uFE0F\u20E3") carry no pictographic codepoint either — their
+// discriminator is the combining enclosing keycap U+20E3, unioned here for the
+// same reason: without it, keycap-only content falls back to a font without
+// the enclosure mark and renders garbled.
+const emojiRegex = /[\u{1F1E6}-\u{1F1FF}]|\u{20E3}|\p{Extended_Pictographic}/u;
 
 const scriptDetectors: { script: Script; regex: RegExp }[] = [
 	{ script: "hangul", regex: hangulRegex },

--- a/packages/pdf/src/hooks/use-register-fonts.ts
+++ b/packages/pdf/src/hooks/use-register-fonts.ts
@@ -159,6 +159,10 @@ const arabicRegex = /[؀-ۿݐ-ݿࢠ-ࣿﭐ-﷿ﹰ-ﻼ]/;
 const hebrewRegex = /[֐-׿יִ-ﭏ]/;
 const thaiRegex = /[฀-๿]/;
 
+// Emoji: regional indicators (flags) are NOT Extended_Pictographic, so union
+// them explicitly with the pictographic property (#3321).
+const emojiRegex = /[\u{1F1E6}-\u{1F1FF}]|\p{Extended_Pictographic}/u;
+
 const scriptDetectors: { script: Script; regex: RegExp }[] = [
 	{ script: "hangul", regex: hangulRegex },
 	{ script: "kana", regex: kanaRegex },
@@ -166,6 +170,7 @@ const scriptDetectors: { script: Script; regex: RegExp }[] = [
 	{ script: "arabic", regex: arabicRegex },
 	{ script: "hebrew", regex: hebrewRegex },
 	{ script: "thai", regex: thaiRegex },
+	{ script: "emoji", regex: emojiRegex },
 ];
 
 const collectScripts = (value: unknown, scripts: Set<Script>): void => {

--- a/packages/utils/src/locale.ts
+++ b/packages/utils/src/locale.ts
@@ -78,7 +78,15 @@ export function isCJKLocale(locale: Locale): boolean {
 // of falling back to a Latin/Han-only font and producing tofu. "emoji" is
 // content-detected only (never locale-derived) and resolves to Noto Emoji so
 // pictographs and regional indicators render instead of mojibake (#3321).
-export type Script = "hangul" | "kana" | "han-traditional" | "han-simplified" | "arabic" | "hebrew" | "thai" | "emoji";
+export type Script =
+	| "hangul"
+	| "kana"
+	| "han-traditional"
+	| "han-simplified"
+	| "arabic"
+	| "hebrew"
+	| "thai"
+	| "emoji";
 
 // The CJK subset of `Script`. CJK needs extra per-character line breaking that
 // must NOT be applied to Arabic (cursive, joined letters) or Thai (combining

--- a/packages/utils/src/locale.ts
+++ b/packages/utils/src/locale.ts
@@ -78,15 +78,7 @@ export function isCJKLocale(locale: Locale): boolean {
 // of falling back to a Latin/Han-only font and producing tofu. "emoji" is
 // content-detected only (never locale-derived) and resolves to Noto Emoji so
 // pictographs and regional indicators render instead of mojibake (#3321).
-export type Script =
-	| "hangul"
-	| "kana"
-	| "han-traditional"
-	| "han-simplified"
-	| "arabic"
-	| "hebrew"
-	| "thai"
-	| "emoji";
+export type Script = "hangul" | "kana" | "han-traditional" | "han-simplified" | "arabic" | "hebrew" | "thai" | "emoji";
 
 // The CJK subset of `Script`. CJK needs extra per-character line breaking that
 // must NOT be applied to Arabic (cursive, joined letters) or Thai (combining

--- a/packages/utils/src/locale.ts
+++ b/packages/utils/src/locale.ts
@@ -75,8 +75,10 @@ export function isCJKLocale(locale: Locale): boolean {
 // because react-pdf (unlike a browser) has no automatic system-font fallback:
 // a glyph only renders if a registered font contains it. We pick the matching
 // Noto font per script so e.g. Hangul → Noto KR, Arabic → Noto Arabic, instead
-// of falling back to a Latin/Han-only font and producing tofu.
-export type Script = "hangul" | "kana" | "han-traditional" | "han-simplified" | "arabic" | "hebrew" | "thai";
+// of falling back to a Latin/Han-only font and producing tofu. "emoji" is
+// content-detected only (never locale-derived) and resolves to Noto Emoji so
+// pictographs and regional indicators render instead of mojibake (#3321).
+export type Script = "hangul" | "kana" | "han-traditional" | "han-simplified" | "arabic" | "hebrew" | "thai" | "emoji";
 
 // The CJK subset of `Script`. CJK needs extra per-character line breaking that
 // must NOT be applied to Arabic (cursive, joined letters) or Thai (combining


### PR DESCRIPTION
## Summary

Fixes #3321.

Unicode emoticons (flags 🇩🇪 🇬🇷, globe 🌐, and other emoji) rendered as
garbled single-byte text (`<é<ê <ì<÷`) in both the preview and the PDF
export. The byte pattern is the fingerprint of @react-pdf/renderer truncating
each UTF-16 code unit to its low byte through a font that has no glyph for
the codepoints: the per-codepoint fallback stack built in #2986/#3190 covers
scripts and punctuation but has no emoji detector and no emoji-capable font
anywhere in the chain — the only symbol fonts in the catalog (Noto Sans
Symbols 1/2) do not cover regional indicators or U+1F310.

This adds an `emoji` script (union of regional indicators and
Extended_Pictographic) detected during font registration, and a Noto Emoji
(monochrome, TrueType outlines — embeddable by fontkit, unlike the CBDT color
font) catalog entry mapped as the emoji fallback for both serif and
sans-serif. Out-of-range weight requests are aliased to real per-weight files
so `getWebFontSource` never silently registers the useless preview subset.

## Test plan

- [x] `pnpm --filter @reactive-resume/fonts test` — 46/46 (incl. new
      emoji catalog/scriptFonts assertions)
- [x] `pnpm --filter @reactive-resume/pdf test -- use-register-fonts` —
      645/645 across 53 files (the hook's own suite: 30/30, incl. new
      emoji-detection tests)
- [x] `pnpm --filter @reactive-resume/utils test -- locale` — 219/219
- [x] Biome clean on touched files
- [x] E2E: real @react-pdf/renderer render through the fallback stack
      extracts all reported codepoints intact (regular + bold); negative
      control without Noto Emoji reproduces the reported garbage

## AI disclosure

AI-assisted: implementation and tests drafted with an AI coding agent;
verified locally before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved emoji font support for PDF content.
  * Emoji characters, including flags, pictographs, and keycap symbols, now use the Noto Emoji fallback font.
  * Emoji fallback selection works consistently across serif and sans-serif typography.
  * Added support for detecting emoji content during PDF font registration.
* **Bug Fixes**
  * Prevented emoji-only content from incorrectly triggering CJK fallback fonts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a Noto Emoji fallback to preserve emoji in PDF output and completes the previously requested keycap-sequence detection.
- Adds Noto Emoji sources and maps emoji content to that family in serif and sans-serif fallback stacks.
- Detects regional indicators, extended pictographs, and U+20E3 keycap sequences while keeping emoji outside CJK-specific line breaking.
- Adds coverage for emoji registration, fallback ordering, flags, pictographs, and keycap-only content.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/hooks/use-register-fonts.ts | Extends script detection to flags, pictographs, and keycap sequences so emoji content registers the new fallback. |
| packages/fonts/src/index.ts | Maps the emoji script to Noto Emoji for both serif and sans-serif PDF fallback stacks. |
| packages/fonts/src/webfontlist.json | Adds stable Noto Emoji font sources and aliases unsupported edge weights to available files. |
| packages/pdf/src/hooks/use-register-fonts.test.ts | Covers emoji registration and detection for flags, pictographs, and keycap-only content. |
| packages/utils/src/locale.ts | Adds emoji to the shared Script type while remaining within the configured formatting limit. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Resume content] --> B[Detect scripts]
  B --> C{Emoji detected?}
  C -- Yes --> D[Register Noto Emoji]
  C -- No --> E[Use other script fallbacks]
  D --> F[Build ordered font-family stack]
  E --> F
  F --> G[Render PDF]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/amruthpillai/reactive-resume/commit/7f3a9ded5b83398ea88c55d4d7995b37646f1805) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54228934)</sub>

**Context used:**

- Knowledge Base — [Document export and fonts](https://app.greptile.com/reactive-resume/-/custom-context/knowledge-base/amruthpillai/reactive-resume/-/docs/document-export-and-fonts.md)

<!-- /greptile_comment -->