### PR TITLE
feat: add compact resume view with session preferences

### DIFF
--- a/apps/web/locales/en-US.po
+++ b/apps/web/locales/en-US.po
@@ -1102,6 +1102,10 @@ msgstr "Command Palette - {currentPage}"
 msgid "Community"
 msgstr "Community"
 
+#: src/routes/dashboard/resumes/index.tsx
+msgid "Compact"
+msgstr "Compact"
+
 #: src/dialogs/resume/sections/experience.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 msgid "Company"

--- a/apps/web/src/routes/dashboard/resumes/-components/grid-view.tsx
+++ b/apps/web/src/routes/dashboard/resumes/-components/grid-view.tsx
@@ -1,6 +1,7 @@
 import type { RouterOutput } from "@/libs/orpc/client";
 import { Trans } from "@lingui/react/macro";
 import { AnimatePresence, m } from "motion/react";
+import { cn } from "@reactive-resume/utils/style";
 import { CreateResumeCard } from "./cards/create-card";
 import { ImportResumeCard } from "./cards/import-card";
 import { ResumeCard } from "./cards/resume-card";
@@ -10,9 +11,17 @@ type Resume = RouterOutput["resume"]["list"][number];
 type Props = {
 	resumes: Resume[];
 	hasResumes: boolean;
+	compact?: boolean;
 };
 
