### PR TITLE
fix(builder): validate and confirm resume passwords

### DIFF
--- a/apps/web/locales/en-US.po
+++ b/apps/web/locales/en-US.po
@@ -563,7 +563,7 @@ msgstr "Anthropic Claude"
 msgid "Any tag"
 msgstr "Any tag"
 
-#: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
+#: src/features/resume/builder/password-dialog.tsx
 msgid "Anyone who opens the public URL will need this password."
 msgstr "Anyone who opens the public URL will need this password."
 
@@ -917,6 +917,7 @@ msgstr "Can I export my resume to PDF?"
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
+#: src/features/resume/builder/password-dialog.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
 #: src/features/settings/pages/api-keys.tsx
@@ -1135,6 +1136,10 @@ msgstr "Compress or remove large images to keep uploads quick."
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Confirm"
 msgstr "Confirm"
+
+#: src/features/resume/builder/password-dialog.tsx
+msgid "Confirm Password"
+msgstr "Confirm Password"
 
 #. Authentication settings action to link a social login provider
 #: src/features/settings/authentication/components/social-provider.tsx
@@ -1973,8 +1978,8 @@ msgid "Enabled"
 msgstr "Enabled"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
-msgid "Enabling password protection..."
-msgstr "Enabling password protection..."
+#~ msgid "Enabling password protection..."
+#~ msgstr "Enabling password protection..."
 
 #: src/dialogs/auth/enable-two-factor.tsx
 msgid "Enabling two-factor authentication…"
@@ -3743,14 +3748,19 @@ msgstr "Passkeys & 2FA"
 #: src/features/auth/pages/login.tsx
 #: src/features/auth/pages/register.tsx
 #: src/features/auth/pages/resume-password.tsx
+#: src/features/resume/builder/password-dialog.tsx
 #: src/features/settings/authentication/components/hooks.tsx
 #: src/features/settings/authentication/components/password.tsx
 msgid "Password"
 msgstr "Password"
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
-msgid "Password cannot be empty."
-msgstr "Password cannot be empty."
+#~ msgid "Password cannot be empty."
+#~ msgstr "Password cannot be empty."
+
+#: src/features/resume/builder/password-dialog.tsx
+msgid "Password must be between 6 and 64 characters."
+msgstr "Password must be between 6 and 64 characters."
 
 #: src/routes/_home/-sections/features.tsx
 msgid "Password Protection"
@@ -3763,6 +3773,10 @@ msgstr "Password protection has been disabled."
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Password protection has been enabled."
 msgstr "Password protection has been enabled."
+
+#: src/features/resume/builder/password-dialog.tsx
+msgid "Passwords do not match."
+msgstr "Passwords do not match."
 
 #: src/routes/builder/$resumeId/-sidebar/right/sections/ats-check.tsx
 msgid "Paste a posting to see which of its terms already appear in your resume."
@@ -3983,7 +3997,7 @@ msgstr "Progress Bar"
 msgid "Projects"
 msgstr "Projects"
 
-#: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
+#: src/features/resume/builder/password-dialog.tsx
 msgid "Protect your resume with a password"
 msgstr "Protect your resume with a password"
 
@@ -4647,6 +4661,7 @@ msgstr "Serbian"
 msgid "Set a password if you want only people who know it to open the public URL."
 msgstr "Set a password if you want only people who know it to open the public URL."
 
+#: src/features/resume/builder/password-dialog.tsx
 #: src/features/settings/authentication/components/password.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Set Password"
@@ -4935,6 +4950,7 @@ msgstr "Something went wrong while signing you in. Please try again."
 
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
+#: src/features/resume/builder/password-dialog.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Something went wrong. Please try again."
 msgstr "Something went wrong. Please try again."
@@ -6044,6 +6060,10 @@ msgstr "Use A4 or US Letter so the layout survives being re-rendered."
 #: src/features/ats-checker/messages.ts
 msgid "Use at least 9pt."
 msgstr "Use at least 9pt."
