### PR TITLE
fix(applications): show saved notes in detail view

### DIFF
--- a/apps/web/src/features/applications/components/application-detail-sheet.tsx
+++ b/apps/web/src/features/applications/components/application-detail-sheet.tsx
@@ -192,6 +192,12 @@ export function ApplicationDetailSheet({ application, onOpenChange, onEdit }: Pr
 						</a>
 					)}
 
+					{current.notes?.trim() && (
+						<Section title={t`Notes`}>
+							<p className="wrap-break-word whitespace-pre-wrap text-sm">{current.notes}</p>
+						</Section>
+					)}
+
 					{/* documents: linked resume + cover letter */}
 					<Section title={t`Documents sent`}>
 						{current.resumeId ? (


### PR DESCRIPTION
Saved application notes were only visible while editing an application. The detail pane now shows a Notes section, preserving line breaks and wrapping long text; empty notes stay hidden.

Closes #3391.

Validation: web typecheck, repository `pnpm check`, diff check, and independent code review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Notes** section to application details when notes are available.
  - Preserved note formatting, including whitespace and line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a conditional Notes section to application details, preserving line breaks and wrapping long text while hiding blank notes.
- Displays the existing nullable notes field in the application detail sheet.
- Uses trimmed content to determine visibility without altering the displayed text.
- Applies multiline and long-word wrapping styles.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable issues identified.

The nullable notes contract is handled safely, blank notes remain hidden as intended, and the selected wrapping utilities are already supported and used within the repository.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/applications/components/application-detail-sheet.tsx | Adds guarded rendering for saved application notes using styling conventions supported by the existing web toolchain. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(applications): show saved notes in d..."](https://github.com/amruthpillai/reactive-resume/commit/822ffd6c38c0f0f56cbf2fbd11d4ba6533fe6c36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60738581)</sub>

<!-- /greptile_comment -->