-export function GridView({ resumes, hasResumes }: Props) {
+export function GridView({ resumes, hasResumes, compact = false }: Props) {
+	const gridClassName = cn(
+		"grid gap-4",
+		compact
+			? "3xl:grid-cols-8 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
+			: "3xl:grid-cols-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5",
+	);
+
 	if (resumes.length === 0 && hasResumes) {
 		return (
 			<p className="py-8 text-center text-muted-foreground text-sm">
@@ -23,7 +32,7 @@ export function GridView({ resumes, hasResumes }: Props) {
 
 	if (resumes.length === 0) {
 		return (
-			<div className="grid 3xl:grid-cols-6 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+			<div className={gridClassName}>
 				<m.div
 					initial={{ y: -20 }}
 					animate={{ opacity: 1, y: 0 }}
@@ -48,7 +57,7 @@ export function GridView({ resumes, hasResumes }: Props) {
 	}
 
 	return (
-		<div className="grid 3xl:grid-cols-6 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+		<div className={gridClassName}>
 			<AnimatePresence initial={false} mode="popLayout">
 				{resumes.map((resume, index) => (
 					<m.div

--- a/apps/web/src/routes/dashboard/resumes/-components/view-mode.test.tsx
+++ b/apps/web/src/routes/dashboard/resumes/-components/view-mode.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useResumeView } from "./view-mode";
+
+beforeEach(() => {
+	sessionStorage.clear();
+});
+afterEach(() => {
+	cleanup();
+	vi.restoreAllMocks();
+});
+
+describe("resume view preference", () => {
+	it("restores the selected view after leaving and returning during the session", async () => {
+		const first = renderHook(() => useResumeView("compact", "owner"));
+		await waitFor(() => expect(sessionStorage.getItem("resume-view:owner")).toBe('"compact"'));
+		first.unmount();
+		const second = renderHook(() => useResumeView(undefined, "owner"));
+		await waitFor(() => expect(second.result.current).toBe("compact"));
+	});
+	it("honors explicit grid in the URL over a saved compact preference", async () => {
+		sessionStorage.setItem("resume-view:owner", '"compact"');
+		const { result } = renderHook(() => useResumeView("grid", "owner"));
+		expect(result.current).toBe("grid");
+		await waitFor(() => expect(sessionStorage.getItem("resume-view:owner")).toBe('"grid"'));
+	});
+	it("keeps the preference scoped to its account", async () => {
+		sessionStorage.setItem("resume-view:first", '"list"');
+		const { result, rerender } = renderHook(({ user }) => useResumeView(undefined, user), {
+			initialProps: { user: "first" },
+		});
+		await waitFor(() => expect(result.current).toBe("list"));
+		rerender({ user: "second" });
+		await waitFor(() => expect(result.current).toBe("grid"));
+	});
+	it("ignores unknown stored views", () => {
+		sessionStorage.setItem("resume-view:owner", '"unknown"');
+		const { result } = renderHook(() => useResumeView(undefined, "owner"));
+		expect(result.current).toBe("grid");
+	});
+	it("renders the default when session storage is unavailable", () => {
+		vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+			throw new DOMException("Blocked", "SecurityError");
+		});
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { result } = renderHook(() => useResumeView(undefined, "owner"));
+		expect(result.current).toBe("grid");
+	});
+});

--- a/apps/web/src/routes/dashboard/resumes/-components/view-mode.ts
+++ b/apps/web/src/routes/dashboard/resumes/-components/view-mode.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useSessionStorage } from "usehooks-ts";
+import z from "zod";
+
+export const resumeViewSchema = z.enum(["grid", "compact", "list"]);
+type ResumeView = z.infer<typeof resumeViewSchema>;
+
+export function useResumeView(view: ResumeView | undefined, userId: string): ResumeView {
+	const [storedView, setStoredView] = useSessionStorage<unknown>(`resume-view:${userId}`, "grid", {
+		initializeWithValue: false,
+	});
+
+	useEffect(() => {
+		if (view !== undefined && storedView !== view) setStoredView(view);
+	}, [view, storedView, setStoredView]);
+
+	return view ?? resumeViewSchema.catch("grid").parse(storedView);
+}

--- a/apps/web/src/routes/dashboard/resumes/index.tsx
+++ b/apps/web/src/routes/dashboard/resumes/index.tsx
@@ -4,6 +4,7 @@ import { Trans } from "@lingui/react/macro";
 import {
 	DownloadSimpleIcon,
 	GridFourIcon,
+	GridNineIcon,
 	ListIcon,
 	MagnifyingGlassIcon,
 	PlusIcon,
@@ -25,6 +26,7 @@ import { orpc } from "@/libs/orpc/client";
 import { DashboardHeader } from "../-components/header";
 import { GridView } from "./-components/grid-view";
 import { ListView } from "./-components/list-view";
+import { resumeViewSchema, useResumeView } from "./-components/view-mode";
 
 type SortOption = "lastUpdatedAt" | "createdAt" | "name";
 
@@ -32,12 +34,12 @@ const searchSchema = z.object({
 	search: z.string().default(""),
 	tags: z.array(z.string()).default([]),
 	sort: z.enum(["lastUpdatedAt", "createdAt", "name"]).default("lastUpdatedAt"),
-	view: z.enum(["grid", "list"]).default("grid"),
+	view: resumeViewSchema.optional().catch(undefined),
 });
 
 type Search = z.output<typeof searchSchema>;
 
-const defaultSearch: Search = { search: "", tags: [], sort: "lastUpdatedAt", view: "grid" };
+const defaultSearch: Search = { search: "", tags: [], sort: "lastUpdatedAt" };
 
 export const Route = createFileRoute("/dashboard/resumes/")({
 	component: RouteComponent,
@@ -49,7 +51,9 @@ export const Route = createFileRoute("/dashboard/resumes/")({
 
 function RouteComponent() {
 	const { i18n } = useLingui();
-	const { search, tags, sort, view } = Route.useSearch();
+	const { search, tags, sort, view: searchView } = Route.useSearch();
+	const { session } = Route.useRouteContext();
+	const view = useResumeView(searchView, session.user.id);
 	const navigate = useNavigate({ from: Route.fullPath });
 	const { openDialog } = useDialogStore();
 
@@ -153,7 +157,7 @@ function RouteComponent() {
 				)}
 
 				<Tabs className="w-full sm:w-auto ltr:sm:ms-auto rtl:sm:me-auto" value={view}>
-					<TabsList className="grid w-full grid-cols-2 sm:inline-flex sm:w-fit">
+					<TabsList className="grid w-full grid-cols-3 sm:inline-flex sm:w-fit">
 						<TabsTrigger
 							value="grid"
 							nativeButton={false}
@@ -162,6 +166,16 @@ function RouteComponent() {
 						>
 							<GridFourIcon />
 							<Trans>Grid</Trans>
+						</TabsTrigger>
+
+						<TabsTrigger
+							value="compact"
+							nativeButton={false}
+							className="rounded-none"
+							render={<Link to="." search={(prev: Search) => ({ ...prev, view: "compact" })} />}
+						>
+							<GridNineIcon />
+							<Trans>Compact</Trans>
 						</TabsTrigger>
 
 						<TabsTrigger
@@ -180,7 +194,7 @@ function RouteComponent() {
 			{view === "list" ? (
 				<ListView resumes={filteredResumes} hasResumes={(resumes?.length ?? 0) > 0} />
 			) : (
-				<GridView resumes={filteredResumes} hasResumes={(resumes?.length ?? 0) > 0} />
+				<GridView resumes={filteredResumes} hasResumes={(resumes?.length ?? 0) > 0} compact={view === "compact"} />
 			)}
 		</div>
 	);

--- a/tests/e2e/specs/resume-views.spec.ts
+++ b/tests/e2e/specs/resume-views.spec.ts
@@ -8,7 +8,7 @@ test("keeps compact and list preferences through navigation and reload, with exp
 	await page.setViewportSize({ width: 1440, height: 1000 });
 	const name = await createSampleResumeFromDashboard(page, testInfo);
 	await page.goto("/dashboard/resumes");
-	const card = page.getByRole("link", { name: new RegExp(name) });
+	const card = page.getByRole("link").filter({ hasText: name });
 	await expect(card).toBeVisible();
 	const gridWidth = (await card.boundingBox())?.width;
 	if (!gridWidth) throw new Error("Resume card has no width.");

--- a/tests/e2e/specs/resume-views.spec.ts
+++ b/tests/e2e/specs/resume-views.spec.ts
@@ -1,0 +1,46 @@
+import { createSampleResumeFromDashboard } from "../fixtures/resume";
+import { expect, test } from "../fixtures/test";
+
+test("keeps compact and list preferences through navigation and reload, with explicit URL overrides", async ({
+	authPage: page,
+}, testInfo) => {
+	test.setTimeout(60_000);
+	await page.setViewportSize({ width: 1440, height: 1000 });
+	const name = await createSampleResumeFromDashboard(page, testInfo);
+	await page.goto("/dashboard/resumes");
+	const card = page.getByRole("link", { name: new RegExp(name) });
+	await expect(card).toBeVisible();
+	const gridWidth = (await card.boundingBox())?.width;
+	if (!gridWidth) throw new Error("Resume card has no width.");
+	await page.getByRole("tab", { name: "Compact", exact: true }).click();
+	await expect(page.getByRole("tab", { name: "Compact", exact: true })).toHaveAttribute("aria-selected", "true");
+	await expect.poll(async () => (await card.boundingBox())?.width ?? gridWidth).toBeLessThan(gridWidth);
+	await card.click();
+	await page.waitForURL(/\/builder\/.+/);
+	await page.goto("/dashboard/resumes");
+	await expect(page.getByRole("tab", { name: "Compact", exact: true })).toHaveAttribute("aria-selected", "true");
+	await page.reload();
+	await expect(page.getByRole("tab", { name: "Compact", exact: true })).toHaveAttribute("aria-selected", "true");
+	await expect(card.locator('[style*="background-image: url("]')).toBeVisible({ timeout: 30_000 });
+	await page.screenshot({ path: testInfo.outputPath("compact-resumes.png"), animations: "disabled" });
+
+	await page.getByRole("tab", { name: "Grid", exact: true }).click();
+	await expect(page).toHaveURL(/view=grid/);
+	await expect(page.getByRole("tab", { name: "Grid", exact: true })).toHaveAttribute("aria-selected", "true");
+	await expect.poll(async () => (await card.boundingBox())?.width).toBe(gridWidth);
+	await page.getByRole("tab", { name: "List", exact: true }).click();
+	await expect(page.getByRole("tab", { name: "List", exact: true })).toHaveAttribute("aria-selected", "true");
+	await page.goto("/dashboard/resumes");
+	await expect(page.getByRole("tab", { name: "List", exact: true })).toHaveAttribute("aria-selected", "true");
+	await page.goto("/dashboard/resumes?view=grid");
+	await expect(page.getByRole("tab", { name: "Grid", exact: true })).toHaveAttribute("aria-selected", "true");
+	await page.goto("/dashboard/resumes?view=invalid");
+	await expect(page.getByRole("tab", { name: "Grid", exact: true })).toHaveAttribute("aria-selected", "true");
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.getByRole("tab", { name: "Compact", exact: true }).click();
+	await expect(page.getByRole("tab", { name: "Compact", exact: true })).toHaveAttribute("aria-selected", "true");
+	await expect(card).toBeVisible();
+	await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(390);
+	await page.screenshot({ path: testInfo.outputPath("compact-resumes-mobile.png"), animations: "disabled" });
+});


### PR DESCRIPTION
Add a Compact resume view with smaller thumbnails while retaining existing card actions, names and tags. Grid, Compact and List selections now persist per account for the browser tab session, including when returning from the builder or reloading the dashboard. An explicit valid `view` URL parameter takes precedence and becomes the saved preference; invalid or unavailable storage falls back safely.

Fixes #3247.

Validation:
- Three preference regressions reproduced before implementation; all five hook tests now pass.
- Production Chromium scenario verifies smaller card width, navigation and reload persistence, List selection, explicit Grid override, invalid URLs and 390px mobile overflow.
- Desktop and mobile screenshots inspected; existing PDF thumbnail generation verified.
- Web typecheck, production build and repository checks pass; independent review found no blocker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Compact view option to the resumes dashboard with a denser responsive layout.
  - Resume view preferences now persist across navigation and page reloads.
  - URL view parameters can override saved preferences, with invalid values falling back to Grid.

- **Tests**
  - Added coverage for view preference persistence, fallback behavior, URL overrides, and mobile layout rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds a compact resumes-dashboard layout and persists each account’s selected Grid, Compact, or List mode in session storage. An explicit valid URL selection overrides and updates the stored preference.
- Adds responsive compact-grid columns while retaining existing resume cards and actions.
- Introduces account-scoped session preference handling with safe stored-value validation.
- Adds hook and browser coverage for persistence, URL overrides, account isolation, and mobile overflow.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/routes/dashboard/resumes/-components/view-mode.ts | Adds validated, account-scoped session persistence with explicit URL precedence. |
| apps/web/src/routes/dashboard/resumes/index.tsx | Integrates Compact mode into dashboard routing, controls, and resume-view rendering. |
| apps/web/src/routes/dashboard/resumes/-components/grid-view.tsx | Adds responsive compact column counts while reusing the existing resume cards. |
| apps/web/src/routes/dashboard/resumes/-components/view-mode.test.tsx | Covers preference restoration, URL precedence, account scoping, invalid values, and unavailable storage. |
| tests/e2e/specs/resume-views.spec.ts | Exercises view selection, navigation and reload persistence, URL overrides, thumbnail rendering, and mobile overflow. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Open resumes dashboard] --> B{Valid view in URL?}
    B -- Yes --> C[Use URL view]
    C --> D[Save view for current account]
    B -- No --> E[Read account-scoped session preference]
    E --> F{Stored value valid?}
    F -- Yes --> G[Use stored view]
    F -- No --> H[Use Grid]
    D --> I{Selected mode}
    G --> I
    H --> I
    I -- Grid --> J[Standard resume grid]
    I -- Compact --> K[Dense resume grid]
    I -- List --> L[Resume list]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: match resume cards by literal name..."](https://github.com/amruthpillai/reactive-resume/commit/5f11125bbb61cc273e4e1631a7eb83488fa65c96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60748753)</sub>

<!-- /greptile_comment -->