+
+#: src/features/resume/builder/password-dialog.tsx
+msgid "Use between 6 and 64 characters."
+msgstr "Use between 6 and 64 characters."
 
 #: src/components/input/color-picker.tsx
 #: src/routes/builder/$resumeId/-sidebar/right/sections/design.tsx

--- a/apps/web/src/features/resume/builder/password-dialog.tsx
+++ b/apps/web/src/features/resume/builder/password-dialog.tsx
@@ -33,6 +33,8 @@ export function ResumePasswordDialog({ onSubmit, onClose }: ResumePasswordDialog
 			setError(t`Password must be between 6 and 64 characters.`);
 			return;
 		}
+		// Both values are entered in this browser form; no server-held secret is compared.
+		// nosemgrep
 		if (password !== confirmation) {
 			setError(t`Passwords do not match.`);
 			return;
@@ -107,6 +109,7 @@ export function ResumePasswordDialog({ onSubmit, onClose }: ResumePasswordDialog
 							type="password"
 							autoComplete="new-password"
 							required
+							minLength={6}
 							maxLength={64}
 							value={confirmation}
 							disabled={isPending}

--- a/apps/web/src/features/resume/builder/password-dialog.tsx
+++ b/apps/web/src/features/resume/builder/password-dialog.tsx
@@ -1,0 +1,135 @@
+import { t } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { ORPCError } from "@orpc/client";
+import { useId, useRef, useState } from "react";
+import { Button } from "@reactive-resume/ui/components/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@reactive-resume/ui/components/dialog";
+import { Input } from "@reactive-resume/ui/components/input";
+import { Label } from "@reactive-resume/ui/components/label";
+
+type ResumePasswordDialogProps = {
+	onSubmit: (password: string) => Promise<void>;
+	onClose: () => void;
+};
+
+export function ResumePasswordDialog({ onSubmit, onClose }: ResumePasswordDialogProps) {
+	const id = useId();
+	const submitting = useRef(false);
+	const [password, setPassword] = useState("");
+	const [confirmation, setConfirmation] = useState("");
+	const [error, setError] = useState("");
+	const [isPending, setIsPending] = useState(false);
+
+	const submit = async () => {
+		if (submitting.current) return;
+		if (password.length < 6 || password.length > 64) {
+			setError(t`Password must be between 6 and 64 characters.`);
+			return;
+		}
+		if (password !== confirmation) {
+			setError(t`Passwords do not match.`);
+			return;
+		}
+
+		submitting.current = true;
+		setIsPending(true);
+		setError("");
+		try {
+			await onSubmit(password);
+			onClose();
+		} catch (error) {
+			setError(error instanceof ORPCError ? error.message : t`Something went wrong. Please try again.`);
+		} finally {
+			submitting.current = false;
+			setIsPending(false);
+		}
+	};
+
+	return (
+		<Dialog
+			open
+			onOpenChange={(open) => {
+				if (!open && !submitting.current) onClose();
+			}}
+		>
+			<DialogContent showCloseButton={!isPending} className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>
+						<Trans>Protect your resume with a password</Trans>
+					</DialogTitle>
+					<DialogDescription>
+						<Trans>Anyone who opens the public URL will need this password.</Trans>
+					</DialogDescription>
+				</DialogHeader>
+				<form
+					noValidate
+					className="space-y-4"
+					onSubmit={(event) => {
+						event.preventDefault();
+						event.stopPropagation();
+						void submit();
+					}}
+				>
+					<div className="space-y-2">
+						<Label htmlFor={`${id}-password`}>
+							<Trans>Password</Trans>
+						</Label>
+						<Input
+							id={`${id}-password`}
+							type="password"
+							autoComplete="new-password"
+							required
+							minLength={6}
+							maxLength={64}
+							value={password}
+							disabled={isPending}
+							onChange={(event) => setPassword(event.target.value)}
+							aria-invalid={!!error}
+							aria-describedby={`${id}-hint${error ? ` ${id}-error` : ""}`}
+						/>
+						<p id={`${id}-hint`} className="text-muted-foreground text-sm">
+							<Trans>Use between 6 and 64 characters.</Trans>
+						</p>
+					</div>
+					<div className="space-y-2">
+						<Label htmlFor={`${id}-confirmation`}>
+							<Trans>Confirm Password</Trans>
+						</Label>
+						<Input
+							id={`${id}-confirmation`}
+							type="password"
+							autoComplete="new-password"
+							required
+							maxLength={64}
+							value={confirmation}
+							disabled={isPending}
+							onChange={(event) => setConfirmation(event.target.value)}
+							aria-invalid={!!error}
+							aria-describedby={error ? `${id}-error` : undefined}
+						/>
+					</div>
+					{error && (
+						<p id={`${id}-error`} role="alert" className="text-destructive text-sm">
+							{error}
+						</p>
+					)}
+					<DialogFooter>
+						<Button type="button" variant="outline" disabled={isPending} onClick={onClose}>
+							<Trans>Cancel</Trans>
+						</Button>
+						<Button type="submit" disabled={isPending}>
+							<Trans>Set Password</Trans>
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/features/resume/builder/sharing.test.tsx
+++ b/apps/web/src/features/resume/builder/sharing.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { ORPCError } from "@orpc/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PromptDialogProvider } from "@/hooks/use-prompt";
+import { SharingSectionBuilder } from "@/routes/builder/$resumeId/-sidebar/right/sections/sharing";
+
+const mocks = vi.hoisted(() => ({
+	setPassword: vi.fn(),
+	patchResume: vi.fn(),
+}));
+
+vi.mock("@/features/resume/builder/draft", () => ({
+	useCurrentResume: () => ({ id: "resume-id", slug: "resume", isPublic: true, hasPassword: false }),
+	usePatchResume: () => mocks.patchResume,
+}));
+vi.mock("@/libs/auth/client", () => ({
+	authClient: { useSession: () => ({ data: { user: { username: "owner" } } }) },
+}));
+vi.mock("@/libs/orpc/client", () => ({
+	orpc: {
+		resume: {
+			setPassword: { mutationOptions: () => ({ mutationFn: mocks.setPassword }) },
+			update: { mutationOptions: () => ({ mutationFn: vi.fn() }) },
+			removePassword: { mutationOptions: () => ({ mutationFn: vi.fn() }) },
+		},
+	},
+}));
+vi.mock("@/hooks/use-confirm", () => ({ useConfirm: () => vi.fn() }));
+vi.mock("@/routes/builder/$resumeId/-sidebar/right/shared/section-base", () => ({
+	SectionBase: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@reactive-resume/ui/components/toast", () => ({ toast: { add: vi.fn(), close: vi.fn() } }));
+
+beforeAll(() => {
+	i18n.loadAndActivate({ locale: "en", messages: {} });
+});
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.setPassword.mockResolvedValue(undefined);
+});
+afterEach(cleanup);
+
+async function openDialog() {
+	render(
+		<I18nProvider i18n={i18n}>
+			<QueryClientProvider client={new QueryClient()}>
+				<PromptDialogProvider>
+					<SharingSectionBuilder />
+				</PromptDialogProvider>
+			</QueryClientProvider>
+		</I18nProvider>,
+	);
+	await act(() => {
+		fireEvent.click(screen.getByRole("button", { name: "Set Password" }));
+	});
+	return within(screen.queryByRole("dialog") ?? screen.getByRole("alertdialog"));
+}
+
+async function submit(dialog: ReturnType<typeof within>, password: string, confirmation = password) {
+	fireEvent.change(dialog.getByLabelText("Password", { exact: true }), { target: { value: password } });
+	fireEvent.change(dialog.getByLabelText("Confirm Password"), { target: { value: confirmation } });
+	await act(() => {
+		fireEvent.click(dialog.getByRole("button", { name: "Set Password" }));
+	});
+}
+
+describe("resume password sharing", () => {
+	it.each(["", "abc", "abcde", "x".repeat(65)])(
+		"keeps invalid length %j open and explains the range",
+		async (password) => {
+			const dialog = await openDialog();
+			await submit(dialog, password);
+			expect(mocks.setPassword).not.toHaveBeenCalled();
+			expect(dialog.getByRole("alert").textContent).toContain("6 and 64");
+		},
+	);
+
+	it("requires matching confirmation", async () => {
+		const dialog = await openDialog();
+		await submit(dialog, "secret", "typooo");
+		expect(mocks.setPassword).not.toHaveBeenCalled();
+		expect(dialog.getByRole("alert").textContent).toContain("match");
+	});
+
+	it.each(["secret", "x".repeat(64)])("saves valid length and closes only after success", async (password) => {
+		const dialog = await openDialog();
+		await submit(dialog, password);
+		expect(mocks.setPassword).toHaveBeenCalledWith({ id: "resume-id", password }, expect.anything());
+		expect(mocks.patchResume).toHaveBeenCalledOnce();
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("preserves values and reports a server failure for retry", async () => {
+		mocks.setPassword.mockRejectedValueOnce(
+			new ORPCError("INTERNAL_SERVER_ERROR", { message: "Could not save password" }),
+		);
+		const dialog = await openDialog();
+		await submit(dialog, "secret");
+		expect(dialog.getByRole("alert").textContent).toBe("Could not save password");
+		expect((dialog.getByLabelText("Password", { exact: true }) as HTMLInputElement).value).toBe("secret");
+		expect(mocks.patchResume).not.toHaveBeenCalled();
+		await act(() => {
+			fireEvent.click(dialog.getByRole("button", { name: "Set Password" }));
+		});
+		expect(mocks.setPassword).toHaveBeenCalledTimes(2);
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("keeps the dialog open and prevents duplicate submission while saving", async () => {
+		let resolveSave!: () => void;
+		mocks.setPassword.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveSave = resolve;
+				}),
+		);
+		const dialog = await openDialog();
+		await submit(dialog, "secret");
+		expect(screen.getByRole("dialog")).toBeTruthy();
+		expect((dialog.getByRole("button", { name: "Set Password" }) as HTMLButtonElement).disabled).toBe(true);
+		const form = dialog.getByLabelText("Password", { exact: true }).closest("form");
+		if (!form) throw new Error("Missing password form");
+		await act(() => {
+			fireEvent.submit(form);
+		});
+		expect(mocks.setPassword).toHaveBeenCalledOnce();
+		expect(mocks.patchResume).not.toHaveBeenCalled();
+		await act(() => {
+			resolveSave();
+		});
+		expect(screen.queryByRole("dialog")).toBeNull();
+	});
+
+	it("validates form submission used by Enter", async () => {
+		const dialog = await openDialog();
+		fireEvent.change(dialog.getByLabelText("Password", { exact: true }), { target: { value: "abc" } });
+		const form = dialog.getByLabelText("Password", { exact: true }).closest("form");
+		if (!form) throw new Error("Missing password form");
+		await act(() => {
+			fireEvent.submit(form);
+		});
+		expect(mocks.setPassword).not.toHaveBeenCalled();
+		expect(dialog.getByRole("alert").textContent).toContain("6 and 64");
+	});
+
+	it("clears passwords after cancel and reopen", async () => {
+		const dialog = await openDialog();
+		fireEvent.change(dialog.getByLabelText("Password", { exact: true }), { target: { value: "secret" } });
+		await act(() => {
+			fireEvent.click(dialog.getByRole("button", { name: "Cancel" }));
+		});
+		await act(() => {
+			fireEvent.click(screen.getByRole("button", { name: "Set Password" }));
+		});
+		expect((screen.getByLabelText("Password", { exact: true }) as HTMLInputElement).value).toBe("");
+		expect(mocks.setPassword).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/resume/builder/sharing.test.tsx
+++ b/apps/web/src/features/resume/builder/sharing.test.tsx
@@ -9,6 +9,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { PromptDialogProvider } from "@/hooks/use-prompt";
 import { SharingSectionBuilder } from "@/routes/builder/$resumeId/-sidebar/right/sections/sharing";
 
+type SectionBaseProps = { children: React.ReactNode };
+
 const mocks = vi.hoisted(() => ({
 	setPassword: vi.fn(),
 	patchResume: vi.fn(),
@@ -32,7 +34,7 @@ vi.mock("@/libs/orpc/client", () => ({
 }));
 vi.mock("@/hooks/use-confirm", () => ({ useConfirm: () => vi.fn() }));
 vi.mock("@/routes/builder/$resumeId/-sidebar/right/shared/section-base", () => ({
-	SectionBase: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	SectionBase: ({ children }: SectionBaseProps) => <div>{children}</div>,
 }));
 vi.mock("@reactive-resume/ui/components/toast", () => ({ toast: { add: vi.fn(), close: vi.fn() } }));
 

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
@@ -3,7 +3,7 @@ import { Trans } from "@lingui/react/macro";
 import { ORPCError } from "@orpc/client";
 import { ClipboardIcon, LockSimpleIcon, LockSimpleOpenIcon } from "@phosphor-icons/react";
 import { useMutation } from "@tanstack/react-query";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useCopyToClipboard } from "usehooks-ts";
 import { Button } from "@reactive-resume/ui/components/button";
 import { Input } from "@reactive-resume/ui/components/input";
@@ -11,14 +11,14 @@ import { Label } from "@reactive-resume/ui/components/label";
 import { Switch } from "@reactive-resume/ui/components/switch";
 import { toast } from "@reactive-resume/ui/components/toast";
 import { useCurrentResume, usePatchResume } from "@/features/resume/builder/draft";
+import { ResumePasswordDialog } from "@/features/resume/builder/password-dialog";
 import { useConfirm } from "@/hooks/use-confirm";
-import { usePrompt } from "@/hooks/use-prompt";
 import { authClient } from "@/libs/auth/client";
 import { orpc } from "@/libs/orpc/client";
 import { SectionBase } from "../shared/section-base";
 
 export function SharingSectionBuilder() {
-	const prompt = usePrompt();
+	const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
 	const confirm = useConfirm();
 	const [_, copyToClipboard] = useCopyToClipboard();
 	const { data: session } = authClient.useSession();
@@ -51,34 +51,16 @@ export function SharingSectionBuilder() {
 		[patchResume, resume.id, updateResume],
 	);
 
-	const onSetPassword = useCallback(async () => {
-		const value = await prompt(t`Protect your resume with a password`, {
-			description: t`Anyone who opens the public URL will need this password.`,
-			confirmText: t`Set Password`,
-			inputProps: {
-				type: "password",
-				minLength: 6,
-				maxLength: 64,
-			},
-		});
-		if (!value) return;
-
-		const password = value.trim();
-		if (!password) return toast.add({ type: "error", description: t`Password cannot be empty.` });
-
-		const toastId = toast.add({ type: "loading", description: t`Enabling password protection...` });
-
-		try {
+	const onSetPassword = useCallback(
+		async (password: string) => {
 			await setPassword({ id: resume.id, password });
 			patchResume((draft) => {
 				draft.hasPassword = true;
 			});
-			toast.add({ type: "success", description: t`Password protection has been enabled.`, id: toastId });
-		} catch (error) {
-			const message = error instanceof ORPCError ? error.message : t`Something went wrong. Please try again.`;
-			toast.add({ type: "error", description: message, id: toastId });
-		}
-	}, [patchResume, prompt, resume.id, setPassword]);
+			toast.add({ type: "success", description: t`Password protection has been enabled.` });
+		},
+		[patchResume, resume.id, setPassword],
+	);
 
 	const onRemovePassword = useCallback(async () => {
 		if (!resume.hasPassword) return;
@@ -108,6 +90,9 @@ export function SharingSectionBuilder() {
 
 	return (
 		<SectionBase type="sharing" className="space-y-4">
+			{isPasswordDialogOpen && (
+				<ResumePasswordDialog onSubmit={onSetPassword} onClose={() => setIsPasswordDialogOpen(false)} />
+			)}
 			<div className="flex items-center gap-x-4">
 				<Switch
 					id="sharing-switch"
@@ -158,7 +143,7 @@ export function SharingSectionBuilder() {
 							<Trans>Remove Password</Trans>
 						</Button>
 					) : (
-						<Button variant="outline" onClick={onSetPassword}>
+						<Button variant="outline" onClick={() => setIsPasswordDialogOpen(true)}>
 							<LockSimpleIcon />
 							<Trans>Set Password</Trans>
 						</Button>

--- a/tests/e2e/specs/sharing-password.spec.ts
+++ b/tests/e2e/specs/sharing-password.spec.ts
@@ -12,9 +12,13 @@ test("password-protects a public resume and unlocks it as a visitor", async ({ b
 
 	const password = "e2e-secret-42";
 	await page.getByRole("button", { name: "Set Password" }).click();
-	const prompt = page.getByRole("alertdialog");
-	await prompt.locator('input[type="password"]').fill(password);
-	await prompt.getByRole("button", { name: "Set Password" }).click();
+	const dialog = page.getByRole("dialog", { name: "Protect your resume with a password" });
+	await dialog.getByLabel("Password", { exact: true }).fill(password);
+	await dialog.getByLabel("Confirm Password", { exact: true }).fill("different-password");
+	await dialog.getByRole("button", { name: "Set Password" }).click();
+	await expect(dialog.getByRole("alert")).toHaveText("Passwords do not match.");
+	await dialog.getByLabel("Confirm Password", { exact: true }).fill(password);
+	await dialog.getByRole("button", { name: "Set Password" }).click();
 	await expect(page.getByRole("button", { name: "Remove Password" })).toBeVisible();
 
 	const anonymous = await browser.newPage();


### PR DESCRIPTION
Setting a resume password used an unlabelled prompt that closed before validation or server failures could be corrected. A dedicated dialog now labels both password fields, confirms the password, validates the API’s 6–64 character range, and retains entered values with an inline error when saving fails.

Closes #3370.

Validation: 16 sharing/prompt tests, web typecheck, package boundaries, repository `pnpm check`, and independent review passed. Source-locale messages were extracted and compiled fallback messages verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated password dialog for protecting resumes.
  * Added password confirmation, length validation, mismatch alerts, and server-error handling.
  * Dialog fields remain available for retrying after a failed save.

* **Bug Fixes**
  * Prevented duplicate submissions while a password is being saved.
  * Ensured the dialog closes only after a successful save and clears values when canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the resume-password prompt with a dedicated dialog that validates password length and confirmation, preserves input after save failures, and blocks duplicate submissions.
- Adds an accessible two-field password dialog with inline validation and retry behavior.
- Integrates the dialog into the resume sharing section.
- Expands component and end-to-end coverage for validation, failures, cancellation, and successful saves.
- Updates the source locale catalog for the new interface text.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/resume/builder/password-dialog.tsx | Adds the validated password and confirmation dialog with pending-state and server-error handling. |
| apps/web/src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx | Replaces the generic prompt flow with the dedicated dialog while retaining the existing password mutation and local resume update. |
| apps/web/src/features/resume/builder/sharing.test.tsx | Covers dialog validation, retries, duplicate-submit prevention, success, and cancellation; the previously reported props typing issue is fixed. |
| tests/e2e/specs/sharing-password.spec.ts | Updates the sharing flow test for the new dialog and verifies mismatch recovery before successful protection. |
| apps/web/locales/en-US.po | Adds and relocates source-locale messages required by the password dialog. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(sharing): exercise password confirm..."](https://github.com/amruthpillai/reactive-resume/commit/6224b20fc11df010e1115b01905040f960612b13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60739601)</sub>

<!-- /greptile_comment -->