### PR TITLE
fix: preserve photo compression during cropping and show upload limits

### DIFF
--- a/apps/web/src/libs/error-message.test.ts
+++ b/apps/web/src/libs/error-message.test.ts
@@ -3,6 +3,46 @@ import { ORPCError } from "@orpc/client";
 import { getOrpcErrorMessage, getReadableErrorMessage, getResumeErrorMessage } from "./error-message";
 
 describe("getReadableErrorMessage", () => {
+	it("shows the upload size validation message instead of the generic oRPC error", () => {
+		const error = new ORPCError("BAD_REQUEST", {
+			message: "Input validation failed",
+			data: { issues: [{ message: "File size must be less than 10MB", path: [] }] },
+		});
+		expect(getReadableErrorMessage(error, "Failed to upload picture.")).toBe("File size must be less than 10MB");
+	});
+
+	it("limits validation messages, removes duplicates, and ignores malformed issues", () => {
+		const error = new ORPCError("BAD_REQUEST", {
+			message: "Input validation failed",
+			data: {
+				issues: [
+					null,
+					{},
+					{ message: 42 },
+					{ message: " " },
+					...["First", "First", "Second", "Third", "Fourth"].map((message) => ({ message })),
+				],
+			},
+		});
+		expect(getReadableErrorMessage(error, "fallback")).toBe("First Second Third");
+	});
+
+	it.each([null, {}, { issues: null }, { issues: "invalid" }, { issues: [{ message: "" }] }])(
+		"retains the error message for malformed validation data %j",
+		(data) => {
+			const error = new ORPCError("BAD_REQUEST", { message: "Input validation failed", data });
+			expect(getReadableErrorMessage(error, "fallback")).toBe("Input validation failed");
+		},
+	);
+
+	it("does not interpret unrelated server errors as input validation", () => {
+		const error = new ORPCError("INTERNAL_SERVER_ERROR", {
+			message: "Unexpected failure",
+			data: { issues: [{ message: "Internal detail" }] },
+		});
+		expect(getReadableErrorMessage(error, "fallback")).toBe("Unexpected failure");
+	});
+
 	it("returns the string error directly", () => {
 		expect(getReadableErrorMessage("explicit error", "fallback")).toBe("explicit error");
 	});

--- a/apps/web/src/libs/error-message.ts
+++ b/apps/web/src/libs/error-message.ts
@@ -1,6 +1,20 @@
 import { ORPCError } from "@orpc/client";
 
 export function getReadableErrorMessage(error: unknown, fallback: string): string {
+	if (error instanceof ORPCError && error.code === "BAD_REQUEST") {
+		const data: unknown = error.data;
+		if (typeof data === "object" && data !== null && "issues" in data && Array.isArray(data.issues)) {
+			const messages = new Set<string>();
+			for (const issue of data.issues) {
+				if (typeof issue !== "object" || issue === null || typeof issue.message !== "string") continue;
+				const message = issue.message.trim();
+				if (message) messages.add(message);
+				if (messages.size === 3) break;
+			}
+			if (messages.size > 0) return [...messages].join(" ");
+		}
+	}
+
 	if (typeof error === "string" && error) return error;
 	if (error instanceof Error && error.message) return error.message;
 	// Better Auth client errors are plain objects ({ code, message, status }), not Error instances.

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -381,7 +381,7 @@ function normalizePictureUrl(url: string, origin: string): string {
 	}
 }
 
-async function getCroppedImageBlob(imageSrc: string, pixelCrop: Area): Promise<Blob> {
+async function getCroppedImageBlob(imageSrc: string, pixelCrop: Area, mimeType: string): Promise<Blob> {
 	const image = await new Promise<HTMLImageElement>((resolve, reject) => {
 		const element = new Image();
 		element.addEventListener("load", () => {
@@ -411,11 +411,17 @@ async function getCroppedImageBlob(imageSrc: string, pixelCrop: Area): Promise<B
 		canvas.height,
 	);
 
+	// Preserve compressed photo formats so cropping cannot inflate a JPEG into a much larger PNG.
+	const outputType = mimeType === "image/jpeg" || mimeType === "image/webp" ? mimeType : "image/png";
 	return new Promise<Blob>((resolve, reject) => {
-		canvas.toBlob((blob) => {
-			if (blob) resolve(blob);
-			else reject(new Error("Canvas is empty"));
-		}, "image/png");
+		canvas.toBlob(
+			(blob) => {
+				if (blob) resolve(blob);
+				else reject(new Error("Canvas is empty"));
+			},
+			outputType,
+			0.9,
+		);
 	});
 }
 
@@ -538,7 +544,7 @@ function PictureSectionForm() {
 		let fileToUpload: File = cropState.file;
 		try {
 			if (croppedAreaPixels) {
-				const blob = await getCroppedImageBlob(cropState.imageSrc, croppedAreaPixels);
+				const blob = await getCroppedImageBlob(cropState.imageSrc, croppedAreaPixels, cropState.file.type);
 				fileToUpload = new File([blob], cropState.file.name, { type: blob.type });
 			}
 		} catch {

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -399,30 +399,42 @@ async function getCroppedImageBlob(imageSrc: string, pixelCrop: Area, mimeType: 
 
 	canvas.width = Math.round(pixelCrop.width);
 	canvas.height = Math.round(pixelCrop.height);
-	context.drawImage(
-		image,
-		pixelCrop.x,
-		pixelCrop.y,
-		pixelCrop.width,
-		pixelCrop.height,
-		0,
-		0,
-		canvas.width,
-		canvas.height,
-	);
-
-	// Preserve compressed photo formats so cropping cannot inflate a JPEG into a much larger PNG.
+	// Preserve transparency for lossless inputs and compressed formats for photos.
 	const outputType = mimeType === "image/jpeg" || mimeType === "image/webp" ? mimeType : "image/png";
-	return new Promise<Blob>((resolve, reject) => {
-		canvas.toBlob(
-			(blob) => {
-				if (blob) resolve(blob);
-				else reject(new Error("Canvas is empty"));
-			},
-			outputType,
-			0.9,
+	const maxUploadBytes = 10 * 1024 * 1024;
+
+	while (true) {
+		context.drawImage(
+			image,
+			pixelCrop.x,
+			pixelCrop.y,
+			pixelCrop.width,
+			pixelCrop.height,
+			0,
+			0,
+			canvas.width,
+			canvas.height,
 		);
-	});
+
+		const blob = await new Promise<Blob>((resolve, reject) => {
+			canvas.toBlob(
+				(result) => {
+					if (result) resolve(result);
+					else reject(new Error("Canvas is empty"));
+				},
+				outputType,
+				0.9,
+			);
+		});
+		if (blob.size <= maxUploadBytes) return blob;
+		if (canvas.width <= 1 && canvas.height <= 1) throw new Error("Cropped image exceeds the upload limit");
+
+		// Re-encoding even a JPEG can exceed the API limit. Reduce only oversized crops,
+		// drawing from the original each time to avoid accumulating resampling artifacts.
+		const scale = Math.min(0.9, Math.sqrt(maxUploadBytes / blob.size) * 0.95);
+		canvas.width = Math.max(1, Math.floor(canvas.width * scale));
+		canvas.height = Math.max(1, Math.floor(canvas.height * scale));
+	}
 }
 
 function usePictureSettingsForm(picture: PictureValues, persist: (data: PictureValues) => void) {

--- a/tests/e2e/specs/picture-upload.spec.ts
+++ b/tests/e2e/specs/picture-upload.spec.ts
@@ -1,17 +1,17 @@
-import { createSampleResumeFromDashboard, openSidebarSection } from "../fixtures/resume";
+import { createSampleResumeFromDashboard } from "../fixtures/resume";
 import { expect, test } from "../fixtures/test";
 
-test("uploads a large JPEG after cropping without expanding it into PNG", async ({ authPage: page }, testInfo) => {
+test("uploads a large JPEG after cropping without exceeding the upload limit", async ({ authPage: page }, testInfo) => {
 	await createSampleResumeFromDashboard(page, testInfo);
-	await openSidebarSection(page, "Picture");
+	await expect(page.locator("#sidebar-picture")).toBeVisible();
 
-	// A deterministic high-detail image: JPEG fits the upload limit, but lossless PNG does not.
+	// A deterministic high-detail image: JPEG fits the upload limit, but re-encoding at higher quality does not.
 	const dataUrl = await page.evaluate(() => {
 		const canvas = document.createElement("canvas");
-		canvas.width = canvas.height = 3200;
+		canvas.width = canvas.height = 4400;
 		const context = canvas.getContext("2d");
 		if (!context) throw new Error("Canvas is unavailable");
-		const pixels = context.createImageData(3200, 3200);
+		const pixels = context.createImageData(4400, 4400);
 		let seed = 42;
 		for (let i = 0; i < pixels.data.length; i += 4) {
 			for (let channel = 0; channel < 3; channel++) {
@@ -21,7 +21,7 @@ test("uploads a large JPEG after cropping without expanding it into PNG", async 
 			pixels.data[i + 3] = 255;
 		}
 		context.putImageData(pixels, 0, 0);
-		return canvas.toDataURL("image/jpeg", 0.8);
+		return canvas.toDataURL("image/jpeg", 0.65);
 	});
 	const buffer = Buffer.from(dataUrl.slice(dataUrl.indexOf(",") + 1), "base64");
 	expect(buffer.byteLength).toBeLessThan(10 * 1024 * 1024);

--- a/tests/e2e/specs/picture-upload.spec.ts
+++ b/tests/e2e/specs/picture-upload.spec.ts
@@ -1,0 +1,40 @@
+import { createSampleResumeFromDashboard, openSidebarSection } from "../fixtures/resume";
+import { expect, test } from "../fixtures/test";
+
+test("uploads a large JPEG after cropping without expanding it into PNG", async ({ authPage: page }, testInfo) => {
+	await createSampleResumeFromDashboard(page, testInfo);
+	await openSidebarSection(page, "Picture");
+
+	// A deterministic high-detail image: JPEG fits the upload limit, but lossless PNG does not.
+	const dataUrl = await page.evaluate(() => {
+		const canvas = document.createElement("canvas");
+		canvas.width = canvas.height = 3200;
+		const context = canvas.getContext("2d");
+		if (!context) throw new Error("Canvas is unavailable");
+		const pixels = context.createImageData(3200, 3200);
+		let seed = 42;
+		for (let i = 0; i < pixels.data.length; i += 4) {
+			for (let channel = 0; channel < 3; channel++) {
+				seed = (Math.imul(seed, 1664525) + 1013904223) | 0;
+				pixels.data[i + channel] = seed >>> 24;
+			}
+			pixels.data[i + 3] = 255;
+		}
+		context.putImageData(pixels, 0, 0);
+		return canvas.toDataURL("image/jpeg", 0.8);
+	});
+	const buffer = Buffer.from(dataUrl.slice(dataUrl.indexOf(",") + 1), "base64");
+	expect(buffer.byteLength).toBeLessThan(10 * 1024 * 1024);
+	await page.locator('input[type="file"][aria-label="Upload picture"]').setInputFiles({
+		name: "large-photo.jpg",
+		mimeType: "image/jpeg",
+		buffer,
+	});
+	const cropDialog = page.getByRole("dialog", { name: "Crop picture" });
+	await expect(cropDialog.locator("img")).toBeVisible();
+	await cropDialog.getByRole("button", { name: "Save & Upload" }).click();
+	await expect(page.locator("#sidebar-picture input[name=url]")).toHaveValue(/\/uploads\//);
+	await expect
+		.poll(() => page.locator("#sidebar-picture img").evaluate((image: HTMLImageElement) => image.naturalWidth))
+		.toBeGreaterThan(0);
+});


### PR DESCRIPTION
Cropping a JPEG always encoded a full-size PNG before uploading. In a real browser reproduction, a valid 6,498,294-byte JPEG became a 34,895,680-byte PNG and failed the 10 MiB upload limit. Crops now preserve JPEG/WebP compression; PNG and other formats keep the PNG fallback and transparency.

When encoding still exceeds the existing upload limit, the crop is proportionally resized from the original until it fits. A near-limit 9,349,704-byte JPEG previously expanded to 13,092,408 bytes; it now produces a 9,727,534-byte crop. Images already within the limit retain their dimensions.

For files still exceeding the existing limit, the readable-error helper now shows the server’s validation explanation instead of “Input validation failed”. Other error types and error-code mappings retain their behavior.

Closes #3305.

Validation: actual Chromium canvas reproductions failed before both fixes and pass afterward, including transparent PNG/WebP/fallback inputs. Two validation-message regressions failed before their fix; all 25 error-message tests and 602 web tests pass. Production build, web typecheck and repository `pnpm check` pass. The browser regression reproduces the near-limit failure through the real crop-and-upload UI, then passes with bounded resizing and verifies the stored picture loads.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves compressed image formats during cropping, bounds oversized encoded crops by reducing their dimensions, and surfaces server validation details for rejected uploads.
- Re-encodes JPEG and WebP crops in their original compressed format while retaining PNG fallback behavior.
- Iteratively scales encoded crops until they satisfy the existing 10 MiB upload contract.
- Adds validation-message unit coverage and a browser-level large-JPEG upload regression test.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx | Preserves compressed output formats and resizes oversized crops before upload, resolving the previously reported fixed-quality inflation failure. |
| apps/web/src/libs/error-message.ts | Extracts bounded, deduplicated validation details from BAD_REQUEST errors while retaining existing fallback behavior. |
| apps/web/src/libs/error-message.test.ts | Covers validation-detail extraction, malformed issue data, deduplication, and unrelated errors. |
| tests/e2e/specs/picture-upload.spec.ts | Exercises a high-detail JPEG through the real crop-and-upload flow and verifies that the resulting picture loads. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Selected image] --> B[Crop canvas]
    B --> C[Encode as JPEG, WebP, or PNG]
    C --> D{At most 10 MiB?}
    D -- No --> E[Reduce canvas dimensions]
    E --> B
    D -- Yes --> F[Upload file]
    F --> G[Store processed picture]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: bound cropped image size before upl..."](https://github.com/amruthpillai/reactive-resume/commit/ce1a628b9ec575e5a5d04b14350ba69b603d526f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60744200)</sub>

<!-- /greptile_comment -->