### PR TITLE
feat(applications): attach generated cover letter PDFs

### DIFF
--- a/apps/web/src/features/applications/components/application-ai-copilot.tsx
+++ b/apps/web/src/features/applications/components/application-ai-copilot.tsx
@@ -1,3 +1,4 @@
+import type { ResumeData } from "@reactive-resume/schema/resume/data";
 import type { Application } from "../types";
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
@@ -6,17 +7,68 @@ import {
 	CaretRightIcon,
 	CopyIcon,
 	EnvelopeSimpleIcon,
+	FilePdfIcon,
 	MagicWandIcon,
 	PaperPlaneTiltIcon,
 	SparkleIcon,
 	SpinnerGapIcon,
 } from "@phosphor-icons/react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { getResumeExportData } from "@reactive-resume/resume/export-sections";
 import { toast } from "@reactive-resume/ui/components/toast";
+import { generateFilename } from "@reactive-resume/utils/file";
 import { cn } from "@reactive-resume/utils/style";
+import { createResumePdfBlob } from "@/features/resume/export/pdf-document";
 import { orpc } from "@/libs/orpc/client";
 import { applicationsListQueryKey } from "../queries";
+
+const COPILOT_COVER_LETTER_SECTION_ID = "copilot-cover-letter";
+
+const escapeHtml = (value: string) =>
+	value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
+
+const toHtmlParagraphs = (value: string) =>
+	value
+		.trim()
+		.split(/\n\s*\n/)
+		.map((paragraph) => `<p>${escapeHtml(paragraph).replace(/\n/g, "<br />")}</p>`)
+		.join("");
+
+function createCoverLetterPdfData(data: ResumeData, text: string): ResumeData {
+	return getResumeExportData(
+		{
+			...data,
+			customSections: [
+				...data.customSections,
+				{
+					id: COPILOT_COVER_LETTER_SECTION_ID,
+					type: "cover-letter",
+					title: "",
+					icon: "",
+					columns: 1,
+					hidden: false,
+					keepTogether: false,
+					startOnNewPage: false,
+					items: [
+						{
+							id: `${COPILOT_COVER_LETTER_SECTION_ID}-item`,
+							hidden: false,
+							recipient: "",
+							content: toHtmlParagraphs(text),
+						},
+					],
+				},
+			],
+		},
+		"cover-letter",
+	);
+}
 
 // Score bands drive the ring color and the label — a job-fit gauge, not a generic percentage.
 function band(score: number) {
@@ -102,6 +154,10 @@ type Props = { application: Application };
 export function ApplicationAiCopilot({ application }: Props) {
 	const queryClient = useQueryClient();
 	const [draft, setDraft] = useState<{ kind: string; text: string } | null>(null);
+	const { data: resume } = useQuery({
+		...orpc.resume.getById.queryOptions({ input: { id: application.resumeId ?? "" } }),
+		enabled: !!application.resumeId,
+	});
 
 	const invalidate = () => {
 		void queryClient.invalidateQueries({ queryKey: applicationsListQueryKey() });
@@ -131,11 +187,39 @@ export function ApplicationAiCopilot({ application }: Props) {
 			onError: (error) => toast.add({ type: "error", description: error.message || t`Drafting failed.` }),
 		}),
 	);
+	const attachCoverLetter = useMutation(
+		orpc.applications.attachDocument.mutationOptions({
+			onSuccess: () => {
+				invalidate();
+				toast.add({ type: "success", description: t`Cover letter PDF attached to this application.` });
+			},
+			onError: (error) =>
+				toast.add({ type: "error", description: error.message || t`Could not attach the cover letter PDF.` }),
+		}),
+	);
 
-	const pending = matchScore.isPending || tailorResume.isPending || draftMessage.isPending;
+	const pending =
+		matchScore.isPending || tailorResume.isPending || draftMessage.isPending || attachCoverLetter.isPending;
 	const canScore = !!application.resumeId && !!application.jobDescription;
 	const score = application.matchScore;
 	const gaps = aiGaps(application);
+	const attachDraftAsPdf = async () => {
+		if (!draft || draft.kind !== "cover-letter") return;
+		if (!resume) {
+			toast.add({ type: "error", description: t`Link a resume to generate a cover letter PDF.` });
+			return;
+		}
+
+		try {
+			const blob = await createResumePdfBlob(createCoverLetterPdfData(resume.data, draft.text));
+			const file = new File([blob], generateFilename(`Cover Letter - ${application.company}`, "pdf"), {
+				type: "application/pdf",
+			});
+			attachCoverLetter.mutate({ id: application.id, kind: "cover-letter", file });
+		} catch {
+			toast.add({ type: "error", description: t`Could not generate the cover letter PDF.` });
+		}
+	};
 
 	return (
 		<section className="overflow-hidden rounded-xl border border-primary/15 bg-primary/[0.04]">
@@ -250,6 +334,17 @@ export function ApplicationAiCopilot({ application }: Props) {
 							>
 								<CopyIcon className="size-3.5" /> <Trans>Copy</Trans>
 							</button>
+							{draft.kind === "cover-letter" && (
+								<button
+									type="button"
+									disabled={attachCoverLetter.isPending}
+									className="inline-flex items-center gap-1 text-muted-foreground text-xs hover:text-foreground disabled:opacity-50"
+									onClick={() => void attachDraftAsPdf()}
+								>
+									<FilePdfIcon className="size-3.5" />
+									{attachCoverLetter.isPending ? <Trans>Attaching…</Trans> : <Trans>Generate PDF & attach</Trans>}
+								</button>
+							)}
 							<button
 								type="button"
 								className="text-muted-foreground text-xs hover:text-foreground"

--- a/apps/web/src/features/applications/components/application-ai-copilot.tsx
+++ b/apps/web/src/features/applications/components/application-ai-copilot.tsx
@@ -15,7 +15,6 @@ import {
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { getResumeExportData } from "@reactive-resume/resume/export-sections";
 import { toast } from "@reactive-resume/ui/components/toast";
 import { generateFilename } from "@reactive-resume/utils/file";
 import { cn } from "@reactive-resume/utils/style";
@@ -41,33 +40,36 @@ const toHtmlParagraphs = (value: string) =>
 		.join("");
 
 function createCoverLetterPdfData(data: ResumeData, text: string): ResumeData {
-	return getResumeExportData(
-		{
-			...data,
-			customSections: [
-				...data.customSections,
-				{
-					id: COPILOT_COVER_LETTER_SECTION_ID,
-					type: "cover-letter",
-					title: "",
-					icon: "",
-					columns: 1,
-					hidden: false,
-					keepTogether: false,
-					startOnNewPage: false,
-					items: [
-						{
-							id: `${COPILOT_COVER_LETTER_SECTION_ID}-item`,
-							hidden: false,
-							recipient: "",
-							content: toHtmlParagraphs(text),
-						},
-					],
-				},
-			],
+	return {
+		...data,
+		customSections: [
+			{
+				id: COPILOT_COVER_LETTER_SECTION_ID,
+				type: "cover-letter",
+				title: "",
+				icon: "",
+				columns: 1,
+				hidden: false,
+				keepTogether: false,
+				startOnNewPage: false,
+				items: [
+					{
+						id: `${COPILOT_COVER_LETTER_SECTION_ID}-item`,
+						hidden: false,
+						recipient: "",
+						content: toHtmlParagraphs(text),
+					},
+				],
+			},
+		],
+		metadata: {
+			...data.metadata,
+			layout: {
+				...data.metadata.layout,
+				pages: [{ fullWidth: true, main: [COPILOT_COVER_LETTER_SECTION_ID], sidebar: [] }],
+			},
 		},
-		"cover-letter",
-	);
+	};
 }
 
 // Score bands drive the ring color and the label — a job-fit gauge, not a generic percentage.
@@ -154,6 +156,7 @@ type Props = { application: Application };
 export function ApplicationAiCopilot({ application }: Props) {
 	const queryClient = useQueryClient();
 	const [draft, setDraft] = useState<{ kind: string; text: string } | null>(null);
+	const [isGeneratingCoverLetter, setIsGeneratingCoverLetter] = useState(false);
 	const { data: resume } = useQuery({
 		...orpc.resume.getById.queryOptions({ input: { id: application.resumeId ?? "" } }),
 		enabled: !!application.resumeId,
@@ -204,20 +207,31 @@ export function ApplicationAiCopilot({ application }: Props) {
 	const score = application.matchScore;
 	const gaps = aiGaps(application);
 	const attachDraftAsPdf = async () => {
-		if (!draft || draft.kind !== "cover-letter") return;
+		if (draft?.kind !== "cover-letter" || isGeneratingCoverLetter) return;
 		if (!resume) {
 			toast.add({ type: "error", description: t`Link a resume to generate a cover letter PDF.` });
 			return;
 		}
 
+		setIsGeneratingCoverLetter(true);
+		let file: File;
 		try {
 			const blob = await createResumePdfBlob(createCoverLetterPdfData(resume.data, draft.text));
-			const file = new File([blob], generateFilename(`Cover Letter - ${application.company}`, "pdf"), {
+			file = new File([blob], generateFilename(`Cover Letter - ${application.company || "Untitled"}`, "pdf"), {
 				type: "application/pdf",
 			});
-			attachCoverLetter.mutate({ id: application.id, kind: "cover-letter", file });
 		} catch {
 			toast.add({ type: "error", description: t`Could not generate the cover letter PDF.` });
+			setIsGeneratingCoverLetter(false);
+			return;
+		}
+
+		try {
+			await attachCoverLetter.mutateAsync({ id: application.id, kind: "cover-letter", file });
+		} catch {
+			// Mutation onError displays the upload failure.
+		} finally {
+			setIsGeneratingCoverLetter(false);
 		}
 	};
 
@@ -337,12 +351,18 @@ export function ApplicationAiCopilot({ application }: Props) {
 							{draft.kind === "cover-letter" && (
 								<button
 									type="button"
-									disabled={attachCoverLetter.isPending}
+									disabled={isGeneratingCoverLetter || attachCoverLetter.isPending}
 									className="inline-flex items-center gap-1 text-muted-foreground text-xs hover:text-foreground disabled:opacity-50"
 									onClick={() => void attachDraftAsPdf()}
 								>
 									<FilePdfIcon className="size-3.5" />
-									{attachCoverLetter.isPending ? <Trans>Attaching…</Trans> : <Trans>Generate PDF & attach</Trans>}
+									{isGeneratingCoverLetter ? (
+										<Trans>Generating PDF…</Trans>
+									) : attachCoverLetter.isPending ? (
+										<Trans>Attaching…</Trans>
+									) : (
+										<Trans>Generate PDF & attach</Trans>
+									)}
 								</button>
 							)}
 							<button


### PR DESCRIPTION
Let users render a generated Application Copilot cover letter with its linked resume styling and attach the PDF to the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to generate a single-page PDF from drafted cover letters.
  - Cover letter PDFs can now be attached directly to applications.
  - Added clear progress states while PDFs are generated and attached.
  - Prevented duplicate generation or attachment requests while an operation is in progress.
  - Added a default filename when no company name is provided.
- **Bug Fixes**
  - Improved recovery after PDF generation or attachment failures so the action can be retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds generation and attachment of cover-letter PDFs using the linked resume's styling.

- Builds a cover-letter-only resume document from the generated draft.
- Renders the document to PDF and uploads it as an application attachment.
- Tracks rendering and upload progress to prevent repeated actions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/applications/components/application-ai-copilot.tsx | Adds a cover-letter-only PDF transformation, rendering/upload flow, and continuous pending-state handling. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor User
  participant Copilot as Application Copilot
  participant Renderer as PDF Renderer
  participant API as Applications API
  User->>Copilot: "Generate PDF & attach"
  Copilot->>Renderer: Render cover-letter resume data
  Renderer-->>Copilot: PDF blob
  Copilot->>API: Attach cover-letter file
  API-->>Copilot: Attachment saved
  Copilot-->>User: Show success notification
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(applications): isolate generated cov..."](https://github.com/amruthpillai/reactive-resume/commit/9fde22a3d0e2adc748c7906176f41becbe86d206) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58957526)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/amruthpillai/reactive-resume/blob/main/AGENTS.md))

<!-- /greptile_comment -->