### PR TITLE
feat(skills): add inline layout option for skill items

### DIFF
--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.test.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from "@testing-library/react";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { SectionDropdownMenu } from "./section-menu";
+
+const mockUpdateResumeData = vi.fn();
+
+vi.mock("@/features/resume/builder/draft", () => ({
+	useCurrentResume: () => ({
+		data: {
+			sections: {
+				skills: {
+					title: "Skills",
+					columns: 2,
+					hidden: false,
+					layout: "default",
+					items: [],
+				},
+			},
+		},
+	}),
+	useUpdateResumeData: () => mockUpdateResumeData,
+}));
+
+vi.mock("@/hooks/use-confirm", () => ({
+	useConfirm: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/use-prompt", () => ({
+	usePrompt: () => vi.fn(),
+}));
+
+vi.mock("@/dialogs/store", () => ({
+	useDialogStore: () => ({
+		openDialog: vi.fn(),
+	}),
+}));
+
+beforeAll(() => {
+	i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+
+beforeEach(() => {
+	mockUpdateResumeData.mockClear();
+});
+
+describe("SkillsSectionDropdownMenu", () => {
+	it("updates resume data correctly when selecting 'inline' for skills section", async () => {
+		render(
+			<I18nProvider i18n={i18n}>
+				<SectionDropdownMenu type="skills" />
+			</I18nProvider>,
+		);
+
+		screen.getByRole("button", { name: "Section options" }).click();
+
+		(await screen.findByRole("menuitem", { name: /columns/i })).click();
+
+		(await screen.findByRole("menuitemradio", { name: /inline/i })).click();
+
+		expect(mockUpdateResumeData).toHaveBeenCalledTimes(1);
+		expect(mockUpdateResumeData).toHaveBeenCalledWith(expect.any(Function));
+
+		const mutation = mockUpdateResumeData.mock.calls[0][0];
+		const mockDraft = {
+			sections: {
+				skills: {
+					title: "Skills",
+					columns: 2,
+					hidden: false,
+					layout: "default",
+					items: [],
+				},
+			},
+		};
+
+		mutation(mockDraft);
+
+		expect(mockDraft.sections.skills.layout).toBe("inline");
+		expect(mockDraft.sections.skills.columns).toBe(1);
+	});
+
+	it("updates resume data correctly when selecting numeric columns for skills section", async () => {
+		render(
+			<I18nProvider i18n={i18n}>
+				<SectionDropdownMenu type="skills" />
+			</I18nProvider>,
+		);
+
+		screen.getByRole("button", { name: "Section options" }).click();
+
+		(await screen.findByRole("menuitem", { name: /columns/i })).click();
+
+		(await screen.findByRole("menuitemradio", { name: /3 columns/i })).click();
+
+		expect(mockUpdateResumeData).toHaveBeenCalledTimes(1);
+		expect(mockUpdateResumeData).toHaveBeenCalledWith(expect.any(Function));
+
+		const mutation = mockUpdateResumeData.mock.calls[0][0];
+		const mockDraft = {
+			sections: {
+				skills: {
+					title: "Skills",
+					columns: 2,
+					hidden: false,
+					layout: "default",
+					items: [],
+				},
+			},
+		};
+
+		mutation(mockDraft);
+
+		expect(mockDraft.sections.skills.layout).toBe("default");
+		expect(mockDraft.sections.skills.columns).toBe(3);
+	});
+});

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -41,6 +41,8 @@ export function SectionDropdownMenu({ type }: Props) {
 	const updateResumeData = useUpdateResumeData();
 	const resume = useCurrentResume();
 	const section = type === "summary" ? resume.data.summary : resume.data.sections[type];
+	const dropDownValue =
+		type === "skills" && resume.data.sections[type].layout === "inline" ? "inline" : section.columns.toString();
 
 	const onAddItem = () => {
 		if (type === "summary") return;
@@ -76,6 +78,15 @@ export function SectionDropdownMenu({ type }: Props) {
 
 	const onSetColumns = (value: string) => {
 		updateResumeData((draft) => {
+			if (type === "skills") {
+				if (value === "inline") {
+					draft.sections[type].layout = value;
+					draft.sections[type].columns = 1;
+					return;
+				}
+				draft.sections[type].layout = "default";
+			}
+
 			if (type === "summary") {
 				draft.summary.columns = Number.parseInt(value, 10);
 			} else {
@@ -150,12 +161,21 @@ export function SectionDropdownMenu({ type }: Props) {
 						</DropdownMenuSubTrigger>
 
 						<DropdownMenuSubContent>
-							<DropdownMenuRadioGroup value={section.columns.toString()} onValueChange={onSetColumns}>
+							<DropdownMenuRadioGroup value={dropDownValue} onValueChange={onSetColumns}>
 								{[1, 2, 3, 4, 5, 6].map((column) => (
 									<DropdownMenuRadioItem key={column} value={column.toString()}>
 										<Plural value={column} one="# Column" other="# Columns" />
 									</DropdownMenuRadioItem>
 								))}
+
+								{type === "skills" && (
+									<>
+										<DropdownMenuSeparator />
+										<DropdownMenuRadioItem value="inline">
+											<Trans>1 Column / Inline</Trans>
+										</DropdownMenuRadioItem>
+									</>
+								)}
 							</DropdownMenuRadioGroup>
 						</DropdownMenuSubContent>
 					</DropdownMenuSub>

--- a/docs/guides/json-resume-schema.mdx
+++ b/docs/guides/json-resume-schema.mdx
@@ -876,6 +876,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 					"description": "The section to display the projects of the author."
 				},
 				"skills": {
+					"description": "The section to display the skills of the author.",
 					"type": "object",
 					"properties": {
 						"title": {
@@ -967,6 +968,15 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								]
 							},
 							"description": "The items to display in the skills section."
+						},
+						"layout": {
+							"default": "default",
+							"description": "The layout style for skill items. 'inline' places item fields next to name",
+							"type": "string",
+							"enum": [
+								"default",
+								"inline"
+							]
 						}
 					},
 					"required": [
@@ -977,8 +987,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 						"keepTogether",
 						"startOnNewPage",
 						"items"
-					],
-					"description": "The section to display the skills of the author."
+					]
 				},
 				"languages": {
 					"type": "object",

--- a/packages/docx/src/section-renderers.test.ts
+++ b/packages/docx/src/section-renderers.test.ts
@@ -84,6 +84,7 @@ const emptySection = <T extends SectionType>(type: T): ResumeData["sections"][T]
 		keepTogether: false,
 		startOnNewPage: false,
 		items: [],
+		...(type === "skills" ? { layout: "default" as const } : {}),
 	}) as ResumeData["sections"][T];
 
 describe("renderBuiltInSection", () => {

--- a/packages/import/src/reactive-resume-v4-json.test.ts
+++ b/packages/import/src/reactive-resume-v4-json.test.ts
@@ -424,3 +424,13 @@ describe("parseReactiveResumeV4JSON – rejects non-v4 input gracefully", () => 
 		expect(() => parseReactiveResumeV4JSON(arrayBranches)).toThrow(/v4/i);
 	});
 });
+
+describe("parseReactiveResumeV4JSON – skills section", () => {
+	it("defaults skills layout to 'default' when 'layout' is missing from v4 data", () => {
+		// 'layout' already omitted
+		const v4 = makeV4Base({});
+
+		const result = parseReactiveResumeV4JSON(JSON.stringify(v4));
+		expect(result.sections.skills.layout).toBe("default");
+	});
+});

--- a/packages/import/src/reactive-resume-v4-json.tsx
+++ b/packages/import/src/reactive-resume-v4-json.tsx
@@ -385,6 +385,7 @@ export function parseReactiveResumeV4JSON(json: string): ResumeData {
 					title: v4Data.sections.skills?.name ?? "",
 					icon: "",
 					columns: v4Data.sections.skills?.columns ?? 1,
+					layout: "default",
 					hidden: !(v4Data.sections.skills?.visible ?? true),
 					keepTogether: false,
 					startOnNewPage: false,

--- a/packages/pdf/src/templates/shared/sections.test.ts
+++ b/packages/pdf/src/templates/shared/sections.test.ts
@@ -1,7 +1,9 @@
+import type { SkillItem } from "@reactive-resume/schema/resume/data";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { getSectionHeadingTextStyle } from "./sections";
+import { getTemplateMetrics } from "./metrics";
+import { getSectionHeadingTextStyle, getSkillsItemStyle } from "./sections";
 
 const source = readFileSync(fileURLToPath(new URL("./sections.tsx", import.meta.url)), "utf8");
 
@@ -52,5 +54,44 @@ describe("SectionShell", () => {
 		expect(source).toMatch(/getSectionHeadingTextStyle\(\s*sectionHeadingStyle,\s*sectionHeadingRuleStyle(?:,|\))/);
 		expect(source).toContain("width: _width");
 		expect(source).not.toContain('width: "auto"');
+	});
+});
+
+const mockMetrics = getTemplateMetrics({ gapX: 10, gapY: 10, marginX: 10, marginY: 10 });
+
+const createSkillItem = (overrides: Partial<SkillItem> = {}): SkillItem => ({
+	id: "1",
+	name: "JavaScript",
+	level: 0,
+	keywords: [],
+	hidden: false,
+	proficiency: "",
+	icon: "",
+	iconColor: "",
+	...overrides,
+});
+
+describe("SkillsSectionInlineFormat", () => {
+	it("uses isInlineSkillsItem in sections.tsx", () => {
+		expect(source).toContain("isInlineSkillsItem");
+	});
+
+	it("returns default rowGap style when isInline is false", () => {
+		const mockItem = createSkillItem();
+		expect(getSkillsItemStyle(false, mockItem, mockMetrics)).toEqual({ rowGap: 2.5 });
+	});
+
+	it("applies alignItems: center when isInline is true and exactly 1 secondary field is present", () => {
+		// 1 secondary field: level only
+		const mockItem = createSkillItem({ level: 3 });
+		const style = getSkillsItemStyle(true, mockItem, mockMetrics);
+		expect(style).toEqual(expect.arrayContaining([{ alignItems: "center" }]));
+	});
+
+	it("does not apply alignItems: center when isInline is true and 0 or multiple secondary fields are present", () => {
+		// 2 secondary fields: level AND keywords
+		const mockItem = createSkillItem({ level: 3, keywords: ["React"] });
+		const style = getSkillsItemStyle(true, mockItem, mockMetrics);
+		expect(style).not.toEqual(expect.arrayContaining([{ alignItems: "center" }]));
 	});
 });

--- a/packages/pdf/src/templates/shared/sections.test.ts
+++ b/packages/pdf/src/templates/shared/sections.test.ts
@@ -81,6 +81,13 @@ describe("SkillsSectionInlineFormat", () => {
 		expect(getSkillsItemStyle(false, mockItem, mockMetrics)).toEqual({ rowGap: 2.5 });
 	});
 
+	it("does not apply alignItems: center when isInline is true and 0 secondary fields are present", () => {
+		// 0 secondary fields: no proficiency, no level, no keywords
+		const mockItem = createSkillItem();
+		const style = getSkillsItemStyle(true, mockItem, mockMetrics);
+		expect(style).not.toEqual(expect.arrayContaining([{ alignItems: "center" }]));
+	});
+
 	it("applies alignItems: center when isInline is true and exactly 1 secondary field is present", () => {
 		// 1 secondary field: level only
 		const mockItem = createSkillItem({ level: 3 });
@@ -88,9 +95,30 @@ describe("SkillsSectionInlineFormat", () => {
 		expect(style).toEqual(expect.arrayContaining([{ alignItems: "center" }]));
 	});
 
-	it("does not apply alignItems: center when isInline is true and 0 or multiple secondary fields are present", () => {
+	it("applies alignItems: center when isInline is true and proficiency is the only secondary field", () => {
+		// 1 secondary field: proficiency only
+		const mockItem = createSkillItem({ proficiency: "Advanced" });
+		const style = getSkillsItemStyle(true, mockItem, mockMetrics);
+		expect(style).toEqual(expect.arrayContaining([{ alignItems: "center" }]));
+	});
+
+	it("applies alignItems: center when isInline is true and keywords is the only secondary field", () => {
+		// 1 secondary field: keywords only
+		const mockItem = createSkillItem({ keywords: ["React", "TypeScript"] });
+		const style = getSkillsItemStyle(true, mockItem, mockMetrics);
+		expect(style).toEqual(expect.arrayContaining([{ alignItems: "center" }]));
+	});
+
+	it("does not apply alignItems: center when isInline is true and 2 secondary fields are present", () => {
 		// 2 secondary fields: level AND keywords
 		const mockItem = createSkillItem({ level: 3, keywords: ["React"] });
+		const style = getSkillsItemStyle(true, mockItem, mockMetrics);
+		expect(style).not.toEqual(expect.arrayContaining([{ alignItems: "center" }]));
+	});
+
+	it("does not apply alignItems: center when isInline is true and 3 secondary fields are present", () => {
+		// 3 secondary fields: proficiency, level, AND keywords
+		const mockItem = createSkillItem({ proficiency: "Advanced", level: 3, keywords: ["React"] });
 		const style = getSkillsItemStyle(true, mockItem, mockMetrics);
 		expect(style).not.toEqual(expect.arrayContaining([{ alignItems: "center" }]));
 	});

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -1129,24 +1129,46 @@ const ProjectsSection = ({ sectionId = "projects", sectionData }: ItemSectionPro
 	);
 };
 
+const inlineSkillsItemStyle = {
+	flexDirection: "row",
+	alignItems: "flex-start",
+	columnGap: 4,
+} satisfies Style;
+
 const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<SkillItem> = {}) => {
 	const data = useRender();
 	const skills = sectionData ?? data.sections.skills;
 	const items = getVisibleItems(skills, "skills");
 	const inlineStyle = useTemplateStyle("inline");
-	const metrics = getTemplateMetrics(data.metadata.page);
+	const _metrics = getTemplateMetrics(data.metadata.page);
 
 	if (items.length === 0) return null;
+
+	const isInlineSkillsItem = "layout" in skills && skills.layout === "inline";
 
 	return (
 		<SectionShell sectionId={sectionId} title={skills.title}>
 			<SectionItems columns={skills.columns}>
 				{items.map((item) => (
-					<SectionItem key={item.id} itemId={item.id} style={{ rowGap: metrics.gapY(0.25) }}>
+					<SectionItem
+						key={item.id}
+						itemId={item.id}
+						style={
+							isInlineSkillsItem
+								? composeStyles(
+										inlineSkillsItemStyle,
+										[hasSplitRowText(item.proficiency), Boolean(item.level), item.keywords.length > 0].filter(Boolean)
+											.length === 1
+											? { alignItems: "center" }
+											: undefined,
+									)
+								: undefined
+						}
+					>
 						<SectionItemHeader>
 							<View style={composeStyles(inlineStyle)}>
 								<Icon name={item.icon as IconName} />
-								<Bold semanticField="name" style={{ flex: 1 }}>
+								<Bold semanticField="name" style={composeStyles(isInlineSkillsItem ? undefined : { flex: 1 })}>
 									{item.name}
 								</Bold>
 							</View>
@@ -1155,9 +1177,8 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 						<View>
 							{hasSplitRowText(item.proficiency) && <Text semanticField="proficiency">{item.proficiency}</Text>}
 							<Small semanticField="keywords">{item.keywords.join(", ")}</Small>
+							<LevelDisplay level={item.level} />
 						</View>
-
-						<LevelDisplay level={item.level} />
 					</SectionItem>
 				))}
 			</SectionItems>

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -1140,7 +1140,7 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 	const skills = sectionData ?? data.sections.skills;
 	const items = getVisibleItems(skills, "skills");
 	const inlineStyle = useTemplateStyle("inline");
-	const _metrics = getTemplateMetrics(data.metadata.page);
+	const metrics = getTemplateMetrics(data.metadata.page);
 
 	if (items.length === 0) return null;
 
@@ -1162,7 +1162,7 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 											? { alignItems: "center" }
 											: undefined,
 									)
-								: undefined
+								: { rowGap: metrics.gapY(0.25) }
 						}
 					>
 						<SectionItemHeader>
@@ -1177,8 +1177,9 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 						<View>
 							{hasSplitRowText(item.proficiency) && <Text semanticField="proficiency">{item.proficiency}</Text>}
 							<Small semanticField="keywords">{item.keywords.join(", ")}</Small>
-							<LevelDisplay level={item.level} />
+							{isInlineSkillsItem && <LevelDisplay level={item.level} />}
 						</View>
+						{!isInlineSkillsItem && <LevelDisplay level={item.level} />}
 					</SectionItem>
 				))}
 			</SectionItems>

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -1164,24 +1164,46 @@ const ProjectsSection = ({ sectionId = "projects", sectionData }: ItemSectionPro
 	);
 };
 
+const inlineSkillsItemStyle = {
+	flexDirection: "row",
+	alignItems: "flex-start",
+	columnGap: 4,
+} satisfies Style;
+
 const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<SkillItem> = {}) => {
 	const data = useRender();
 	const skills = sectionData ?? data.sections.skills;
 	const items = getVisibleItems(skills, "skills");
 	const inlineStyle = useTemplateStyle("inline");
-	const metrics = getTemplateMetrics(data.metadata.page);
+	const _metrics = getTemplateMetrics(data.metadata.page);
 
 	if (items.length === 0) return null;
+
+	const isInlineSkillsItem = "layout" in skills && skills.layout === "inline";
 
 	return (
 		<SectionShell sectionId={sectionId} title={skills.title}>
 			<SectionItems columns={skills.columns}>
 				{items.map((item) => (
-					<SectionItem key={item.id} itemId={item.id} style={{ rowGap: metrics.gapY(0.25) }}>
+					<SectionItem
+						key={item.id}
+						itemId={item.id}
+						style={
+							isInlineSkillsItem
+								? composeStyles(
+										inlineSkillsItemStyle,
+										[hasSplitRowText(item.proficiency), Boolean(item.level), item.keywords.length > 0].filter(Boolean)
+											.length === 1
+											? { alignItems: "center" }
+											: undefined,
+									)
+								: undefined
+						}
+					>
 						<SectionItemHeader>
 							<View style={composeStyles(inlineStyle)}>
 								<Icon name={item.icon as IconName} />
-								<Bold semanticField="name" style={{ flex: 1 }}>
+								<Bold semanticField="name" style={composeStyles(isInlineSkillsItem ? undefined : { flex: 1 })}>
 									{item.name}
 								</Bold>
 							</View>
@@ -1190,9 +1212,8 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 						<View style={{ flexGrow: skills.columns > 1 ? 1 : 0 }}>
 							{hasSplitRowText(item.proficiency) && <Text semanticField="proficiency">{item.proficiency}</Text>}
 							<Small semanticField="keywords">{item.keywords.join(", ")}</Small>
+							<LevelDisplay level={item.level} />
 						</View>
-
-						<LevelDisplay level={item.level} />
 					</SectionItem>
 				))}
 			</SectionItems>

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -1175,7 +1175,7 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 	const skills = sectionData ?? data.sections.skills;
 	const items = getVisibleItems(skills, "skills");
 	const inlineStyle = useTemplateStyle("inline");
-	const _metrics = getTemplateMetrics(data.metadata.page);
+	const metrics = getTemplateMetrics(data.metadata.page);
 
 	if (items.length === 0) return null;
 
@@ -1197,7 +1197,7 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 											? { alignItems: "center" }
 											: undefined,
 									)
-								: undefined
+								: { rowGap: metrics.gapY(0.25) }
 						}
 					>
 						<SectionItemHeader>
