### PR TITLE
fix: remove empty custom sections and affected pages after moving items

### DIFF
--- a/apps/web/src/libs/resume/move-item-round-trip.test.ts
+++ b/apps/web/src/libs/resume/move-item-round-trip.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { applyPatches, enablePatches, produce, produceWithPatches } from "immer";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { moveItem } from "./move-item";
+
+const company = (id: string) => ({
+	id,
+	hidden: false,
+	company: `Company ${id}`,
+	position: `Position ${id}`,
+	location: "",
+	period: "",
+	description: "",
+	roles: [],
+	website: { url: "", label: "", inlineLink: false },
+});
+const base = () =>
+	produce(defaultResumeData, (draft) => {
+		draft.sections.experience.items = [company("1"), company("2")];
+		draft.metadata.layout.pages = [{ fullWidth: false, main: ["experience"], sidebar: [] }];
+	});
+const split = () =>
+	produce(base(), (draft) => {
+		moveItem(draft, { itemId: "2", type: "experience", target: { type: "new-page", title: "Experience" } });
+	});
+
+describe("moving the last custom-section item (#3180)", () => {
+	it("restores the original JSON after moving an experience item to a new page and back", () => {
+		const initial = base();
+		const moved = split();
+		expect(moved.metadata.layout.pages).toHaveLength(2);
+		const restored = produce(moved, (draft) => {
+			moveItem(draft, {
+				itemId: "2",
+				type: "experience",
+				customSectionId: moved.customSections[0].id,
+				target: { type: "section", sectionId: "experience" },
+			});
+		});
+		expect(restored).toEqual(initial);
+	});
+	it("preserves unrelated blank pages and pages with other section references", () => {
+		const moved = produce(split(), (draft) => {
+			draft.metadata.layout.pages.push({ fullWidth: true, main: [], sidebar: [] });
+			draft.metadata.layout.pages[1].sidebar.push("skills");
+		});
+		const restored = produce(moved, (draft) => {
+			moveItem(draft, {
+				itemId: "2",
+				type: "experience",
+				customSectionId: moved.customSections[0].id,
+				target: { type: "section", sectionId: "experience" },
+			});
+		});
+		expect(restored.customSections).toEqual([]);
+		expect(restored.metadata.layout.pages).toEqual([
+			{ fullWidth: false, main: ["experience"], sidebar: [] },
+			{ fullWidth: false, main: [], sidebar: ["skills"] },
+			{ fullWidth: true, main: [], sidebar: [] },
+		]);
+	});
+	it("preserves the first page when its only custom section becomes empty", () => {
+		const moved = produce(split(), (draft) => {
+			draft.metadata.layout.pages.reverse();
+		});
+		const restored = produce(moved, (draft) => {
+			moveItem(draft, {
+				itemId: "2",
+				type: "experience",
+				customSectionId: moved.customSections[0].id,
+				target: { type: "section", sectionId: "experience" },
+			});
+		});
+		expect(restored.metadata.layout.pages).toEqual([
+			{ fullWidth: false, main: [], sidebar: [] },
+			{ fullWidth: false, main: ["experience"], sidebar: [] },
+		]);
+	});
+	it("inserts into the selected later page before pruning the source page", () => {
+		const moved = produce(split(), (draft) => {
+			draft.metadata.layout.pages.push({ fullWidth: true, main: [], sidebar: ["skills"] });
+		});
+		const restored = produce(moved, (draft) => {
+			moveItem(draft, {
+				itemId: "2",
+				type: "experience",
+				customSectionId: moved.customSections[0].id,
+				target: { type: "new-section", pageIndex: 2, title: "Later" },
+			});
+		});
+		expect(restored.metadata.layout.pages).toHaveLength(2);
+		expect(restored.customSections).toHaveLength(1);
+		expect(restored.customSections[0]).toMatchObject({ title: "Later", items: [company("2")] });
+		expect(restored.metadata.layout.pages[1]).toEqual({
+			fullWidth: true,
+			main: [restored.customSections[0].id],
+			sidebar: ["skills"],
+		});
+	});
+	it("keeps a custom section with hidden remaining items", () => {
+		const moved = produce(split(), (draft) => {
+			draft.customSections[0].items.push({ ...company("3"), hidden: true });
+		});
+		const restored = produce(moved, (draft) => {
+			moveItem(draft, {
+				itemId: "2",
+				type: "experience",
+				customSectionId: moved.customSections[0].id,
+				target: { type: "section", sectionId: "experience" },
+			});
+		});
+		expect(restored.customSections[0].items).toEqual([{ ...company("3"), hidden: true }]);
+		expect(restored.metadata.layout.pages).toHaveLength(2);
+	});
+	it.each([
+		{ type: "section", sectionId: "missing" },
+		{ type: "section", sectionId: "skills" },
+		{ type: "new-section", pageIndex: 99, title: "Missing" },
+	] as const)("leaves data intact for an invalid destination $type", (target) => {
+		const moved = split();
+		expect(
+			produce(moved, (draft) => {
+				moveItem(draft, { itemId: "2", type: "experience", customSectionId: moved.customSections[0].id, target });
+			}),
+		).toEqual(moved);
+	});
+
+	it("keeps data intact when the source is missing or destination is the source", () => {
+		const moved = split();
+		const sourceId = moved.customSections[0].id;
+		for (const [itemId, sectionId] of [
+			["missing", "experience"],
+			["2", sourceId],
+		]) {
+			expect(
+				produce(moved, (draft) => {
+					moveItem(draft, {
+						itemId,
+						type: "experience",
+						customSectionId: sourceId,
+						target: { type: "section", sectionId },
+					});
+				}),
+			).toEqual(moved);
+		}
+	});
+	it("cleans the source sidebar while preserving unrelated blank pages when moving to a new page", () => {
+		const moved = produce(split(), (draft) => {
+			const page = draft.metadata.layout.pages[1];
+			page.sidebar = page.main;
+			page.main = [];
+			draft.metadata.layout.pages.push({ fullWidth: true, main: [], sidebar: [] });
+		});
+		const restored = produce(moved, (draft) => {
+			moveItem(draft, {
+				itemId: "2",
+				type: "experience",
+				customSectionId: moved.customSections[0].id,
+				target: { type: "new-page", title: "New destination" },
+			});
+		});
+		expect(restored.customSections).toHaveLength(1);
+		expect(restored.metadata.layout.pages).toEqual([
+			{ fullWidth: false, main: ["experience"], sidebar: [] },
+			{ fullWidth: true, main: [], sidebar: [] },
+			{ fullWidth: false, main: [restored.customSections[0].id], sidebar: [] },
+		]);
+		expect(restored.customSections[0].items).toEqual([company("2")]);
+	});
+	it("undo restores the custom section, layout page, and custom settings", () => {
+		enablePatches();
+		const moved = produce(split(), (draft) => {
+			Object.assign(draft.customSections[0], { title: "Custom title", icon: "star", columns: 2, keepTogether: true });
+		});
+		const [restored, , inverse] = produceWithPatches(moved, (draft) => {
+			moveItem(draft, {
+				itemId: "2",
+				type: "experience",
+				customSectionId: moved.customSections[0].id,
+				target: { type: "section", sectionId: "experience" },
+			});
+		});
+		expect(restored.customSections).toEqual([]);
+		expect(applyPatches(restored, inverse)).toEqual(moved);
+	});
+});

