### PR TITLE
fix(pdf): constrain bullet list content within horizontal margin

### DIFF
--- a/packages/pdf/src/templates/shared/base-template-styles.ts
+++ b/packages/pdf/src/templates/shared/base-template-styles.ts
@@ -110,7 +110,8 @@ export function createBaseTemplateStyles({
 
 		richListItemContent: {
 			...bodyText,
-			flex: "initial",
+			flex: 1,
+			minWidth: 0,
 		} satisfies Style,
 
 		splitRow: {


### PR DESCRIPTION
## Problem

Bullet list items push text beyond the user-configured horizontal margin. The `richListItemRow` flex row contains a fixed-width marker (`width: fontSize`) and a `columnGap: gapX(1/3)`, while `richListItemContent` uses `flex: "initial"` (natural sizing). The combined width of marker + gap + content exceeds the column bounds, and the overflow compounds with each nesting level.

Fixes #3336

## Fix

Change `richListItemContent` from `flex: "initial"` to `flex: 1` with `minWidth: 0` in `packages/pdf/src/templates/shared/base-template-styles.ts`. This makes the content area fill the remaining space after the marker and gap are accounted for, so text wraps within the margin boundary instead of overflowing.

## Testing

- Verified no template overrides `flex` on `richListItemContent` (5 templates that reference it only override `color`)
- `flex: 1` gives `flexGrow: 1, flexShrink: 1, flexBasis: 0%` in Yoga layout, correctly constraining content to available width
- `minWidth: 0` ensures the content can shrink below its intrinsic minimum

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR constrains rich-list content to the horizontal space remaining after its marker and gap.
- Changes `richListItemContent` from intrinsic sizing to flexible sizing.
- Adds `minWidth: 0` so long and nested list content can shrink and wrap within configured margins.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The shared list-content style now consumes only the row’s remaining width and can shrink below its intrinsic minimum, while existing template overrides preserve these layout properties.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/base-template-styles.ts | Replaces intrinsic list-content sizing with the repository’s established shrinkable flex pattern; no actionable regression was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pdf): constrain bullet list content ..."](https://github.com/amruthpillai/reactive-resume/commit/db71449d44b67a2b8eba8358c85dc2ad1eb86116) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55445523)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved rich-list-item layout behavior with flexible sizing.
  * Prevented content overflow in shared PDF templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->