### PR TITLE
fix(sharing): use neutral social preview image

### DIFF
--- a/apps/server/src/static/web.test.ts
+++ b/apps/server/src/static/web.test.ts
@@ -151,9 +151,9 @@ describe("web app fallback classification", () => {
 			expect(html).toContain('<link rel="canonical" href="https://rxresu.me/jane/resume">');
 			expect(html).toContain('<meta property="og:type" content="profile">');
 			expect(html).toContain('<meta property="og:title" content="Jane Doe — Staff Engineer">');
-			expect(html).toContain('<meta property="og:image" content="https://rxresu.me/templates/jpg/azurill.jpg">');
+			expect(html).toContain('<meta property="og:image" content="https://rxresu.me/opengraph/banner.jpg">');
 			expect(html).toContain('<meta name="twitter:card" content="summary_large_image">');
-			expect(html).toContain('<meta name="twitter:image" content="https://rxresu.me/templates/jpg/azurill.jpg">');
+			expect(html).toContain('<meta name="twitter:image" content="https://rxresu.me/opengraph/banner.jpg">');
 		});
 
 		it("escapes user-authored values so resume content cannot break out of the attribute", async () => {

--- a/apps/server/src/static/web.ts
+++ b/apps/server/src/static/web.ts
@@ -224,7 +224,7 @@ async function createPublicResumeSeoMarkup(pathname: string, origin: string) {
 	if (!meta) return null;
 
 	const canonicalUrl = `${origin}/${username}/${slug}`;
-	const imageUrl = `${origin}/templates/jpg/${meta.template}.jpg`;
+	const imageUrl = `${origin}/opengraph/banner.jpg`;
 	const pageTitle = escapeAttribute(`${meta.name} - Reactive Resume`);
 	const title = escapeAttribute(meta.title);
 	const description = escapeAttribute(meta.description);

--- a/apps/web/src/routes/$username/$slug.tsx
+++ b/apps/web/src/routes/$username/$slug.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute("/$username/$slug")({
 
 		const base = getCanonicalRootUrl(typeof window === "undefined" ? undefined : window.location.origin);
 		const canonicalUrl = `${base}${params.username}/${params.slug}`;
-		const imageUrl = `${base}templates/jpg/${social.template}.jpg`;
+		const imageUrl = `${base}opengraph/banner.jpg`;
 
 		return {
 			meta: [


### PR DESCRIPTION
Public resume social previews used a template thumbnail containing a sample identity. Use the existing neutral Reactive Resume banner while preserving the resume’s personalized title, description, and canonical URL.

Closes #3359.

Validation: inspected the banner asset, web typecheck, repository `pnpm check`, and independent review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Open Graph and Twitter preview images for public resumes to use a consistent static banner when shared, regardless of the selected resume template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces template-specific public-resume preview images with the neutral Reactive Resume banner while retaining personalized titles, descriptions, and canonical URLs.
- Uses the neutral banner in both server-generated crawler metadata and client route metadata.
- Updates focused server expectations for Open Graph and Twitter image tags.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/server/src/static/web.ts | Server-generated public-resume metadata now references the existing neutral banner, resolving the previously reported crawler-path inconsistency. |
| apps/server/src/static/web.test.ts | Regression expectations verify that both Open Graph and Twitter metadata use the neutral banner. |
| apps/web/src/routes/$username/$slug.tsx | Client route metadata now uses the same neutral banner as the server-generated metadata. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(sharing): use neutral server social ..."](https://github.com/amruthpillai/reactive-resume/commit/38cafc1b966379f7f2e164b4b4ba5cbce956e7be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60739847)</sub>

<!-- /greptile_comment -->