### PR TITLE
fix(pdf): apply opacity to rating icons

### DIFF
--- a/packages/pdf/src/templates/shared/icon-opacity.test.tsx
+++ b/packages/pdf/src/templates/shared/icon-opacity.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { getDocument, OPS } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act, createElement } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+
+const renderLevel = async (level: number, css = "") => {
+	const data = structuredClone(defaultResumeData);
+	data.basics.name = "Audit";
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.layout.pages = [{ fullWidth: true, main: ["skills"], sidebar: [] }];
+	data.metadata.design.level = { type: "icon", icon: "star" };
+	data.metadata.stylesheet = { mode: "semantic", source: { languageVersion: 1, text: `@version 1; ${css}` } };
+	data.sections.skills.items = [
+		{ id: "skill", hidden: false, name: "Skill", proficiency: "Expert", level, keywords: [], icon: "", iconColor: "" },
+	];
+	const element = createElement(ResumeDocument, { data, template: "scizor" }) as unknown as Parameters<
+		typeof renderToBuffer
+	>[0];
+	let bytes: Uint8Array = new Uint8Array();
+	await act(async () => {
+		bytes = new Uint8Array(await renderToBuffer(element));
+	});
+	const loadingTask = getDocument({ data: bytes, useSystemFonts: true });
+	try {
+		const document = await loadingTask.promise;
+		const page = await document.getPage(1);
+		const operators = await page.getOperatorList();
+		return operators.fnArray.flatMap((fn, index) => (fn === OPS.setGState ? operators.argsArray[index][0] : []));
+	} finally {
+		await loadingTask.destroy();
+	}
+};
+
+describe("PDF icon opacity (#3352)", () => {
+	it.each([1, 3, 4])("writes inactive level %i opacity to PDF graphics state", async (level) => {
+		const states = await renderLevel(level);
+		expect(states).toContainEqual(["ca", 0.35]);
+		expect(states).toContainEqual(["CA", 0.35]);
+	});
+	it("honors semantic icon opacity overrides, including zero", async () => {
+		const states = await renderLevel(
+			3,
+			'level icon[role~="active"] { opacity: 0.2; } level icon[role~="inactive"] { opacity: 0; }',
+		);
+		expect(states).toContainEqual(["ca", 0.2]);
+		expect(states).toContainEqual(["CA", 0.2]);
+		expect(states).toContainEqual(["ca", 0]);
+		expect(states).toContainEqual(["CA", 0]);
+		expect(states).not.toContainEqual(["ca", 0.35]);
+	});
+	it.each([0, 5])("does not dim fully active or hidden level %i", async (level) => {
+		expect(await renderLevel(level)).not.toContainEqual(["ca", 0.35]);
+	});
+});

--- a/packages/pdf/src/templates/shared/primitives.tsx
+++ b/packages/pdf/src/templates/shared/primitives.tsx
@@ -19,7 +19,7 @@ import { semanticNodeKeys } from "../../semantic/node-keys";
 import { useSectionStyleRule, useTemplateIconSlot, useTemplatePageNodeKey, useTemplateStyle } from "./context";
 import { resolveIconSize } from "./icon-size";
 import { safeTextStyle } from "./safe-text-style";
-import { composeLinkStyles, composeStyles } from "./styles";
+import { composeLinkStyles, composeStyles, mergeStyles } from "./styles";
 
 const asStyleInput = (style: unknown): StyleInput => style as StyleInput;
 
@@ -303,6 +303,9 @@ export const Icon = ({
 	const resolvedNodeKey = nodeKey ?? (parentKey ? semanticNodeKeys.icon(parentKey, "item") : undefined);
 	const resolved = useResolvedNode(resolvedNodeKey);
 	const visible = useSemanticNodeVisible(resolvedNodeKey);
+	const resolvedStyle = composeStyles(composedStyle, resolved.style);
+	// React PDF inherits SVG opacity from props, not the root SVG style.
+	const { opacity } = mergeStyles(resolvedStyle);
 	const resolvedSize =
 		resolveIconSize({
 			size: sizeProp,
@@ -316,7 +319,8 @@ export const Icon = ({
 			{...iconProps}
 			{...props}
 			{...(resolvedSize === undefined ? {} : { size: resolvedSize })}
-			style={composeStyles(composedStyle, resolved.style)}
+			{...(opacity === undefined ? {} : { opacity })}
+			style={resolvedStyle}
 		/>
 	);
 };


### PR DESCRIPTION
Skill ratings using icons rendered active and inactive stars with identical opacity. React PDF inherits SVG opacity from props, but the shared icon primitive only passed it through the root style. The primitive now forwards the final resolved opacity as an SVG prop, preserving semantic overrides and zero opacity.

Closes #3352.

Validation: reproduced with the reporter's exact JSON and compared the rendered PDF before and after. Six regression tests inspect actual PDF fill/stroke graphics state; all 689 PDF tests, package typecheck, repository `pnpm check`, and independent review passed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes PDF skill-rating icon transparency by forwarding the final resolved style opacity to the SVG primitive while preserving semantic overrides and zero opacity.
- Resolves icon styles once and forwards the resulting opacity as an SVG prop.
- Adds PDF graphics-state regression coverage for active, inactive, overridden, zero-opacity, and hidden rating levels.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or maintainability issues identified.

The resolved opacity preserves existing style precedence and reaches the SVG rendering path, while regression tests cover inactive ratings, semantic overrides including zero, and fully active or hidden levels.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/primitives.tsx | Correctly forwards resolved icon opacity to the React PDF SVG prop without changing semantic style precedence. |
| packages/pdf/src/templates/shared/icon-opacity.test.tsx | Adds focused PDF operator-level tests covering default and semantic icon opacity behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pdf): apply opacity to rating icons"](https://github.com/amruthpillai/reactive-resume/commit/50f45b2259ee29f6017453bcf1977fc34703ae31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60740887)</sub>

<!-- /greptile_comment -->