### PR TITLE
fix(pdf): constrain Onyx headlines to page margins

### DIFF
--- a/packages/pdf/src/templates/onyx/OnyxPage.test.tsx
+++ b/packages/pdf/src/templates/onyx/OnyxPage.test.tsx
@@ -1,0 +1,73 @@
+import type { TextItem } from "pdfjs-dist/types/src/display/api";
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act, createElement } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+
+const PICTURE =
+	"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a1ioAAAAASUVORK5CYII=";
+const HEADLINE = Array.from({ length: 12 }, (_, index) => `Experience ${index} designing accessible applications`).join(
+	" ",
+);
+
+const renderHeader = async (locale: string, hasPicture: boolean) => {
+	const data = structuredClone(defaultResumeData);
+	data.basics.name = "Audit";
+	data.basics.headline = HEADLINE;
+	data.picture.hidden = !hasPicture;
+	data.picture.url = PICTURE;
+	data.picture.size = 100;
+	data.metadata.page.locale = locale;
+	data.metadata.page.marginX = 30;
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.stylesheet = { mode: "semantic", source: { languageVersion: 1, text: "@version 1;" } };
+	data.metadata.layout.pages = [{ fullWidth: true, main: [], sidebar: [] }];
+	const element = createElement(ResumeDocument, { data, template: "onyx" }) as unknown as Parameters<
+		typeof renderToBuffer
+	>[0];
+	let bytes: Uint8Array = new Uint8Array();
+	await act(async () => {
+		bytes = new Uint8Array(await renderToBuffer(element));
+	});
+	const loadingTask = getDocument({ data: bytes, useSystemFonts: true });
+	try {
+		const document = await loadingTask.promise;
+		const page = await document.getPage(1);
+		const content = await page.getTextContent();
+		return content.items.filter(
+			(item): item is TextItem => "str" in item && item.str !== "Audit" && Boolean(item.str.trim()),
+		);
+	} finally {
+		await loadingTask.destroy();
+	}
+};
+
+describe("Onyx headline width (#3339)", () => {
+	it.each([
+		{ locale: "en-US", hasPicture: true },
+		{ locale: "ar-SA", hasPicture: true },
+		{ locale: "en-US", hasPicture: false },
+	])(
+		"keeps the complete headline within page margins ($locale, picture: $hasPicture)",
+		async ({ locale, hasPicture }) => {
+			const lines = await renderHeader(locale, hasPicture);
+			expect(
+				lines
+					.map((line) => line.str)
+					.join(" ")
+					.replace(/\s+/g, " "),
+			).toBe(HEADLINE);
+			for (const line of lines) {
+				expect(line.transform[4]).toBeGreaterThanOrEqual(29.9);
+				expect(line.transform[4] + line.width).toBeLessThanOrEqual(565.38);
+			}
+			if (locale === "en-US" && hasPicture) {
+				// The 100pt photo keeps its width, followed by the configured 4pt gap.
+				expect(lines[0]?.transform[4]).toBeCloseTo(134, 1);
+			}
+		},
+	);
+});

--- a/packages/pdf/src/templates/onyx/OnyxPage.tsx
+++ b/packages/pdf/src/templates/onyx/OnyxPage.tsx
@@ -165,6 +165,7 @@ const useOnyxTemplate = (): OnyxTemplate => {
 				paddingBottom: metrics.page.paddingVertical,
 			},
 			headerTitle: {
+				flex: 1,
 				rowGap: metrics.gapY(0.5),
 			},
 			headerIdentity: {


### PR DESCRIPTION
An Onyx resume with a photo and long headline could extend beyond the page margin and lose text. Constrain the title column to its available flex width so the full headline wraps beside the photo.

Closes #3339.

Validation: three actual PDF regressions cover LTR/RTL, photo/no-photo, text completeness and page bounds. Full PDF suite passes 686 tests; PDF typecheck, repository `pnpm check`, and independent review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Onyx PDF header layout so long headlines fit within page margins.
  * Ensured headline positioning remains correct when a profile picture is displayed.

* **Tests**
  * Added coverage for long headlines across supported locales and picture configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR constrains the Onyx header title column to its available flex width so long headlines wrap within page margins.
- Adds `flex: 1` to the title and contact-information column.
- Adds PDF regression coverage for LTR and RTL layouts, with and without a profile picture.
- Verifies headline completeness, page bounds, and picture spacing.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The title-column constraint matches established sibling-template layout behavior, and the regression tests exercise the reported overflow across representative picture and text-direction configurations.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/onyx/OnyxPage.tsx | Adds the flex constraint needed for the title column to consume only the space remaining beside the optional picture. |
| packages/pdf/src/templates/onyx/OnyxPage.test.tsx | Adds focused PDF rendering regressions covering headline wrapping, text preservation, margins, RTL layout, and picture spacing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pdf): constrain Onyx headlines to pa..."](https://github.com/amruthpillai/reactive-resume/commit/b9d71c9efb370f991ebf2d1d035672f04415ef9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60739834)</sub>

<!-- /greptile_comment -->