@@ -1212,8 +1212,9 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 						<View style={{ flexGrow: skills.columns > 1 ? 1 : 0 }}>
 							{hasSplitRowText(item.proficiency) && <Text semanticField="proficiency">{item.proficiency}</Text>}
 							<Small semanticField="keywords">{item.keywords.join(", ")}</Small>
-							<LevelDisplay level={item.level} />
+							{isInlineSkillsItem && <LevelDisplay level={item.level} />}
 						</View>
+						{!isInlineSkillsItem && <LevelDisplay level={item.level} />}
 					</SectionItem>
 				))}
 			</SectionItems>

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -1170,6 +1170,22 @@ const inlineSkillsItemStyle = {
 	columnGap: 4,
 } satisfies Style;
 
+export const getSkillsItemStyle = (
+	isInline: boolean,
+	item: SkillItem,
+	metrics: ReturnType<typeof getTemplateMetrics>,
+) => {
+	if (isInline) {
+		return composeStyles(
+			inlineSkillsItemStyle,
+			[hasSplitRowText(item.proficiency), Boolean(item.level), item.keywords.length > 0].filter(Boolean).length === 1
+				? { alignItems: "center" }
+				: undefined,
+		);
+	}
+	return { rowGap: metrics.gapY(0.25) };
+};
+
 const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<SkillItem> = {}) => {
 	const data = useRender();
 	const skills = sectionData ?? data.sections.skills;
@@ -1185,21 +1201,7 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 		<SectionShell sectionId={sectionId} title={skills.title}>
 			<SectionItems columns={skills.columns}>
 				{items.map((item) => (
-					<SectionItem
-						key={item.id}
-						itemId={item.id}
-						style={
-							isInlineSkillsItem
-								? composeStyles(
-										inlineSkillsItemStyle,
-										[hasSplitRowText(item.proficiency), Boolean(item.level), item.keywords.length > 0].filter(Boolean)
-											.length === 1
-											? { alignItems: "center" }
-											: undefined,
-									)
-								: { rowGap: metrics.gapY(0.25) }
-						}
-					>
+					<SectionItem key={item.id} itemId={item.id} style={getSkillsItemStyle(isInlineSkillsItem, item, metrics)}>
 						<SectionItemHeader>
 							<View style={composeStyles(inlineStyle)}>
 								<Icon name={item.icon as IconName} />

--- a/packages/schema/src/resume/data.test.ts
+++ b/packages/schema/src/resume/data.test.ts
@@ -14,6 +14,7 @@ import {
 	resumeDataSchema,
 	sectionTypeSchema,
 	skillItemSchema,
+	skillsSectionSchema,
 	styleRuleSchema,
 	styleRulesSchema,
 	summarySchema,
@@ -682,5 +683,42 @@ describe("styleRulesSchema", () => {
 				slots: { heading: { opacity: 2, lineHeight: 10, letterSpacing: -17 } },
 			}).success,
 		).toBe(false);
+	});
+});
+
+describe("skillsSectionSchema", () => {
+	it("forces columns to 1 when layout is 'inline'", () => {
+		const result = skillsSectionSchema.parse({
+			title: "Skills",
+			columns: 2,
+			hidden: false,
+			layout: "inline",
+			items: [],
+		});
+		expect(result.columns).toBe(1);
+		expect(result.layout).toBe("inline");
+	});
+
+	it("preserves columns when layout is 'default'", () => {
+		const result = skillsSectionSchema.parse({
+			title: "Skills",
+			columns: 3,
+			hidden: false,
+			layout: "default",
+			items: [],
+		});
+		expect(result.columns).toBe(3);
+		expect(result.layout).toBe("default");
+	});
+
+	it("defaults layout to 'default' when missing", () => {
+		const result = skillsSectionSchema.parse({
+			title: "Skills",
+			columns: 2,
+			hidden: false,
+			items: [],
+		});
+		expect(result.layout).toBe("default");
+		expect(result.columns).toBe(2);
 	});
 });

