### PR TITLE
fix(ui): restore hover feedback for primary buttons

### DIFF
--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
 	{
 		variants: {
 			variant: {
-				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+				default: "bg-primary text-primary-foreground hover:bg-primary/80",
 				outline:
 					"border-input bg-transparent hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
 				secondary:


### PR DESCRIPTION
Primary buttons lacked hover feedback because their hover background selector only matched anchors. Apply the existing hover color to primary buttons as well, preserving disabled pointer-event behavior.

Closes #3251.

Validation: compiled Tailwind selectors before/after, UI and web typechecks, repository `pnpm check`, and independent review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hover styling for default buttons so the background color applies consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores hover feedback for primary buttons while preserving existing anchor hover behavior and disabled pointer-event handling.
- Replaces the anchor-only primary hover selector with a general hover selector.
- Aligns the default variant with the hover convention used by sibling button variants.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The generalized hover selector restores feedback for native primary buttons, continues matching anchor-rendered buttons, and leaves the shared disabled pointer-event behavior intact.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/button.tsx | Broadens the default variant’s hover utility from anchors to all rendered button forms without identifying a concrete regression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): restore hover feedback for prim..."](https://github.com/amruthpillai/reactive-resume/commit/67f470368da61c7ff6c06c793a9e34f01d54ecc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60739412)</sub>

<!-- /greptile_comment -->