### PR TITLE
fix(builder): preserve explicit HTTP URLs

### DIFF
--- a/apps/web/src/components/input/url-input.test.tsx
+++ b/apps/web/src/components/input/url-input.test.tsx
@@ -56,6 +56,43 @@ describe("URLInput", () => {
 		});
 	});
 
+	it.each(["http://other.example/path", "HTTP://other.example/path"])(
+		"preserves an explicitly pasted HTTP URL: %s",
+		(url) => {
+			const onChange = vi.fn();
+			renderInput({ url: "https://example.com", label: "Company" }, onChange);
+
+			fireEvent.change(screen.getByRole("textbox"), { target: { value: url } });
+
+			expect(onChange).toHaveBeenCalledWith({ url, label: "Company" });
+		},
+	);
+
+	it("shows an existing HTTP URL with its matching prefix", () => {
+		renderInput({ url: "http://example.com/path", label: "" });
+
+		expect((screen.getByRole("textbox") as HTMLInputElement).value).toBe("example.com/path");
+		expect(screen.getByText("http://")).toBeDefined();
+	});
+
+	it("preserves HTTP while editing the host or path", () => {
+		const onChange = vi.fn();
+		renderInput({ url: "http://example.com/path", label: "Company" }, onChange);
+
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "example.com/new-path" } });
+
+		expect(onChange).toHaveBeenCalledWith({ url: "http://example.com/new-path", label: "Company" });
+	});
+
+	it("allows switching an existing HTTP URL to HTTPS by pasting", () => {
+		const onChange = vi.fn();
+		renderInput({ url: "http://example.com", label: "" }, onChange);
+
+		fireEvent.change(screen.getByRole("textbox"), { target: { value: "https://example.com" } });
+
+		expect(onChange).toHaveBeenCalledWith({ url: "https://example.com", label: "" });
+	});
+
 	it("emits an empty url string when cleared", () => {
 		const onChange = vi.fn();
 		renderInput({ url: "https://example.com", label: "" }, onChange);

--- a/apps/web/src/components/input/url-input.tsx
+++ b/apps/web/src/components/input/url-input.tsx
@@ -15,15 +15,16 @@ import { Label } from "@reactive-resume/ui/components/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@reactive-resume/ui/components/popover";
 import { cn } from "@reactive-resume/utils/style";
 
-const PREFIX = "https://";
+const DEFAULT_PREFIX = "https://";
+const HTTP_PREFIX = /^https?:\/\//i;
 
 function stripPrefix(url: string) {
-	return url.startsWith(PREFIX) ? url.slice(PREFIX.length) : url;
+	return url.replace(HTTP_PREFIX, "");
 }
 
-function ensurePrefix(url: string) {
+function ensurePrefix(url: string, prefix: string) {
 	if (url === "") return "";
-	return url.startsWith(PREFIX) ? url : PREFIX + url;
+	return HTTP_PREFIX.test(url) ? url : prefix + url;
 }
 
 type Props<TValue extends Website = Website> = Omit<React.ComponentProps<"input">, "value" | "onChange"> & {
@@ -33,14 +34,15 @@ type Props<TValue extends Website = Website> = Omit<React.ComponentProps<"input"
 };
 
 export function URLInput<TValue extends Website>({ value, onChange, hideLabelButton, ...props }: Props<TValue>) {
+	const prefix = value.url.match(HTTP_PREFIX)?.[0] ?? DEFAULT_PREFIX;
 	const handleUrlChange = useCallback(
 		(e: React.ChangeEvent<HTMLInputElement>) => {
 			onChange({
 				...value,
-				url: ensurePrefix(e.target.value),
+				url: ensurePrefix(e.target.value, prefix),
 			});
 		},
-		[onChange, value],
+		[onChange, value, prefix],
 	);
 
 	const handleLabelChange = useCallback(
@@ -55,7 +57,7 @@ export function URLInput<TValue extends Website>({ value, onChange, hideLabelBut
 	return (
 		<InputGroup>
 			<InputGroupAddon align="inline-start">
-				<InputGroupText>{PREFIX}</InputGroupText>
+				<InputGroupText>{prefix}</InputGroupText>
 			</InputGroupAddon>
 
 			<InputGroupInput


### PR DESCRIPTION
Pasting an explicit HTTP URL into the builder produced `https://http://…`. URL inputs now preserve explicit HTTP/HTTPS schemes, display the stored scheme, and retain it when editing the host or path. New bare URLs still default to HTTPS.

Closes #2735.

Validation: 12 URLInput tests, web typecheck, repository `pnpm check`, and independent review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URL inputs now preserve the selected HTTP or HTTPS scheme when pasting, editing, or displaying URLs.
  * Existing HTTP URLs retain their `http://` prefix instead of being changed to `https://`.
  * URL scheme detection is now case-insensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the builder’s URL input to recognize HTTP and HTTPS schemes case-insensitively, display the stored scheme, and retain it during edits while continuing to default bare URLs to HTTPS.
- Replaces the fixed HTTPS prefix with a prefix derived from the controlled URL value.
- Preserves explicitly pasted HTTP or HTTPS URLs without adding a second scheme.
- Adds tests for HTTP pasting, display, subsequent path edits, scheme switching, and uppercase schemes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable changed-code defects identified.

The revised input consistently derives and preserves explicit HTTP or HTTPS prefixes, leaves pasted schemes intact, defaults bare URLs to HTTPS, and includes tests for the principal editing paths.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/input/url-input.tsx | Implements scheme-aware display and editing without an identified changed-code regression. |
| apps/web/src/components/input/url-input.test.tsx | Adds focused coverage for preserving and switching explicit HTTP and HTTPS schemes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(builder): preserve explicit HTTP URL..."](https://github.com/amruthpillai/reactive-resume/commit/53973d13a80471fe7ffcfc0ebd7b984c6499f05d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60739286)</sub>

<!-- /greptile_comment -->