### PR TITLE
fix(email): preserve optional Nodemailer property types

### DIFF
--- a/packages/email/src/transport.ts
+++ b/packages/email/src/transport.ts
@@ -13,23 +13,17 @@ type SendEmailOptions = {
 	from?: string;
 };
 
-const isSmtpEnabled = () => !!env.SMTP_HOST && !!env.SMTP_USER && !!env.SMTP_PASS && !!env.SMTP_FROM;
-
 let cachedTransport: Transporter | undefined;
 
 const getTransport = () => {
-	if (!isSmtpEnabled()) return;
+	const { SMTP_HOST: host, SMTP_USER: user, SMTP_PASS: pass, SMTP_FROM: from } = env;
+	if (!host || !user || !pass || !from) return;
 
 	cachedTransport ??= nodemailer.createTransport({
-		host: env.SMTP_HOST,
+		host,
 		port: env.SMTP_PORT,
 		secure: env.SMTP_SECURE,
-		auth: {
-			// biome-ignore lint/style/noNonNullAssertion: guarded by isSmtpEnabled
-			user: env.SMTP_USER!,
-			// biome-ignore lint/style/noNonNullAssertion: guarded by isSmtpEnabled
-			pass: env.SMTP_PASS!,
-		},
+		auth: { user, pass },
 	});
 
 	return cachedTransport;
@@ -42,8 +36,8 @@ export const sendEmail = async (options: SendEmailOptions) => {
 		to: options.to,
 		from,
 		subject: options.subject,
-		text: options.text,
-		html: options.html,
+		...(options.text === undefined ? {} : { text: options.text }),
+		...(options.html === undefined ? {} : { html: options.html }),
 	};
 
 	if (options.react) {


### PR DESCRIPTION
API and server typechecks failed because Nodemailer's optional properties were explicitly assigned `undefined`, and the SMTP helper did not narrow the host type. The transport now narrows configured SMTP values locally and includes optional text/HTML fields only when supplied.

Validation: all six existing email tests and email, API, and server typechecks pass. Repository `pnpm check` passes. SMTP configuration requirements and message rendering behavior are preserved.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes exact-optional-property type errors without changing SMTP configuration requirements or normal message rendering.
- Narrows required SMTP values locally before creating the transport.
- Omits optional `text` and `html` properties when callers do not supply them.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The SMTP guard retains the previous configuration requirements, while conditional message-property inclusion resolves the type failure without altering the exercised React email path.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/email/src/transport.ts | Preserves existing SMTP enablement semantics while constructing Nodemailer-compatible transport and message objects. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(email): preserve optional Nodemailer..."](https://github.com/amruthpillai/reactive-resume/commit/a0996961b59f938aa610bbc39d54c451b90fb3c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60742283)</sub>

<!-- /greptile_comment -->