### PR TITLE
fix(docker): load local environment overrides in Compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -90,6 +90,8 @@ services:
     env_file:
       - path: .env.example
         required: false
+      - path: .env
+        required: false
     volumes:
       - ./data:/app/data
     depends_on:

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -46,7 +46,7 @@ Create a new folder (for example `reactive-resume/`) with:
   <Step title="Create your .env">
     Start by creating a `.env` file next to your `compose.yml`.
 
-    The repository's Compose file loads `.env.example` defaults first, then overrides them with your `.env` values.
+    The Compose example below reads `.env` directly. If you use the repository's `compose.yml` instead, copy its `.env.example` into the same folder. That file supplies defaults before your `.env` overrides are applied.
 
 ```bash .env
 # --- Server ---

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -46,6 +46,8 @@ Create a new folder (for example `reactive-resume/`) with:
   <Step title="Create your .env">
     Start by creating a `.env` file next to your `compose.yml`.
 
+    The repository's Compose file loads `.env.example` defaults first, then overrides them with your `.env` values.
+
 ```bash .env
 # --- Server ---
 TZ="Etc/UTC"


### PR DESCRIPTION
The repository's Docker Compose file loaded `.env.example` but ignored user settings in `.env`, so settings such as `APP_URL` and feature flags kept their sample values. Compose now loads an optional `.env` after the optional defaults, and the Docker guide explains the override order.

Closes #3361.

Validation: real `docker compose config` checks reproduced the ignored settings before the change and verified custom settings, retained defaults, and operation without `.env` after it. Repository `pnpm check` and independent review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker self-hosting configuration and environment variable precedence.

* **Configuration**
  * Compose deployments can now load custom values from a local `.env` file while retaining optional defaults from `.env.example`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes the application service load an optional local `.env` after `.env.example`, allowing user settings to override repository defaults.
- Adds `.env` as the final optional `env_file` for the `reactive_resume` service.
- Documents the default and override order in the Docker self-hosting guide.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| compose.yml | Adds an optional local environment file after the sample defaults, using Compose’s last-file-wins precedence. |
| docs/self-hosting/docker.mdx | Explains how the repository Compose file combines `.env.example` defaults with local `.env` overrides. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(docker): clarify repository Compose..."](https://github.com/amruthpillai/reactive-resume/commit/5f36f6e891f703c798734612f5c91c172b27d10e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60740449)</sub>

<!-- /greptile_comment -->