### PR TITLE
fix(sharing): hide signup link when registration is disabled

### DIFF
--- a/apps/web/src/features/resume/public/public-resume.test.tsx
+++ b/apps/web/src/features/resume/public/public-resume.test.tsx
@@ -15,6 +15,7 @@ type PdfViewerProps = {
 };
 
 const publicResumeMock = vi.hoisted(() => ({
+	flags: { disableSignups: false },
 	onDownloadPDF: vi.fn(),
 	PdfViewer: vi.fn<(_props: PdfViewerProps) => ReactNode>(() => null),
 	useResumeExport: vi.fn(),
@@ -29,7 +30,10 @@ const publicResumeMock = vi.hoisted(() => ({
 
 vi.mock("@tanstack/react-query", () => ({ useQuery: () => ({ data: publicResumeMock.resume }) }));
 vi.mock("@tanstack/react-router", () => ({
-	getRouteApi: () => ({ useParams: () => ({ username: "amruth", slug: "sample" }) }),
+	getRouteApi: () => ({
+		useParams: () => ({ username: "amruth", slug: "sample" }),
+		useRouteContext: () => ({ flags: publicResumeMock.flags }),
+	}),
 }));
 vi.mock("./pdf-viewer", () => ({ PdfViewer: publicResumeMock.PdfViewer }));
 vi.mock("@/libs/orpc/client", () => ({
@@ -44,6 +48,7 @@ const { PublicResumeRoute } = await import("./public-resume");
 beforeAll(() => i18n.loadAndActivate({ locale: "en", messages: {} }));
 
 beforeEach(() => {
+	publicResumeMock.flags.disableSignups = false;
 	publicResumeMock.resume = { data: sampleResumeData, name: "Sample Resume", slug: "sample" };
 	publicResumeMock.PdfViewer.mockClear();
 	publicResumeMock.useResumeExport.mockReset();
@@ -64,6 +69,20 @@ const renderPublicResumeRoute = () =>
 	);
 
 describe("PublicResumeRoute", () => {
+	it("shows the create-resume link when registration is enabled", () => {
+		renderPublicResumeRoute();
+
+		expect(screen.getByRole("link", { name: /Build your own resume/ })).toHaveAttribute("href", "/");
+	});
+
+	it("hides the create-resume link when registration is disabled", () => {
+		publicResumeMock.flags.disableSignups = true;
+		renderPublicResumeRoute();
+
+		expect(screen.queryByRole("link", { name: /Build your own resume/ })).not.toBeInTheDocument();
+		expect(screen.getByTestId("pdf-viewer")).toBeInTheDocument();
+	});
+
 	it("passes exposed source data directly to the browser viewer and export fallback", () => {
 		renderPublicResumeRoute();
 

--- a/apps/web/src/features/resume/public/public-resume.tsx
+++ b/apps/web/src/features/resume/public/public-resume.tsx
@@ -15,6 +15,7 @@ const publicResumeRoute = getRouteApi("/$username/$slug");
 
 export function PublicResumeRoute() {
 	const { username, slug } = publicResumeRoute.useParams();
+	const { flags } = publicResumeRoute.useRouteContext();
 
 	const { data: resume } = useQuery(orpc.resume.getBySlug.queryOptions({ input: { username, slug } }));
 	const publicResume = useMemo(() => ({ username, slug }), [slug, username]);
@@ -51,15 +52,17 @@ export function PublicResumeRoute() {
 					<PdfViewer data={resume.data} className="block w-full" publicResume={publicResume} />
 				</main>
 
-				<footer className="flex justify-center print:hidden">
-					<a
-						href="/"
-						className="flex items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground"
-					>
-						<BrandIcon variant="icon" className="size-5" />
-						<Trans>Build your own resume</Trans>
-					</a>
-				</footer>
+				{!flags.disableSignups && (
+					<footer className="flex justify-center print:hidden">
+						<a
+							href="/"
+							className="flex items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground"
+						>
+							<BrandIcon variant="icon" className="size-5" />
+							<Trans>Build your own resume</Trans>
+						</a>
+					</footer>
+				)}
 			</div>
 
 			<Button


### PR DESCRIPTION
Public resume pages advertised creating a resume even when the instance disabled registration. Hide that footer link when the existing `disableSignups` flag is set.

Closes #3401.

Validation: four public-route tests pass, including enabled/disabled registration; web typecheck, repository `pnpm check`, and independent review passed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR hides the public resume footer’s create-resume link when registration is disabled.
- Reads the existing `disableSignups` flag from route context.
- Adds tests covering both enabled and disabled registration states.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The public route receives a complete feature-flag object, and the new conditional correctly hides only the signup-related footer while preserving the resume viewer.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/resume/public/public-resume.tsx | Correctly gates the create-resume footer on the required route-context feature flag without affecting resume rendering. |
| apps/web/src/features/resume/public/public-resume.test.tsx | Extends the router mock and verifies link visibility for both feature-flag states. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(sharing): hide signup link when regi..."](https://github.com/amruthpillai/reactive-resume/commit/b5298df4ccf420c6d54abfbe021ffa88e31cb72d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60739843)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The public resume view now hides the “Build your own resume” link when registration is disabled.
  * Resume PDF viewing remains available when registration is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->