### PR TITLE
fix(pdf): honor semantic section heading colors

### DIFF
--- a/packages/pdf/src/templates/shared/primitives.tsx
+++ b/packages/pdf/src/templates/shared/primitives.tsx
@@ -493,6 +493,7 @@ export const SectionHeadingIcon = ({
 			{...iconPropsWithoutDisplay}
 			{...props}
 			{...(resolvedSize === undefined ? {} : { size: resolvedSize })}
+			{...(resolved.style?.color === undefined ? {} : { color: resolved.style.color })}
 			style={composeStyles(asStyleInput(iconStyle), asStyleInput(style), resolved.style)}
 		/>
 	);

--- a/packages/pdf/src/templates/shared/section-heading-color.test.tsx
+++ b/packages/pdf/src/templates/shared/section-heading-color.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { getDocument, OPS } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act, createElement } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+
+const renderHeading = async (css: string, hideSectionIcons = false) => {
+	const data = structuredClone(defaultResumeData);
+	data.basics.name = "Audit";
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.page.hideSectionIcons = hideSectionIcons;
+	data.metadata.layout.pages = [{ fullWidth: true, main: ["skills"], sidebar: [] }];
+	data.metadata.stylesheet = { mode: "semantic", source: { languageVersion: 1, text: `@version 1; ${css}` } };
+	data.sections.skills.items = [
+		{ id: "skill", hidden: false, name: "Skill", proficiency: "", level: 0, keywords: [], icon: "", iconColor: "" },
+	];
+	const element = createElement(ResumeDocument, {
+		data,
+		template: "scizor",
+		resolveSectionTitle: () => "Heading",
+	}) as unknown as Parameters<typeof renderToBuffer>[0];
+	let bytes: Uint8Array = new Uint8Array();
+	await act(async () => {
+		bytes = new Uint8Array(await renderToBuffer(element));
+	});
+	const loadingTask = getDocument({ data: bytes, useSystemFonts: true });
+	try {
+		const document = await loadingTask.promise;
+		const page = await document.getPage(1);
+		const operators = await page.getOperatorList();
+		let fill = "";
+		const text: { value: string; fill: string }[] = [];
+		const colors: string[] = [];
+		for (const [index, fn] of operators.fnArray.entries()) {
+			const args = operators.argsArray[index];
+			if (fn === OPS.setFillRGBColor) fill = args[0];
+			if (fn === OPS.setFillRGBColor || fn === OPS.setStrokeRGBColor) colors.push(args[0]);
+			if (fn === OPS.showText)
+				text.push({
+					value: args[0]
+						.map((glyph: { unicode?: string } | number) => (typeof glyph === "number" ? "" : (glyph.unicode ?? "")))
+						.join(""),
+					fill,
+				});
+		}
+		return { text, colors };
+	} finally {
+		await loadingTask.destroy();
+	}
+};
+
+describe("Semantic section heading colors (#3348)", () => {
+	it.each([false, true])("colors heading text with hideSectionIcons=%s", async (hidden) => {
+		const { text } = await renderHeading("section-heading { color: #1234ef; }", hidden);
+		expect(text).toContainEqual({ value: "HEADING", fill: "#1234ef" });
+	});
+	it("colors explicitly targeted section icons", async () => {
+		const { colors } = await renderHeading("section-heading icon { color: #178a6b; }");
+		expect(colors).toContain("#178a6b");
+	});
+	it("allows independent heading and icon colors", async () => {
+		const { text, colors } = await renderHeading(
+			"section-heading { color: #1234ef; } section-heading icon { color: #178a6b; }",
+		);
+		expect(text).toContainEqual({ value: "HEADING", fill: "#1234ef" });
+		expect(colors).toContain("#178a6b");
+	});
+	it("retains template colors without a custom rule", async () => {
+		const { text, colors } = await renderHeading("");
+		expect(text).toContainEqual({ value: "HEADING", fill: "#000000" });
+		expect(colors).toContain("#dc2626");
+	});
+});

