### PR TITLE
fix(pdf): align dates when optional item fields are empty

### DIFF
--- a/packages/pdf/src/templates/shared/section-header-alignment.test.tsx
+++ b/packages/pdf/src/templates/shared/section-header-alignment.test.tsx
@@ -64,6 +64,14 @@ const findText = (items: TextItem[], text: string) => {
 	return item;
 };
 
+const expectTrailingAlignment = (items: TextItem[]) => {
+	const expectedText = ["2010", "2011", "2012", "Paris • 2020", "Paris • 2021", "Paris • 2022", "Paris • 2023"];
+	for (const text of expectedText) {
+		const item = findText(items, text);
+		expect(item.transform[4] + item.width, text).toBeCloseTo(565.28, 1);
+	}
+};
+
 describe("optional experience and education header fields (#3338)", () => {
 	it.each(["legacy", "semantic"] as const)(
 		"keeps dates at the trailing edge with empty leading fields in %s mode",
@@ -71,10 +79,7 @@ describe("optional experience and education header fields (#3338)", () => {
 			const data = fixture();
 			data.metadata.stylesheet = { mode, source: { languageVersion: 1, text: "@version 1;" } };
 			const items = await renderText(data);
-			for (const text of ["2010", "2011", "2012", "Paris • 2020", "Paris • 2021", "Paris • 2022", "Paris • 2023"]) {
-				const item = findText(items, text);
-				expect(item.transform[4] + item.width, text).toBeCloseTo(565.28, 1);
-			}
+			expectTrailingAlignment(items);
 		},
 	);
 
@@ -82,10 +87,7 @@ describe("optional experience and education header fields (#3338)", () => {
 		const data = fixture();
 		data.metadata.page.locale = "ar-SA";
 		const items = await renderText(data);
-		for (const text of ["2010", "2011", "2012", "Paris • 2020", "Paris • 2021", "Paris • 2022", "Paris • 2023"]) {
-			const item = findText(items, text);
-			expect(item.transform[4] + item.width, text).toBeCloseTo(565.28, 1);
-		}
+		expectTrailingAlignment(items);
 	});
 
 	it("preserves the leading alignment of stacked sidebar fields", async () => {

--- a/packages/pdf/src/templates/shared/section-header-alignment.test.tsx
+++ b/packages/pdf/src/templates/shared/section-header-alignment.test.tsx
@@ -1,0 +1,106 @@
+import type { ResumeData } from "@reactive-resume/schema/resume/data";
+import type { Template } from "@reactive-resume/schema/templates";
+import type { TextItem } from "pdfjs-dist/types/src/display/api";
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act, createElement } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+
+const fixture = (): ResumeData => {
+	const data = structuredClone(defaultResumeData);
+	data.picture.hidden = true;
+	data.metadata.page.marginX = 30;
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.layout.pages = [{ fullWidth: true, main: ["experience", "education"], sidebar: [] }];
+	data.sections.experience.items = ["Engineer", "", "  "].map((position, index) => ({
+		id: `experience-${index}`,
+		hidden: false,
+		company: `Company ${index}`,
+		position,
+		location: "London",
+		period: `201${index}`,
+		website: { url: "", label: "", inlineLink: false },
+		description: "",
+		roles: [],
+	}));
+	data.sections.education.items = ["Computing", "", "  ", ""].map((area, index) => ({
+		id: `education-${index}`,
+		hidden: false,
+		school: `School ${index}`,
+		degree: index === 3 ? "" : "Degree",
+		area,
+		grade: "",
+		location: "Paris",
+		period: `202${index}`,
+		website: { url: "", label: "", inlineLink: false },
+		description: "",
+	}));
+	return data;
+};
+
+const renderText = async (data: ResumeData, template: Template = "onyx") => {
+	const element = createElement(ResumeDocument, { data, template }) as unknown as Parameters<typeof renderToBuffer>[0];
+	let bytes: Uint8Array = new Uint8Array();
+	await act(async () => {
+		bytes = new Uint8Array(await renderToBuffer(element));
+	});
+	const loadingTask = getDocument({ data: bytes, useSystemFonts: true });
+	try {
+		const document = await loadingTask.promise;
+		const page = await document.getPage(1);
+		const content = await page.getTextContent();
+		return content.items.filter((item): item is TextItem => "str" in item);
+	} finally {
+		await loadingTask.destroy();
+	}
+};
+
+const findText = (items: TextItem[], text: string) => {
+	const item = items.find((item) => item.str === text);
+	if (!item) throw new Error(`Missing PDF text: ${text}`);
+	return item;
+};
+
+describe("optional experience and education header fields (#3338)", () => {
+	it.each(["legacy", "semantic"] as const)(
+		"keeps dates at the trailing edge with empty leading fields in %s mode",
+		async (mode) => {
+			const data = fixture();
+			data.metadata.stylesheet = { mode, source: { languageVersion: 1, text: "@version 1;" } };
+			const items = await renderText(data);
+			for (const text of ["2010", "2011", "2012", "Paris • 2020", "Paris • 2021", "Paris • 2022", "Paris • 2023"]) {
+				const item = findText(items, text);
+				expect(item.transform[4] + item.width, text).toBeCloseTo(565.28, 1);
+			}
+		},
+	);
+
+	it("preserves RTL row alignment when leading fields are empty", async () => {
+		const data = fixture();
+		data.metadata.page.locale = "ar-SA";
+		const items = await renderText(data);
+		for (const text of ["2010", "2011", "2012", "Paris • 2020", "Paris • 2021", "Paris • 2022", "Paris • 2023"]) {
+			const item = findText(items, text);
+			expect(item.transform[4] + item.width, text).toBeCloseTo(565.28, 1);
+		}
+	});
+
+	it("preserves the leading alignment of stacked sidebar fields", async () => {
+		const data = fixture();
+		data.metadata.layout.pages = [{ fullWidth: false, main: [], sidebar: ["experience", "education"] }];
+		const items = await renderText(data, "chikorita");
+		for (const index of [0, 1, 2]) {
+			expect(findText(items, `201${index}`).transform[4]).toBeCloseTo(
+				findText(items, `Company ${index}`).transform[4],
+				1,
+			);
+			expect(findText(items, `Paris • 202${index}`).transform[4]).toBeCloseTo(
+				findText(items, `School ${index}`).transform[4],
+				1,
+			);
+		}
+	});
+});

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -906,7 +906,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 							</View>
 
 							{(hasPosition || hasSplitRowText(headerPeriod)) && (
-								<View style={hasPosition ? composeStyles(splitRowStyle) : getTrailingOnlySplitRowStyle(splitRowStyle)}>
+								<View style={hasPosition ? splitRowStyle : getTrailingOnlySplitRowStyle(splitRowStyle)}>
 									{hasPosition && <Text semanticField="position">{item.position}</Text>}
 									{hasSplitRowText(headerPeriod) && (
 										<SemanticTextRuns
@@ -1082,7 +1082,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 							</View>
 
 							{(hasArea || (hasDegreeOrGrade && hasLocationOrPeriod)) && (
-								<View style={hasArea ? composeStyles(splitRowStyle) : getTrailingOnlySplitRowStyle(splitRowStyle)}>
+								<View style={hasArea ? splitRowStyle : getTrailingOnlySplitRowStyle(splitRowStyle)}>
 									{hasArea && <Text semanticField="area">{item.area}</Text>}
 									{hasDegreeOrGrade && hasLocationOrPeriod && (
 										<SemanticTextRuns

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -607,6 +607,14 @@ const useSectionSplitRowStyle = () => {
 	);
 };
 
+// A single child in a space-between row otherwise falls back to the leading edge.
+// Only adjust horizontal split rows; sidebar templates may intentionally stack the cells.
+const getTrailingOnlySplitRowStyle = (style: StyleInput) => {
+	const { flexDirection, justifyContent } = mergeStyles(style);
+	const isSplitRow = (flexDirection === "row" || flexDirection === "row-reverse") && justifyContent === "space-between";
+	return composeStyles(style, isSplitRow ? { justifyContent: "flex-end" } : undefined);
+};
+
 type ItemHeaderRowProps = {
 	children: ReactNode;
 	style: StyleInput;
@@ -898,7 +906,7 @@ const ExperienceSection = ({ sectionId = "experience", sectionData }: ItemSectio
 							</View>
 
 							{(hasPosition || hasSplitRowText(headerPeriod)) && (
-								<View style={composeStyles(splitRowStyle)}>
+								<View style={hasPosition ? composeStyles(splitRowStyle) : getTrailingOnlySplitRowStyle(splitRowStyle)}>
 									{hasPosition && <Text semanticField="position">{item.position}</Text>}
 									{hasSplitRowText(headerPeriod) && (
 										<SemanticTextRuns
@@ -1074,7 +1082,7 @@ const EducationSection = ({ sectionId = "education", sectionData }: ItemSectionP
 							</View>
 
 							{(hasArea || (hasDegreeOrGrade && hasLocationOrPeriod)) && (
-								<View style={composeStyles(splitRowStyle)}>
+								<View style={hasArea ? composeStyles(splitRowStyle) : getTrailingOnlySplitRowStyle(splitRowStyle)}>
 									{hasArea && <Text semanticField="area">{item.area}</Text>}
 									{hasDegreeOrGrade && hasLocationOrPeriod && (
 										<SemanticTextRuns


### PR DESCRIPTION
Education and experience dates jumped to the leading edge when the optional area of study or position was empty. Horizontal split rows now retain trailing alignment when only their metadata remains; stacked and custom-aligned rows keep their existing layout.

Closes #3338.

Validation: four actual PDF geometry regressions cover legacy/Semantic CSS, missing fields, RTL, and a stacked sidebar. Full PDF suite passes 687 tests; PDF typecheck, repository `pnpm check`, and independent review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed PDF resume section headers so dates, locations, and other trailing details align correctly when leading fields are empty.
  - Preserved correct alignment for right-to-left locales and stacked sidebar fields across supported templates.
- **Tests**
  - Added coverage validating header alignment in legacy, semantic, RTL, and sidebar PDF layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects trailing metadata alignment in PDF section headers when optional leading fields are empty.
- Detects horizontal split rows and aligns their sole remaining child to the trailing edge.
- Preserves existing stacked and custom-aligned layouts.
- Adds PDF geometry regressions for legacy, semantic, RTL, and sidebar layouts.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/sections.tsx | Adds conditional trailing alignment for metadata-only experience and education split rows while preserving other layouts. |
| packages/pdf/src/templates/shared/section-header-alignment.test.tsx | Adds PDF-coordinate regression coverage across stylesheet modes, RTL output, missing optional fields, and stacked sidebar layouts. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(pdf): simplify alignment regres..."](https://github.com/amruthpillai/reactive-resume/commit/f5570eca14175116cac4b6d7e0d53e8b8bce6200) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60739549)</sub>

<!-- /greptile_comment -->