--- a/apps/web/src/libs/resume/move-item.ts
+++ b/apps/web/src/libs/resume/move-item.ts
@@ -236,3 +236,49 @@ export function createPageWithSection(
 	draft.customSections.push(makeCustomSection(newSectionId, type, sectionTitle, item) as WritableDraft<CustomSection>);
 	draft.metadata.layout.pages.push({ fullWidth: false, main: [newSectionId], sidebar: [] });
 }
+
+type MoveItemInput = {
+	itemId: string;
+	type: CustomSectionType;
+	customSectionId?: string | undefined;
+	target:
+		| { type: "section"; sectionId: string }
+		| { type: "new-section"; pageIndex: number; title: string }
+		| { type: "new-page"; title: string };
+};
+
+/** Moves an item atomically, then removes only custom source sections emptied by that move. */
+export function moveItem(draft: WritableDraft<ResumeData>, input: MoveItemInput): void {
+	const { itemId, type, customSectionId, target } = input;
+	const source = customSectionId
+		? draft.customSections.find((section) => section.id === customSectionId && section.type === type)
+		: draft.sections[type as SectionType];
+	if (!source?.items.some((item) => item.id === itemId)) return;
+
+	if (target.type === "section") {
+		if (target.sectionId === (customSectionId ?? type)) return;
+		const compatible = isStandardSectionId(target.sectionId, draft.sections)
+			? target.sectionId === type
+			: draft.customSections.some((section) => section.id === target.sectionId && section.type === type);
+		if (!compatible) return;
+	} else if (target.type === "new-section" && !draft.metadata.layout.pages[target.pageIndex]) return;
+
+	const item = removeItemFromSource(draft, itemId, type, customSectionId);
+	if (!item) return;
+	if (target.type === "section") addItemToSection(draft, item, target.sectionId, type);
+	else if (target.type === "new-section")
+		createCustomSectionWithItem(draft, item, type, target.title, target.pageIndex);
+	else createPageWithSection(draft, item, type, target.title);
+
+	// Insert first so removing the source page cannot change the chosen destination index.
+	if (!customSectionId || source.items.length > 0) return;
+	draft.customSections = draft.customSections.filter((section) => section.id !== customSectionId);
+	draft.metadata.layout.pages = draft.metadata.layout.pages.filter((page, index) => {
+		const affected = page.main.includes(customSectionId) || page.sidebar.includes(customSectionId);
+		if (!affected) return true;
+		page.main = page.main.filter((sectionId) => sectionId !== customSectionId);
+		page.sidebar = page.sidebar.filter((sectionId) => sectionId !== customSectionId);
+		// Keep the header page and any page with other references, even if those sections are hidden.
+		return index === 0 || page.main.length > 0 || page.sidebar.length > 0;
+	});
+}

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-item.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-item.tsx
@@ -40,14 +40,7 @@ import { useDialogStore } from "@/dialogs/store";
 import { useCurrentResume, useUpdateResumeData } from "@/features/resume/builder/draft";
 import { useConfirm } from "@/hooks/use-confirm";
 import { atsFindingItemElementId } from "@/libs/resume/ats";