--- a/packages/pdf/src/templates/shared/sections.test.ts
+++ b/packages/pdf/src/templates/shared/sections.test.ts
@@ -43,7 +43,7 @@ describe("SectionShell", () => {
 		);
 
 		expect(headingContainerBlock?.groups?.body).toContain('alignItems: "flex-start"');
-		expect(source).toContain("getSectionHeadingTextStyle(sectionHeadingStyle, sectionHeadingRuleStyle)");
+		expect(source).toMatch(/getSectionHeadingTextStyle\(\s*sectionHeadingStyle,\s*sectionHeadingRuleStyle(?:,|\))/);
 		expect(source).toContain("width: _width");
 		expect(source).not.toContain('width: "auto"');
 	});

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -366,7 +366,13 @@ const SectionShell = ({ sectionId, title, showHeading = true, children }: Sectio
 						/>
 						<Heading
 							bindSemanticNode={false}
-							style={getSectionHeadingTextStyle(sectionHeadingStyle, sectionHeadingRuleStyle)}
+							style={getSectionHeadingTextStyle(
+								sectionHeadingStyle,
+								sectionHeadingRuleStyle,
+								sectionHeadingResolved.style?.color === undefined
+									? undefined
+									: { color: sectionHeadingResolved.style.color },
+							)}
 						>
 							{sectionTitle}
 						</Heading>


### PR DESCRIPTION
Semantic CSS changed the section-heading container color, but headings with icons kept the template's text color and icon components ignored the resolved color. The heading text now receives the resolved color without duplicating container layout styles, and section icons receive their own resolved color prop.

Closes #3348.

Validation: five regression tests inspect colors in actual generated PDFs, covering visible/hidden icons, independent heading/icon overrides, and unchanged defaults. All 688 PDF tests, package typecheck, repository `pnpm check`, and independent review passed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR propagates resolved semantic colors to PDF section-heading text and icons and adds generated-PDF regression coverage.
- Applies authored section-heading colors without copying container layout styles.
- Passes resolved icon colors to the PDF icon component.
- Tests visible and hidden icons, independent overrides, and default colors.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the non-blocking test formatting issue is cleaned up.

The semantic color propagation preserves default template styling and is covered by generated-PDF tests; the only accepted issue is two oversized lines in the new test.

**Files Needing Attention:** packages/pdf/src/templates/shared/section-heading-color.test.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/primitives.tsx | Passes a resolved semantic color to section-heading icons while retaining the existing composed styles. |
| packages/pdf/src/templates/shared/sections.tsx | Adds the resolved authored color as the final text-only section-heading style override. |
| packages/pdf/src/templates/shared/section-heading-color.test.tsx | Adds generated-PDF color regression coverage, with two lines exceeding the repository's formatting limit. |
| packages/pdf/src/templates/shared/sections.test.ts | Makes the source assertion tolerate the expanded multiline helper invocation. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20amruthpillai%2Freactive-resume%20PR%20%233415%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=3415&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Ftemplates%2Fshared%2Fsection-heading-color.test.tsx%3A17%0A**Test%20lines%20exceed%20width**%0A%0AThe%20skill%20fixture%20here%20and%20the%20glyph-mapping%20expression%20on%20line%2047%20exceed%20the%20repository's%20120-character%20limit%2C%20adding%20avoidable%20formatting%20cleanup%20to%20the%20new%20regression%20test.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3415&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Ftemplates%2Fshared%2Fsection-heading-color.test.tsx%3A17%0A**Test%20lines%20exceed%20width**%0A%0AThe%20skill%20fixture%20here%20and%20the%20glyph-mapping%20expression%20on%20line%2047%20exceed%20the%20repository's%20120-character%20limit%2C%20adding%20avoidable%20formatting%20cleanup%20to%20the%20new%20regression%20test.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3415&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amruthpillai%2Freactive-resume%22%20on%20the%20existing%20branch%20%22codex%2Fissue-3348-heading-color%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fissue-3348-heading-color%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Ftemplates%2Fshared%2Fsection-heading-color.test.tsx%3A17%0A**Test%20lines%20exceed%20width**%0A%0AThe%20skill%20fixture%20here%20and%20the%20glyph-mapping%20expression%20on%20line%2047%20exceed%20the%20repository's%20120-character%20limit%2C%20adding%20avoidable%20formatting%20cleanup%20to%20the%20new%20regression%20test.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3415&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/pdf/src/templates/shared/section-heading-color.test.tsx:17
**Test lines exceed width**

The skill fixture here and the glyph-mapping expression on line 47 exceed the repository's 120-character limit, adding avoidable formatting cleanup to the new regression test.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pdf): honor semantic section heading..."](https://github.com/amruthpillai/reactive-resume/commit/50ebb32630b5151be7f90f909df7ad52d72ea7e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60742126)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/amruthpillai/reactive-resume/blob/main/AGENTS.md))

<!-- /greptile_comment -->