--- a/packages/schema/src/resume/data.ts
+++ b/packages/schema/src/resume/data.ts
@@ -318,7 +318,7 @@ const publicationsSectionSchema = itemSection(
 	"The items to display in the publications section.",
 );
 const referencesSectionSchema = itemSection(referenceItemSchema, "The items to display in the references section.");
-const skillsSectionSchema = itemSection(skillItemSchema, "The items to display in the skills section.")
+export const skillsSectionSchema = itemSection(skillItemSchema, "The items to display in the skills section.")
 	.extend({
 		layout: z
 			.enum(["default", "inline"])

--- a/packages/schema/src/resume/data.ts
+++ b/packages/schema/src/resume/data.ts
@@ -318,7 +318,15 @@ const publicationsSectionSchema = itemSection(
 	"The items to display in the publications section.",
 );
 const referencesSectionSchema = itemSection(referenceItemSchema, "The items to display in the references section.");
-const skillsSectionSchema = itemSection(skillItemSchema, "The items to display in the skills section.");
+const skillsSectionSchema = itemSection(skillItemSchema, "The items to display in the skills section.")
+	.extend({
+		layout: z
+			.enum(["default", "inline"])
+			.default("default")
+			.catch("default")
+			.describe("The layout style for skill items. 'inline' places item fields next to name"),
+	})
+	.transform((section) => (section.layout === "inline" ? { ...section, columns: 1 } : section));
 const volunteerSectionSchema = itemSection(volunteerItemSchema, "The items to display in the volunteer section.");
 
 const sectionsSchema = z.object({

--- a/packages/schema/src/resume/default.ts
+++ b/packages/schema/src/resume/default.ts
@@ -47,7 +47,7 @@ export const defaultResumeData: ResumeData = {
 		experience: section("briefcase"),
 		education: section("graduation-cap"),
 		projects: section("code-simple"),
-		skills: section("compass-tool"),
+		skills: { ...section("compass-tool"), layout: "default" },
 		languages: section("translate"),
 		interests: section("football"),
 		awards: section("trophy"),

--- a/packages/schema/src/resume/sample.ts
+++ b/packages/schema/src/resume/sample.ts
@@ -191,6 +191,7 @@ export const sampleResumeData: ResumeData = {
 			title: "",
 			icon: "compass-tool",
 			columns: 1,
+			layout: "default",
 			hidden: false,
 			keepTogether: false,
 			startOnNewPage: false,

--- a/skills/resume-builder/references/schema.md
+++ b/skills/resume-builder/references/schema.md
@@ -171,6 +171,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `sections.skills.items[].level` | `number` | yes | minimum: 0; maximum: 5; default: 0 | The proficiency level of the skill, defined as a number between 0 and 5. If set to 0, the icons displaying the level will be hidden. |
 | `sections.skills.items[].keywords` | `array` | yes | default: [] | The keywords associated with the skill, if any. These are displayed as tags below the name. |
 | `sections.skills.items[].keywords[]` | `string` | — | — | — |
+| `sections.skills.layout` | `string` | no | enum: ["default","inline"]; default: "default" | The layout style for skill items. 'inline' places item fields next to name |
 | `sections.languages` | `object` | yes | — | The section to display the languages of the author. |
 | `sections.languages.title` | `string` | yes | — | The title of the section. |
 | `sections.languages.icon` | `string` | yes | default: "" | Phosphor icon name to display before the section title in the PDF output. Empty string uses the default section icon; 'none' hides the icon. |


### PR DESCRIPTION
## Summary

Adds a new "1 Column / Inline" layout option for the Skills section, alongside the existing column-count options in the section's drop-down menu.

When enabled, proficiency, keywords, and level render alongside name instead of the default stacked block layout below

This is useful for resumes with many short skills in order to preserve space and give a better display than a multi-column grid.

## Note:

I couldn't achieve this with custom CSS alone, so I'm proposing it as a schema/renderer change. Happy to adjust the approach if there's a lighter way to do this

## Changes:
- schema: skillsSectionSchema gains a `layout: "default" | "inline"` field. When layout is "inline", columns is normalized to 1 on parse so the two settings can't drift out of sync.
- section menu: adds an "Inline" radio option under the section's Columns submenu (skills section only).
- renderer: SkillsSection applies a row-based style to each item when layout is "inline", with centered alignment when exactly one secondary field (proficiency/level/keywords) is present.


## Examples

**1 Column**
<img width="661" height="480" alt="column 1" src="https://github.com/user-attachments/assets/ffba971b-1cc7-49e9-88d4-a49a8f4e2007" />


**1 Column / Inline**
<img width="731" height="347" alt="column1 - inline" src="https://github.com/user-attachments/assets/a0e64cc1-b879-48e0-aa39-77826db6472f" />

**Dropdown menu**
<img width="616" height="469" alt="dropdown menu" src="https://github.com/user-attachments/assets/7625d964-8114-4a82-a861-7e2381f13b39" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline layout option for the Skills section.
  * Inline skills display in a single, row-oriented layout with improved alignment.
  * Selecting another column option restores the standard Skills layout.

* **Improvements**
  * Skills layout settings are now handled consistently across resume editing, rendering, and conversion.
  * Existing resumes continue using the default Skills layout.
  * Inline alignment adapts based on the number of additional skill details shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

















<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds an inline, single-column layout for skill items while preserving the existing default rendering.
- Extends the skills schema, defaults, imports, samples, and documentation with the new layout field.
- Adds an Inline option to the builder’s Columns menu and normalizes that selection to one column.
- Updates the PDF renderer to arrange skill details horizontally in inline mode and adds schema, menu, import, and renderer tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported default-layout regression has been corrected at the current head.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/sections.tsx | Adds layout-specific skill rendering while restoring the default branch’s original spacing, name sizing, and level placement. |
| packages/schema/src/resume/data.ts | Adds a defaulted skills layout enum and normalizes inline sections to one column during parsing. |
| apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx | Adds the skills-only inline menu option and keeps layout and column selections synchronized. |
| packages/import/src/reactive-resume-v4-json.tsx | Initializes imported v4 skills sections with the default layout. |
| docs/guides/json-resume-schema.mdx | Documents the new optional skills layout property and its supported values. |

</details>

<sub>Reviews (10): Last reviewed commit: ["test(docx): include skills layout in sec..."](https://github.com/amruthpillai/reactive-resume/commit/4086a6be8d5007b39be5988f6f4a0a6d6c6e1a10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54553338)</sub>

<!-- /greptile_comment -->