-import {
-	addItemToSection,
-	createCustomSectionWithItem,
-	createPageWithSection,
-	getCompatibleMoveTargets,
-	getSourceSectionTitle,
-	removeItemFromSource,
-} from "@/libs/resume/move-item";
+import { getCompatibleMoveTargets, getSourceSectionTitle, moveItem } from "@/libs/resume/move-item";
 
 // ============================================================================
 // MoveItemSubmenu Component
@@ -85,27 +78,36 @@ function MoveItemSubmenu({ type, item, customSectionId }: MoveItemSubmenuProps) 
 	/** Handler: Move item to an existing section */
 	const handleMoveToSection = (targetSectionId: string) => {
 		updateResumeData((draft) => {
-			const removedItem = removeItemFromSource(draft, item.id, type, customSectionId);
-			if (!removedItem) return;
-			addItemToSection(draft, removedItem, targetSectionId, type);
+			moveItem(draft, {
+				itemId: item.id,
+				type,
+				customSectionId,
+				target: { type: "section", sectionId: targetSectionId },
+			});
 		});
 	};
 
 	/** Handler: Create a new custom section on an existing page and move the item there */
 	const handleNewSectionOnPage = (pageIndex: number) => {
 		updateResumeData((draft) => {
-			const removedItem = removeItemFromSource(draft, item.id, type, customSectionId);
-			if (!removedItem) return;
-			createCustomSectionWithItem(draft, removedItem, type, currentSectionTitle, pageIndex);
+			moveItem(draft, {
+				itemId: item.id,
+				type,
+				customSectionId,
+				target: { type: "new-section", title: currentSectionTitle, pageIndex },
+			});
 		});
 	};
 
 	/** Handler: Create a new page with a new custom section and move the item there */
 	const handleNewPage = () => {
 		updateResumeData((draft) => {
-			const removedItem = removeItemFromSource(draft, item.id, type, customSectionId);
-			if (!removedItem) return;
-			createPageWithSection(draft, removedItem, type, currentSectionTitle);
+			moveItem(draft, {
+				itemId: item.id,
+				type,
+				customSectionId,
+				target: { type: "new-page", title: currentSectionTitle },
+			});
 		});
 	};
 


### PR DESCRIPTION
Moving the final item out of a custom section left its empty section and page behind. Moves now validate their destination before removing data, insert the item, then remove the emptied custom source section and only the affected pages that have no remaining section references.

The first page, unrelated empty pages, hidden remaining items, and other section references are preserved. Undo restores the removed section, its settings, and page placement.

Closes #3180.

Validation: the original move-out-and-back sequence now restores identical resume JSON. Thirty targeted move/history tests cover invalid destinations, page-index changes, hidden items, and undo; all 605 web tests, web typecheck, repository `pnpm check`, and independent review passed.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes item moves atomic and removes custom source sections emptied by a move, along with only affected non-header pages that become unreferenced.
- Validates the source and destination before mutating resume data.
- Inserts the moved item before pruning its former custom section and affected pages.
- Routes all sidebar move actions through the unified helper.
- Adds round-trip, invalid-target, hidden-item, page-preservation, and undo coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness, security, or data-loss issue identified in the changed paths.

Destination validation precedes mutation, insertion precedes source-page pruning, unrelated layout references are preserved, and whole-resume history snapshots restore compound moves atomically.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/libs/resume/move-item.ts | Introduces an atomic move operation with destination validation and targeted cleanup of emptied custom sections and affected pages. |
| apps/web/src/libs/resume/move-item-round-trip.test.ts | Adds focused coverage for round trips, invalid destinations, page-index changes, hidden items, reference preservation, and undo. |
| apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-item.tsx | Replaces separate remove-and-add UI mutations with calls to the unified atomic move helper. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Move Item UI
    participant Store as Resume Update
    participant Move as moveItem
    participant Layout as Resume Layout
    UI->>Store: Submit destination
    Store->>Move: Move item in one update
    Move->>Move: Validate source and destination
    Move->>Layout: Remove item from source
    Move->>Layout: Insert item at destination
    alt Custom source is now empty
        Move->>Layout: Remove source section references
        Move->>Layout: Remove affected empty non-header pages
    end
    Store-->>UI: Persist updated resume and history snapshot
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(builder): remove sections emptied by..."](https://github.com/amruthpillai/reactive-resume/commit/cc60e405624c3954d7a5da2d00c3cca796faf014) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60742859)</sub>

<!-- /greptile_comment -->