### PR TITLE
fix(applications): handle cover letter copy failures

### DIFF
--- a/apps/web/src/features/applications/components/application-ai-copilot.tsx
+++ b/apps/web/src/features/applications/components/application-ai-copilot.tsx
@@ -241,7 +241,10 @@ export function ApplicationAiCopilot({ application }: Props) {
 			await navigator.clipboard.writeText(draft?.text ?? "");
 			toast.add({ type: "success", description: t`Copied to clipboard.` });
 		} catch {
-			toast.add({ type: "error", description: t`Could not copy to clipboard. Please copy the text manually.` });
+			toast.add({
+				type: "error",
+				description: t`Could not copy to clipboard. Please copy the text manually.`,
+			});
 		}
 	};
 

--- a/apps/web/src/features/applications/components/application-ai-copilot.tsx
+++ b/apps/web/src/features/applications/components/application-ai-copilot.tsx
@@ -14,7 +14,7 @@ import {
 	SpinnerGapIcon,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "@reactive-resume/ui/components/toast";
 import { generateFilename } from "@reactive-resume/utils/file";
 import { cn } from "@reactive-resume/utils/style";
@@ -235,7 +235,8 @@ export function ApplicationAiCopilot({ application }: Props) {
 		}
 	};
 
-	const copyDraft = async () => {
+	// biome-ignore lint/correctness/useExhaustiveDependencies: keep review-requested callback dependencies explicit.
+	const copyDraft = useCallback(async () => {
 		try {
 			if (!navigator.clipboard?.writeText) throw new Error("Clipboard unavailable");
 			await navigator.clipboard.writeText(draft?.text ?? "");
@@ -246,7 +247,7 @@ export function ApplicationAiCopilot({ application }: Props) {
 				description: t`Could not copy to clipboard. Please copy the text manually.`,
 			});
 		}
-	};
+	}, [draft?.text, toast, t]);
 
 	return (
 		<section className="overflow-hidden rounded-xl border border-primary/15 bg-primary/[0.04]">

--- a/apps/web/src/features/applications/components/application-ai-copilot.tsx
+++ b/apps/web/src/features/applications/components/application-ai-copilot.tsx
@@ -235,6 +235,16 @@ export function ApplicationAiCopilot({ application }: Props) {
 		}
 	};
 
+	const copyDraft = async () => {
+		try {
+			if (!navigator.clipboard?.writeText) throw new Error("Clipboard unavailable");
+			await navigator.clipboard.writeText(draft?.text ?? "");
+			toast.add({ type: "success", description: t`Copied to clipboard.` });
+		} catch {
+			toast.add({ type: "error", description: t`Could not copy to clipboard. Please copy the text manually.` });
+		}
+	};
+
 	return (
 		<section className="overflow-hidden rounded-xl border border-primary/15 bg-primary/[0.04]">
 			<header className="flex items-center gap-2 px-3.5 pt-3">
@@ -341,10 +351,7 @@ export function ApplicationAiCopilot({ application }: Props) {
 							<button
 								type="button"
 								className="inline-flex items-center gap-1 text-muted-foreground text-xs hover:text-foreground"
-								onClick={() => {
-									void navigator.clipboard.writeText(draft.text);
-									toast.add({ type: "success", description: t`Copied to clipboard.` });
-								}}
+								onClick={() => void copyDraft()}
 							>
 								<CopyIcon className="size-3.5" /> <Trans>Copy</Trans>
 							</button>


### PR DESCRIPTION
Handle unavailable or rejected Clipboard API writes before reporting success in Application Copilot.

Currently clicking on the Copy button never works for me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved the reliability and consistency of copying AI-generated drafts.
  * Copy actions continue to provide clear success or failure feedback.
  * Added graceful handling for environments where clipboard access is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR now waits for clipboard writes to complete before reporting success and displays an error when clipboard access is unavailable or rejected.
- Adds an asynchronous clipboard-copy callback with availability and rejection handling.
- Reports success only after `writeText` resolves.
- Reformats the error notification to comply with repository formatting conventions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/applications/components/application-ai-copilot.tsx | Adds reliable Clipboard API failure handling and correctly formats the resulting user feedback. |

</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(applications): memoize copy dra..."](https://github.com/amruthpillai/reactive-resume/commit/3f09fb32840ef9fb27703f216f103a504de1987e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58957394)</sub>

<!-- /greptile_comment -->