### PR TITLE
feat(applications): export filtered applications as CSV

### DIFF
--- a/apps/web/locales/af-ZA.po
+++ b/apps/web/locales/af-ZA.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" en die volledige tydlyn daarvan sal permanent uitgevee wo
 msgid "(opens in new tab)"
 msgstr "(maak in nuwe oortjie oop)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "KI-verskaffers vereis dat REDIS_URL en ENCRYPTION_SECRET gekonfigureer w
 msgid "Albanian"
 msgstr "Albanees"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Laat publieke toegang toe"
@@ -618,6 +627,14 @@ msgstr "Aansoek is by jou pyplyn gevoeg."
 msgid "Application Copilot"
 msgstr "Aansoek-Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Aansoeke oor tyd"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Aansoeke per week gestuur (laaste 8 weke)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Kan ek my CV na PDF uitvoer?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Sny prent"
 msgid "CSV data"
 msgstr "CSV-data"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Huidige wagwoord"
@@ -1793,6 +1819,14 @@ msgstr "Laai af"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Laai 'n kopie van al jou data, insluitend jou profiel en elke CV, as 'n JSON-lêer af."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Verval op {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Uitvoer"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nie seker wat om te skryf nie?"
 msgid "Note"
 msgstr "Let wel"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Begin om jou CV te bou deur dit 'n naam te gee."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Begin bou jou CV van nuuts af"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Zoem uit"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zoeloe"
-

--- a/apps/web/locales/am-ET.po
+++ b/apps/web/locales/am-ET.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" እና ሙሉ የጊዜ መስመሩ በቋሚነት ይ�
 msgid "(opens in new tab)"
 msgstr "(በአዲስ ታብ ይከፈታል)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "የAI አቅራቢዎች REDIS_URL እና ENCRYPTION_SECRET እንዲዋ
 msgid "Albanian"
 msgstr "አልባኒኛ"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "ለሁሉም ይገናኛል"
@@ -618,6 +627,14 @@ msgstr "ማመልከቻ ወደ ሂደትዎ ታክሏል።"
 msgid "Application Copilot"
 msgstr "የማመልከቻ ኮፓይለት"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "ማመልከቻዎች በጊዜ ሂደት"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "በሳምንት የተላኩ ማመልከቻዎች (ያለፉት 8 ሳምንታት)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "የየታሪክዬን ወደ PDF ልላክ እችላለሁ?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "ስዕልን ይከርክሙ"
 msgid "CSV data"
 msgstr "የCSV ውሂብ"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "አሁን ያለዎት የይለፍ ቃል"
@@ -1793,6 +1819,14 @@ msgstr "አውርድ"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "መገለጫዎን እና እያንዳንዱን የስራ ልምድዎን ጨምሮ የሁሉም ውሂብዎን ቅጂ እንደ JSON ፋይል ያውርዱ።"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "በ{0} ያበቃል"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "ወደ ውጪ አስመጣ"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "ምን መጻፍ እንዳለብህ እርግጠኛ አይደለህም?"
 msgid "Note"
 msgstr "ማስታወሻ"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "የየታሪክዎን ማቅረቢያ በስም በመስጠት መገ�
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "የየታሪክዎን ማቅረቢያ ከመጀመሪያው በሙሉ ጀምሩ"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "አጉር"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "ዙሉ"
-

--- a/apps/web/locales/ar-SA.po
+++ b/apps/web/locales/ar-SA.po
@@ -32,6 +32,11 @@ msgstr "سيتم حذف \"{0} · {1}\" وسجله الزمني الكامل نه
 msgid "(opens in new tab)"
 msgstr "(يفتح في علامة تبويب جديدة)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "يتطلب موفرو خدمات الذكاء الاصطناعي تهي�
 msgid "Albanian"
 msgstr "الألبانية"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "السماح بالوصول العام"
@@ -618,6 +627,14 @@ msgstr "تمت إضافة الطلب إلى مسار العمل الخاص بك.
 msgid "Application Copilot"
 msgstr "مساعد الطلبات"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "الطلبات بمرور الوقت"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "الطلبات المرسلة أسبوعيًا (آخر 8 أسابيع)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "هل يمكنني تصدير سيرتي الذاتية إلى PDF؟"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "صورة مقصوصة"
 msgid "CSV data"
 msgstr "بيانات CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "كلمة المرور الحالية"
@@ -1793,6 +1819,14 @@ msgstr "تنزيل"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "قم بتنزيل نسخة من جميع بياناتك، بما في ذلك ملفك الشخصي وكل سيرة ذاتية، كملف JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "تنتهي في {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "تصدير"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "لست متأكدًا مما يجب كتابته؟"
 msgid "Note"
 msgstr "ملحوظة"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "ابدأ في إنشاء سيرتك الذاتية من خلال إعط�
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "ابدأ في إنشاء سيرتك الذاتية من الصفر"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "تصغير"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "الزولو"
-

--- a/apps/web/locales/az-AZ.po
+++ b/apps/web/locales/az-AZ.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" və onun tam zaman xətti həmişəlik silinəcək. Bu ə
 msgid "(opens in new tab)"
 msgstr "(yeni vərəqdə açılır)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Süni intellekt provayderləri REDIS_URL və ENCRYPTION_SECRET-in konfiq
 msgid "Albanian"
 msgstr "Albanca"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "İctimai Girişi İcazə ver"
@@ -618,6 +627,14 @@ msgstr "Müraciət prosesinizə əlavə edildi."
 msgid "Application Copilot"
 msgstr "Müraciət Kopilotu"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Zaman üzrə müraciətlər"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Həftəlik göndərilən müraciətlər (son 8 həftə)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Özgeçmişimi PDF‑ə ixrac edə bilərəm?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Şəkli kəsin"
 msgid "CSV data"
 msgstr "CSV məlumatları"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Cari Parol"
@@ -1793,6 +1819,14 @@ msgstr "Endir"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Profiliniz və hər bir CV-niz daxil olmaqla bütün məlumatlarınızın surətini JSON faylı olaraq yükləyin."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0} tarixində başa çatır"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "İxrac"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nə yazacağınızdan əmin deyilsiniz?"
 msgid "Note"
 msgstr "Qeyd"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Özgeçmişinizi ona ad verərək qurmağa başlayın."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Özgeçmişinizi sıfırdan qurmağa başlayın"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Uzaqlaşdır"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/bg-BG.po
+++ b/apps/web/locales/bg-BG.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" и цялата му хронология ще бъдат
 msgid "(opens in new tab)"
 msgstr "(отваря се в нов раздел)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Доставчиците на изкуствен интелект изи
 msgid "Albanian"
 msgstr "Албански"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Разрешаване на публичен достъп"
@@ -618,6 +627,14 @@ msgstr "Кандидатурата е добавена към вашия про�
 msgid "Application Copilot"
 msgstr "Copilot за кандидатури"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Кандидатури във времето"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Изпратени кандидатури на седмица (последните 8 седмици)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Мога ли да експортирам автобиографията
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Изрязване на снимката"
 msgid "CSV data"
 msgstr "CSV данни"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Текуща парола"
@@ -1793,6 +1819,14 @@ msgstr "Изтегляне"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Изтеглете копие на всички ваши данни, включително вашия профил и всяка автобиография, като JSON файл."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Изтича на {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Експорт"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Не сте сигурни какво да напишете?"
 msgid "Note"
 msgstr "Забележка"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Започнете да създавате автобиографият�
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Започнете да изграждате автобиографията си от нулата"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Намаляване"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Зулуски"
-

--- a/apps/web/locales/bn-BD.po
+++ b/apps/web/locales/bn-BD.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" এবং এর সম্পূর্ণ টাইমল
 msgid "(opens in new tab)"
 msgstr "(নতুন ট্যাবে খুলবে)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "এআই প্রোভাইডারদের REDIS_URL এবং EN
 msgid "Albanian"
 msgstr "আলবেনিয়ান"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "সর্বজনীন অ্যাক্সেসের অনুমতি দিন"
@@ -618,6 +627,14 @@ msgstr "আপনার পাইপলাইনে আবেদন যোগ �
 msgid "Application Copilot"
 msgstr "আবেদন কোপাইলট"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "সময়ের সাথে আবেদন"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "প্রতি সপ্তাহে পাঠানো আবেদন (শেষ 8 সপ্তাহ)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "আমি কি আমার জীবনবৃত্তান্তক
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "ছবি ক্রপ করুন"
 msgid "CSV data"
 msgstr "CSV ডেটা"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "বর্তমান পাসওয়ার্ড"
@@ -1793,6 +1819,14 @@ msgstr "ডাউনলোড"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "আপনার প্রোফাইল এবং প্রতিটি জীবনবৃত্তান্ত সহ আপনার সমস্ত ডেটার একটি কপি JSON ফাইল হিসাবে ডাউনলোড করুন।"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "মেয়াদ শেষ হবে {0} তারিখে"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "এক্সপোর্ট"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "কী লিখবেন বুঝতে পারছেন না?"
 msgid "Note"
 msgstr "দ্রষ্টব্য"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "নামের মাধ্যমে জীবনবৃত্তান�
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "শূন্য থেকে শুরু করে আপনার জীবনবৃত্তান্ত তৈরি করুন"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "জুম আউট"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "জুলু"
-

--- a/apps/web/locales/ca-ES.po
+++ b/apps/web/locales/ca-ES.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" i tota la seva cronologia se suprimiran permanentment. Ai
 msgid "(opens in new tab)"
 msgstr "(s’obre en una pestanya nova)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Els proveïdors d'IA requereixen que REDIS_URL i ENCRYPTION_SECRET estig
 msgid "Albanian"
 msgstr "Albanès"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Permet accés públic"
@@ -618,6 +627,14 @@ msgstr "Candidatura afegida al teu pipeline."
 msgid "Application Copilot"
 msgstr "Copilot de candidatures"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Sol·licituds al llarg del temps"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Sol·licituds enviades per setmana (darreres 8 setmanes)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Puc exportar el meu currículum a PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Retallar imatge"
 msgid "CSV data"
 msgstr "Dades CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Contrasenya actual"
@@ -1793,6 +1819,14 @@ msgstr "Baixa"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Baixeu una còpia de totes les vostres dades, incloent-hi el vostre perfil i tots els currículums, com a fitxer JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Caduca el {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exporta"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "No saps què escriure?"
 msgid "Note"
 msgstr "Nota"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Comença a crear el currículum posant-li un nom."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Comença a crear el currículum des de zero"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Allunya"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulú"
-

--- a/apps/web/locales/cs-CZ.po
+++ b/apps/web/locales/cs-CZ.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" a celá jeho časová osa budou trvale smazány. Tuto akc
 msgid "(opens in new tab)"
 msgstr "(otevře se na nové kartě)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Poskytovatelé umělé inteligence vyžadují konfiguraci parametrů RED
 msgid "Albanian"
 msgstr "Albánština"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Povolit veřejný přístup"
@@ -618,6 +627,14 @@ msgstr "Žádost přidána do vašeho procesu."
 msgid "Application Copilot"
 msgstr "Kopilot žádostí"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Žádosti v čase"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Žádosti odeslané týdně (posledních 8 týdnů)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Mohu svůj životopis exportovat do PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Oříznout obrázek"
 msgid "CSV data"
 msgstr "Data CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Aktuální heslo"
@@ -1793,6 +1819,14 @@ msgstr "Stáhnout"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Stáhněte si kopii všech svých dat, včetně profilu a všech životopisů, jako soubor JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Platnost vyprší {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Export"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nejste si jisti, co napsat?"
 msgid "Note"
 msgstr "Poznámka"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Začněte vytvářet životopis tak, že mu dáte název."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Začněte vytvářet životopis od nuly"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Oddálit"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/da-DK.po
+++ b/apps/web/locales/da-DK.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" og hele dens tidslinje slettes permanent. Dette kan ikke 
 msgid "(opens in new tab)"
 msgstr "(åbner i ny fane)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI-udbydere kræver, at REDIS_URL og ENCRYPTION_SECRET konfigureres."
 msgid "Albanian"
 msgstr "Albansk"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Tillad offentlig adgang"
@@ -618,6 +627,14 @@ msgstr "Ansøgning føjet til din pipeline."
 msgid "Application Copilot"
 msgstr "Ansøgnings-Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Ansøgninger over tid"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Ansøgninger sendt pr. uge (sidste 8 uger)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Kan jeg eksportere mit CV til PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Beskær billede"
 msgid "CSV data"
 msgstr "CSV-data"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Nuværende adgangskode"
@@ -1793,6 +1819,14 @@ msgstr "Download"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Download en kopi af alle dine data, inklusive din profil og alle CV'er, som en JSON-fil."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Udløber den {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Eksportér"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Ikke sikker på, hvad du skal skrive?"
 msgid "Note"
 msgstr "Note"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Begynd at opbygge dit CV ved at give det et navn."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Begynd at opbygge dit CV helt fra bunden"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Zoom ud"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/de-DE.po
+++ b/apps/web/locales/de-DE.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" und der gesamte Verlauf werden dauerhaft gelöscht. Dies 
 msgid "(opens in new tab)"
 msgstr "(öffnet in neuem Tab)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "KI-Anbieter benötigen die Konfiguration von REDIS_URL und ENCRYPTION_SE
 msgid "Albanian"
 msgstr "Albanisch"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Öffentlichen Zugriff erlauben"
@@ -618,6 +627,14 @@ msgstr "Bewerbung wurde deiner Pipeline hinzugefügt."
 msgid "Application Copilot"
 msgstr "Bewerbungs-Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Bewerbungen im Zeitverlauf"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Pro Woche gesendete Bewerbungen (letzte 8 Wochen)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Kann ich meinen Lebenslauf als PDF exportieren?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Ausschnitt"
 msgid "CSV data"
 msgstr "CSV-Daten"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Aktuelles Passwort"
@@ -1793,6 +1819,14 @@ msgstr "Herunterladen"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Laden Sie eine Kopie all Ihrer Daten, einschließlich Ihres Profils und jedes Lebenslaufs, als JSON-Datei herunter."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Läuft am {0} ab"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exportieren"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Sie wissen nicht, was Sie schreiben sollen?"
 msgid "Note"
 msgstr "Hinweis"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Beginnen Sie mit dem Erstellen Ihres Lebenslaufs, indem Sie ihm einen Na
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Erstellen Sie Ihren Lebenslauf von Grund auf"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Herauszoomen"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/el-GR.po
+++ b/apps/web/locales/el-GR.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" και ολόκληρο το χρονολόγιό του 
 msgid "(opens in new tab)"
 msgstr "(ανοίγει σε νέα καρτέλα)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Οι πάροχοι τεχνητής νοημοσύνης απαιτού
 msgid "Albanian"
 msgstr "Αλβανικά"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Να επιτρέπεται δημόσια πρόσβαση"
@@ -618,6 +627,14 @@ msgstr "Η αίτηση προστέθηκε στη ροή σας."
 msgid "Application Copilot"
 msgstr "Βοηθός αιτήσεων"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Αιτήσεις με την πάροδο του χρόνου"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Αιτήσεις που στάλθηκαν ανά εβδομάδα (τελευταίες 8 εβδομάδες)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Μπορώ να εξαγάγω το βιογραφικό μου σημε
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Περικοπή εικόνας"
 msgid "CSV data"
 msgstr "Δεδομένα CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Τρέχων κωδικός πρόσβασης"
@@ -1793,6 +1819,14 @@ msgstr "Λήψη"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Κατεβάστε ένα αντίγραφο όλων των δεδομένων σας, συμπεριλαμβανομένου του προφίλ σας και κάθε βιογραφικού σας, ως αρχείο JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Λήγει στις {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Εξαγωγή"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Δεν είστε σίγουροι τι να γράψετε;"
 msgid "Note"
 msgstr "Σημείωση"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Ξεκινήστε να φτιάχνετε το βιογραφικό σ�
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Ξεκινήστε να φτιάχνετε το βιογραφικό σας σημείωμα από την αρχή"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Σμίκρυνση"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Ζουλού"
-

--- a/apps/web/locales/en-GB.po
+++ b/apps/web/locales/en-GB.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" and its full timeline will be permanently deleted. This c
 msgid "(opens in new tab)"
 msgstr "(opens in new tab)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI providers require REDIS_URL and ENCRYPTION_SECRET to be configured."
 msgid "Albanian"
 msgstr "Albanian"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Allow Public Access"
@@ -618,6 +627,14 @@ msgstr "Application added to your pipeline."
 msgid "Application Copilot"
 msgstr "Application Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Applications over time"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Applications sent per week (last 8 weeks)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Can I export my resume to PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Crop picture"
 msgid "CSV data"
 msgstr "CSV data"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Current Password"
@@ -1793,6 +1819,14 @@ msgstr "Download"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Download a copy of all your data, including your profile and every resume, as a JSON file."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Expires on {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Export"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Not sure what to write?"
 msgid "Note"
 msgstr "Note"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Start building your resume by giving it a name."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Start building your resume from scratch"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Zoom out"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/en-US.po
+++ b/apps/web/locales/en-US.po
@@ -27,6 +27,11 @@ msgstr "\"{0} · {1}\" and its full timeline will be permanently deleted. This c
 msgid "(opens in new tab)"
 msgstr "(opens in new tab)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr "{0, plural, one {# application to export} other {# applications to export}}"
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -514,6 +519,10 @@ msgstr "AI providers require REDIS_URL and ENCRYPTION_SECRET to be configured."
 msgid "Albanian"
 msgstr "Albanian"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr "All applications (including archived)"
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Allow Public Access"
@@ -613,6 +622,14 @@ msgstr "Application added to your pipeline."
 msgid "Application Copilot"
 msgstr "Application Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr "Application date from"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr "Application date to"
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -640,6 +657,10 @@ msgstr "Applications over time"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Applications sent per week (last 8 weeks)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr "Applications to export"
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -916,6 +937,7 @@ msgstr "Can I export my resume to PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1515,6 +1537,10 @@ msgstr "Crop picture"
 msgid "CSV data"
 msgstr "CSV data"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr "Current filters"
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Current Password"
@@ -1788,6 +1814,14 @@ msgstr "Download"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Download a copy of all your data, including your profile and every resume, as a JSON file."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr "Download application details, contacts, notes, and timeline history as CSV."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr "Download CSV"
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2070,6 +2104,14 @@ msgstr "Expires on {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Export"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr "Export applications"
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr "Export CSV"
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3529,6 +3571,7 @@ msgstr "Not sure what to write?"
 msgid "Note"
 msgstr "Note"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5032,6 +5075,10 @@ msgstr "Start building your resume by giving it a name."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Start building your resume from scratch"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr "Start date must be on or before end date."
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6564,48 +6611,3 @@ msgstr "Zoom out"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-
-#. placeholder {0}: selected.length
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "{0, plural, one {# application to export} other {# applications to export}}"
-msgstr "{0, plural, one {# application to export} other {# applications to export}}"
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "All applications (including archived)"
-msgstr "All applications (including archived)"
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "Application date from"
-msgstr "Application date from"
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "Application date to"
-msgstr "Application date to"
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "Applications to export"
-msgstr "Applications to export"
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "Current filters"
-msgstr "Current filters"
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "Download application details, contacts, notes, and timeline history as CSV."
-msgstr "Download application details, contacts, notes, and timeline history as CSV."
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "Download CSV"
-msgstr "Download CSV"
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "Export applications"
-msgstr "Export applications"
-
-#: src/routes/dashboard/applications/index.tsx
-msgid "Export CSV"
-msgstr "Export CSV"
-
-#: src/features/applications/components/export-applications-sheet.tsx
-msgid "Start date must be on or before end date."
-msgstr "Start date must be on or before end date."

--- a/apps/web/locales/en-US.po
+++ b/apps/web/locales/en-US.po
@@ -6564,3 +6564,48 @@ msgstr "Zoom out"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
+
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr "{0, plural, one {# application to export} other {# applications to export}}"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr "All applications (including archived)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr "Application date from"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr "Application date to"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr "Applications to export"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr "Current filters"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr "Download application details, contacts, notes, and timeline history as CSV."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr "Download CSV"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr "Export applications"
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr "Export CSV"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr "Start date must be on or before end date."

--- a/apps/web/locales/es-ES.po
+++ b/apps/web/locales/es-ES.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" y todo su historial se eliminarán permanentemente. Esta 
 msgid "(opens in new tab)"
 msgstr "(abrir en una nueva pestaña)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Los proveedores de IA requieren que se configuren REDIS_URL y ENCRYPTION
 msgid "Albanian"
 msgstr "Albanés"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Permitir acceso público"
@@ -618,6 +627,14 @@ msgstr "Candidatura añadida a tu pipeline."
 msgid "Application Copilot"
 msgstr "Copiloto de candidaturas"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Candidaturas a lo largo del tiempo"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Candidaturas enviadas por semana (últimas 8 semanas)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "¿Puedo exportar mi currículum a PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Imagen recortada"
 msgid "CSV data"
 msgstr "Datos CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Contraseña actual"
@@ -1793,6 +1819,14 @@ msgstr "Descargar"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Descarga una copia de todos tus datos, incluyendo tu perfil y todos tus currículums, en formato JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Expira el {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exportar"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "¿No sabes qué escribir?"
 msgid "Note"
 msgstr "Nota"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Comienza a crear tu currículum dándole un nombre."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Comienza a crear tu currículum desde cero"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Alejar"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulú"
-

--- a/apps/web/locales/fa-IR.po
+++ b/apps/web/locales/fa-IR.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" و کل تاریخچه آن برای همیشه حذف م
 msgid "(opens in new tab)"
 msgstr "(در زبانهٔ جدید باز می‌شود)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "ارائه دهندگان هوش مصنوعی نیاز به پیکربن
 msgid "Albanian"
 msgstr "آلبانیایی"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "اجازهٔ دسترسی عمومی"
@@ -618,6 +627,14 @@ msgstr "درخواست به مسیر شما اضافه شد."
 msgid "Application Copilot"
 msgstr "دستیار درخواست‌ها"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "درخواست‌ها در طول زمان"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "درخواست‌های ارسال‌شده در هفته (۸ هفته گذشته)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "آیا می‌توانم رزومه‌ام را به PDF خروجی بگ
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "برش تصویر"
 msgid "CSV data"
 msgstr "داده‌های CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "گذرواژهٔ فعلی"
@@ -1793,6 +1819,14 @@ msgstr "دانلود"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "یک کپی از تمام اطلاعات خود، از جمله پروفایل و هر رزومه، را به صورت یک فایل JSON دانلود کنید."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "در {0} منقضی می‌شود"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "خروجی گرفتن"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "مطمئن نیستید چه بنویسید؟"
 msgid "Note"
 msgstr "یادداشت"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "ساخت رزومه خود را با دادن یک نام به آن شر
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "ساخت رزومه خود را از صفر شروع کنید"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "کوچک‌نمایی"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "زولو"
-

--- a/apps/web/locales/fi-FI.po
+++ b/apps/web/locales/fi-FI.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" ja sen koko aikajana poistetaan pysyvästi. Tätä ei voi
 msgid "(opens in new tab)"
 msgstr "(avautuu uuteen välilehteen)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Tekoälypalveluntarjoajat vaativat REDIS_URL- ja ENCRYPTION_SECRET-mää
 msgid "Albanian"
 msgstr "albania"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Salli julkinen käyttö"
@@ -618,6 +627,14 @@ msgstr "Hakemus lisättiin prosessiisi."
 msgid "Application Copilot"
 msgstr "Hakemusavustaja"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Hakemukset ajan kuluessa"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Lähetetyt hakemukset viikoittain (viimeiset 8 viikkoa)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Voinko viedä ansioluetteloni PDF-muotoon?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Rajaa kuvaa"
 msgid "CSV data"
 msgstr "CSV-tiedot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Nykyinen salasana"
@@ -1793,6 +1819,14 @@ msgstr "Lataa"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Lataa kopio kaikista tiedoistasi, mukaan lukien profiilisi ja jokainen ansioluettelosi, JSON-tiedostona."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Vanhenee {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Vienti"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Etkö ole varma, mitä kirjoittaa?"
 msgid "Note"
 msgstr "Huom"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Aloita ansioluettelon laatiminen antamalla sille nimi."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Aloita ansioluettelon laatiminen alusta"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Loitonna"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/fr-FR.po
+++ b/apps/web/locales/fr-FR.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" et tout son historique seront supprimés définitivement.
 msgid "(opens in new tab)"
 msgstr "(s'ouvre dans un nouvel onglet)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Les fournisseurs d'IA exigent la configuration de REDIS_URL et ENCRYPTIO
 msgid "Albanian"
 msgstr "Albanais"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Autoriser l'accès public"
@@ -618,6 +627,14 @@ msgstr "Candidature ajoutée à votre pipeline."
 msgid "Application Copilot"
 msgstr "Copilote de candidature"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Candidatures au fil du temps"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Candidatures envoyées par semaine (8 dernières semaines)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Puis-je exporter mon CV au format PDF ?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Image recadrée"
 msgid "CSV data"
 msgstr "Données CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Mot de passe actuel"
@@ -1793,6 +1819,14 @@ msgstr "Télécharger"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Téléchargez une copie de toutes vos données, y compris votre profil et tous vos CV, sous forme de fichier JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Expire le {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exporter"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Vous ne savez pas quoi écrire ?"
 msgid "Note"
 msgstr "Note"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Commencez à créer votre CV en lui donnant un nom."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Commencez à rédiger votre CV en partant de zéro"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Zoom arrière"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zoulou"
-

--- a/apps/web/locales/he-IL.po
+++ b/apps/web/locales/he-IL.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" וכל ציר הזמן שלו יימחקו לצמיתות
 msgid "(opens in new tab)"
 msgstr "(נפתח בלשונית חדשה)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "ספקי בינה מלאכותית דורשים הגדרה של REDIS_UR
 msgid "Albanian"
 msgstr "אלבנית"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "לאפשר גישה ציבורית"
@@ -618,6 +627,14 @@ msgstr "המועמדות נוספה לתהליך שלך."
 msgid "Application Copilot"
 msgstr "עוזר מועמדויות"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "מועמדויות לאורך זמן"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "מועמדויות שנשלחו בשבוע (8 השבועות האחרונים)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "האם אפשר לייצא את קורות החיים שלי ל־PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "חיתוך תמונה"
 msgid "CSV data"
 msgstr "נתוני CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "סיסמה נוכחית"
@@ -1793,6 +1819,14 @@ msgstr "הורדה"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "הורד עותק של כל הנתונים שלך, כולל הפרופיל שלך וכל קורות החיים, כקובץ JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "פג בתאריך {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "ייצוא"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "לא בטוחים מה לכתוב?"
 msgid "Note"
 msgstr "הערה"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "אפשר להתחיל לבנות את קורות החיים שלך על 
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "התחלת בנייה מאפס של קורות החיים שלך"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "התרחקות"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "זולו"
-

--- a/apps/web/locales/hi-IN.po
+++ b/apps/web/locales/hi-IN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" और इसकी पूरी टाइमलाइन
 msgid "(opens in new tab)"
 msgstr "(नए टैब में खुलता है)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "एआई प्रदाताओं को REDIS_URL और ENCRYPTION
 msgid "Albanian"
 msgstr "अल्बानियाई"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "सार्वजनिक एक्सेस की अनुमति दें"
@@ -618,6 +627,14 @@ msgstr "आवेदन आपकी पाइपलाइन में जो�
 msgid "Application Copilot"
 msgstr "आवेदन कोपायलट"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "समय के साथ आवेदन"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "प्रति सप्ताह भेजे गए आवेदन (पिछले 8 सप्ताह)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "क्या मैं अपना रेज़्यूमे PDF म�
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "तस्वीर काटें"
 msgid "CSV data"
 msgstr "CSV डेटा"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "वर्तमान पासवर्ड"
@@ -1793,6 +1819,14 @@ msgstr "डाउनलोड"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "अपनी प्रोफ़ाइल और अपने सभी रिज्यूमे सहित अपने सभी डेटा की एक कॉपी JSON फ़ाइल के रूप में डाउनलोड करें।"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0} को समाप्त होगा"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "निर्यात"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "मैं आश्वस्त नहीं हूं कि क्य�
 msgid "Note"
 msgstr "टिप्पणी"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "अपने रेज़्यूमे को नाम देकर �
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "शुरुआत से अपना रेज़्यूमे बनाना शुरू करें"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "ज़ूम आउट"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "ज़ुलु"
-

--- a/apps/web/locales/hu-HU.po
+++ b/apps/web/locales/hu-HU.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" és a teljes idővonala véglegesen törlődik. Ez nem vo
 msgid "(opens in new tab)"
 msgstr "(új lapon nyílik meg)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "A mesterséges intelligencia szolgáltatók megkövetelik a REDIS_URL é
 msgid "Albanian"
 msgstr "albán"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Nyilvános hozzáférés engedélyezése"
@@ -618,6 +627,14 @@ msgstr "A jelentkezés hozzáadva a folyamathoz."
 msgid "Application Copilot"
 msgstr "Jelentkezési Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Jelentkezések időben"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Hetente elküldött jelentkezések (az elmúlt 8 hét)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Exportálhatom az önéletrajzomat PDF‑be?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Kép kivágása"
 msgid "CSV data"
 msgstr "CSV-adatok"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Jelenlegi jelszó"
@@ -1793,6 +1819,14 @@ msgstr "Letöltés"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Töltsd le az összes adatod másolatát, beleértve a profilodat és minden önéletrajzodat, JSON fájlként."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Lejár ekkor: {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exportálás"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nem tudod, mit írj?"
 msgid "Note"
 msgstr "Megjegyzés"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Kezdd az önéletrajzod építését azzal, hogy nevet adsz neki."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Kezdd el az önéletrajzod építését a nulláról"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Kicsinyítés"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/id-ID.po
+++ b/apps/web/locales/id-ID.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" dan seluruh linimasanya akan dihapus permanen. Ini tidak 
 msgid "(opens in new tab)"
 msgstr "(terbuka di tab baru)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Penyedia AI memerlukan REDIS_URL dan ENCRYPTION_SECRET untuk dikonfigura
 msgid "Albanian"
 msgstr "Albania"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Izinkan Akses Publik"
@@ -618,6 +627,14 @@ msgstr "Lamaran ditambahkan ke pipeline kamu."
 msgid "Application Copilot"
 msgstr "Copilot Lamaran"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Lamaran dari waktu ke waktu"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Lamaran dikirim per minggu (8 minggu terakhir)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Bisakah saya mengekspor resume saya ke PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Gambar tanaman"
 msgid "CSV data"
 msgstr "Data CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Kata Sandi Saat Ini"
@@ -1793,6 +1819,14 @@ msgstr "Unduh"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Unduh salinan semua data Anda, termasuk profil dan semua resume Anda, sebagai file JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Berakhir pada {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Ekspor"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Tidak yakin harus menulis apa?"
 msgid "Note"
 msgstr "Catatan"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Mulai membuat resume Anda dengan memberikan nama."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Mulai membuat resume Anda dari awal"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Perkecil"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/it-IT.po
+++ b/apps/web/locales/it-IT.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" e tutta la sua cronologia verranno eliminati definitivame
 msgid "(opens in new tab)"
 msgstr "(apre in una nuova scheda)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "I provider di intelligenza artificiale richiedono la configurazione di R
 msgid "Albanian"
 msgstr "Albanese"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Consenti accesso pubblico"
@@ -618,6 +627,14 @@ msgstr "Candidatura aggiunta alla pipeline."
 msgid "Application Copilot"
 msgstr "Copilot candidature"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Candidature nel tempo"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Candidature inviate a settimana (ultime 8 settimane)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Posso esportare il mio curriculum in PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Immagine ritagliata"
 msgid "CSV data"
 msgstr "Dati CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Password attuale"
@@ -1793,6 +1819,14 @@ msgstr "Download"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Scarica una copia di tutti i tuoi dati, inclusi il tuo profilo e ogni curriculum, in formato JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Scade il {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Esporta"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Non sai cosa scrivere?"
 msgid "Note"
 msgstr "Nota"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Inizia a costruire il tuo curriculum dandogli un nome."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Inizia a costruire il tuo curriculum da zero"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Rimpicciolisci"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/ja-JP.po
+++ b/apps/web/locales/ja-JP.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" とその全タイムラインは完全に削除されま
 msgid "(opens in new tab)"
 msgstr "（新しいタブで開きます）"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AIプロバイダーは、REDIS_URLとENCRYPTION_SECRETの設定を必�
 msgid "Albanian"
 msgstr "アルバニア語"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "公開アクセスを許可"
@@ -618,6 +627,14 @@ msgstr "応募をパイプラインに追加しました。"
 msgid "Application Copilot"
 msgstr "応募 Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "応募数の推移"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "週ごとの応募送信数（直近8週間）"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "履歴書を PDF にエクスポートできますか？"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "トリミング画像"
 msgid "CSV data"
 msgstr "CSV データ"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "現在のパスワード"
@@ -1793,6 +1819,14 @@ msgstr "ダウンロード"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "プロフィールや履歴書など、すべてのデータをJSONファイルとしてダウンロードできます。"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "有効期限: {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "エクスポート"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "何を書けばいいか分からない？"
 msgid "Note"
 msgstr "注記"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "まずレジュメに名前を付けてください。"
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "ゼロからレジュメの作成を始める"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "ズームアウト"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "ズールー語"
-

--- a/apps/web/locales/km-KH.po
+++ b/apps/web/locales/km-KH.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" និងប្រវត្តិពេលវេលាទ
 msgid "(opens in new tab)"
 msgstr "(បើក​ក្នុងផ្ទាំង​ថ្មី)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "អ្នកផ្តល់សេវា AI តម្រូវឱ្យ R
 msgid "Albanian"
 msgstr "Albanian"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "អនុញ្ញាត​ឱ្យ​ចូល​ដំណើរការ​សាធារណៈ"
@@ -618,6 +627,14 @@ msgstr "បានបន្ថែមពាក្យសុំទៅដំណើរ
 msgid "Application Copilot"
 msgstr "Copilot សម្រាប់ពាក្យសុំ"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "ពាក្យសុំតាមពេលវេលា"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "ពាក្យសុំបានផ្ញើក្នុងមួយសប្តាហ៍ (៨ សប្តាហ៍ចុងក្រោយ)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "តើ​ខ្ញុំ​អាច​នាំចេញ​ប្រវ
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "ច្រឹបរូបភាព"
 msgid "CSV data"
 msgstr "ទិន្នន័យ CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "ពាក្យសម្ងាត់​បច្ចុប្បន្ន"
@@ -1793,6 +1819,14 @@ msgstr "ទាញយក"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "ទាញយកច្បាប់ចម្លងនៃទិន្នន័យទាំងអស់របស់អ្នក រួមទាំងប្រវត្តិរូប និងប្រវត្តិរូបសង្ខេបនីមួយៗរបស់អ្នក ជាឯកសារ JSON។"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "ផុតកំណត់​នៅ​ថ្ងៃទី {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "នាំចេញ"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "មិនប្រាកដថាត្រូវសរសេរអ្វ
 msgid "Note"
 msgstr "ចំណាំ"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "ចាប់ផ្តើម​បង្កើត​ប្រវត្ត
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "ចាប់ផ្តើម​បង្កើត​ប្រវត្តិរូប​របស់​អ្នក​ពី​សូន្យ"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "បង្រួម"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/kn-IN.po
+++ b/apps/web/locales/kn-IN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" ಮತ್ತು ಅದರ ಸಂಪೂರ್ಣ ಕಾಲ
 msgid "(opens in new tab)"
 msgstr "(ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆಯುತ್ತದೆ)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI ಪೂರೈಕೆದಾರರು REDIS_URL ಮತ್ತು ENCRYPTIO
 msgid "Albanian"
 msgstr "ಅಲ್ಬೇನಿಯನ್"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "ಸಾರ್ವಜನಿಕ ಪ್ರವೇಶಕ್ಕೆ ಅನುಮತಿಸಿ"
@@ -618,6 +627,14 @@ msgstr "ಅರ್ಜಿಯನ್ನು ನಿಮ್ಮ ಪೈಪ್‌ಲೈನ�
 msgid "Application Copilot"
 msgstr "ಅರ್ಜಿಯ Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "ಕಾಲಕ್ರಮದಲ್ಲಿ ಅರ್ಜಿಗಳು"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "ಪ್ರತಿ ವಾರ ಕಳುಹಿಸಿದ ಅರ್ಜಿಗಳು (ಕೊನೆಯ 8 ವಾರಗಳು)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "ನಾನು ನನ್ನ ರೆಸ್ಯೂಮ್ ಅನ್ನು PDF �
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "ಚಿತ್ರವನ್ನು ಕ್ರಾಪ್ ಮಾಡಿ"
 msgid "CSV data"
 msgstr "CSV ಡೇಟಾ"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "ಪ್ರಸ್ತುತ ಪಾಸ್‌ವರ್ಡ್"
@@ -1793,6 +1819,14 @@ msgstr "ಡೌನ್‌ಲೋಡ್"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "ನಿಮ್ಮ ಪ್ರೊಫೈಲ್ ಮತ್ತು ಪ್ರತಿಯೊಂದು ರೆಸ್ಯೂಮ್ ಸೇರಿದಂತೆ ನಿಮ್ಮ ಎಲ್ಲಾ ಡೇಟಾದ ನಕಲನ್ನು JSON ಫೈಲ್ ಆಗಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0} ರಂದು ಅವಧಿ ಮುಗಿಯುತ್ತದೆ"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "ರಫ್ತು ಮಾಡು"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "ಏನು ಬರೆಯಬೇಕೆಂದು ಖಚಿತವಿಲ್ಲ�
 msgid "Note"
 msgstr "ಗಮನಿಸಿ"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "ಹೆಸರನ್ನು ನೀಡುವ ಮೂಲಕ ನಿಮ್ಮ �
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "ಮೊದಲಿನಿಂದ ನಿಮ್ಮ ರೆಸ್ಯೂಮ್ ಅನ್ನು ನಿರ್ಮಿಸಲು ಪ್ರಾರಂಭಿಸಿ"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "ಗಾತ್ರ ಕುಗ್ಗಿಸಿ"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "ಜೂಲೂ"
-

--- a/apps/web/locales/ko-KR.po
+++ b/apps/web/locales/ko-KR.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" 및 전체 타임라인이 영구적으로 삭제됩니�
 msgid "(opens in new tab)"
 msgstr "(새 탭에서 열림)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI 제공업체는 REDIS_URL 및 ENCRYPTION_SECRET이 구성되어 있�
 msgid "Albanian"
 msgstr "알바니아어"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "공개 액세스 허용"
@@ -618,6 +627,14 @@ msgstr "지원이 파이프라인에 추가되었습니다."
 msgid "Application Copilot"
 msgstr "지원 Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "시간별 지원 현황"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "주당 보낸 지원서 (최근 8주)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "이력서를 PDF로 내보낼 수 있나요?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "사진을 잘라내세요"
 msgid "CSV data"
 msgstr "CSV 데이터"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "현재 비밀번호"
@@ -1793,6 +1819,14 @@ msgstr "다운로드"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "프로필과 모든 이력서를 포함한 모든 데이터를 JSON 파일로 다운로드하세요."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "만료일: {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "내보내기"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "무엇을 써야 할지 모르겠나요?"
 msgid "Note"
 msgstr "참고"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "이력서 이름을 정해 작성을 시작해 보세요."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "처음부터 이력서를 직접 작성하기"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "축소"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "줄루어"
-

--- a/apps/web/locales/lt-LT.po
+++ b/apps/web/locales/lt-LT.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" ir visa jos laiko juosta bus visam laikui ištrinta. To n
 msgid "(opens in new tab)"
 msgstr "(atsidaro naujame skirtuke)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Dirbtinio intelekto teikėjams reikia sukonfigūruoti REDIS_URL ir ENCRY
 msgid "Albanian"
 msgstr "Albanų"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Leisti viešą prieigą"
@@ -618,6 +627,14 @@ msgstr "Paraiška pridėta prie jūsų proceso."
 msgid "Application Copilot"
 msgstr "Paraiškų Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Paraiškos laikui bėgant"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Per savaitę išsiųstos paraiškos (paskutinės 8 savaitės)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Ar galiu eksportuoti savo gyvenimo aprašymą į PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Apkirpti paveikslėlį"
 msgid "CSV data"
 msgstr "CSV duomenys"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Dabartinis slaptažodis"
@@ -1793,6 +1819,14 @@ msgstr "Atsisiųsti"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Atsisiųskite visų savo duomenų, įskaitant profilį ir kiekvieną gyvenimo aprašymą, kopiją kaip JSON failą."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Baigia galioti {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Eksportuoti"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nežinote, ką rašyti?"
 msgid "Note"
 msgstr "Pastaba"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Pradėkite kurti savo gyvenimo aprašymą suteikdami jam pavadinimą."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Pradėkite kurti savo gyvenimo aprašymą nuo nulio"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Tolinti"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulų"
-

--- a/apps/web/locales/lv-LV.po
+++ b/apps/web/locales/lv-LV.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" un visa tās laika skala tiks neatgriezeniski dzēsta. To
 msgid "(opens in new tab)"
 msgstr "(atveras jaunā cilnē)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Mākslīgā intelekta pakalpojumu sniedzējiem ir jākonfigurē REDIS_UR
 msgid "Albanian"
 msgstr "Albāņu"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Atļaut publisku piekļuvi"
@@ -618,6 +627,14 @@ msgstr "Pieteikums pievienots jūsu procesam."
 msgid "Application Copilot"
 msgstr "Pieteikumu Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Pieteikumi laika gaitā"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Nedēļā nosūtītie pieteikumi (pēdējās 8 nedēļas)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Vai varu eksportēt savu CV uz PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Apgriezt attēlu"
 msgid "CSV data"
 msgstr "CSV dati"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Pašreizējā parole"
@@ -1793,6 +1819,14 @@ msgstr "Lejupielādēt"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Lejupielādējiet visu savu datu kopiju, tostarp savu profilu un katru CV, kā JSON failu."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Beidzas {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Eksports"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Neesat pārliecināts, ko rakstīt?"
 msgid "Note"
 msgstr "Piezīme"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Sāciet veidot savu CV, piešķirot tam nosaukumu."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Sāciet veidot savu CV no nulles"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Tālināt"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/ml-IN.po
+++ b/apps/web/locales/ml-IN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" എന്നതും അതിന്റെ പൂർണ�
 msgid "(opens in new tab)"
 msgstr "(പുതിയ ടാബിൽ തുറക്കും)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI ദാതാക്കൾക്ക് REDIS_URL ഉം ENCRYPTION_SECR
 msgid "Albanian"
 msgstr "അൽബേനിയൻ"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "പബ്ലിക് ആക്സസ് അനുവദിക്കുക"
@@ -618,6 +627,14 @@ msgstr "നിങ്ങളുടെ പൈപ്പ്ലൈനിലേക്�
 msgid "Application Copilot"
 msgstr "അപേക്ഷ കോപൈലറ്റ്"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "കാലക്രമേണ അപേക്ഷകൾ"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "ആഴ്ചയിൽ അയച്ച അപേക്ഷകൾ (കഴിഞ്ഞ 8 ആഴ്ച)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "എന്റെ റിസ്യൂം PDF ആയി എക്സ്പ�
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "ചിത്രം ക്രോപ്പ് ചെയ്യുക"
 msgid "CSV data"
 msgstr "CSV ഡാറ്റ"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "നിലവിലെ പാസ്‌വേഡ്"
@@ -1793,6 +1819,14 @@ msgstr "ഡൗൺലോഡ്"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "നിങ്ങളുടെ പ്രൊഫൈലും എല്ലാ റെസ്യൂമെയും ഉൾപ്പെടെ എല്ലാ ഡാറ്റയുടെയും ഒരു പകർപ്പ് ഒരു JSON ഫയലായി ഡൗൺലോഡ് ചെയ്യുക."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0}-ന് കാലാവധി അവസാനിക്കും"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "എക്സ്പോർട്ട്"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "എന്ത് എഴുതണമെന്ന് ഉറപ്പില�
 msgid "Note"
 msgstr "കുറിപ്പ്"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "ഒരു പേര് നൽകിക്കൊണ്ട് നിങ്
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "നിറുത്തിടുന്നിടത്ത് നിന്ന് നിങ്ങളുടെ റിസ്യൂം പൂർണ്ണമായും പുതിയതായി നിർമ്മിക്കാൻ ആരംഭിക്കുക"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "സൂം ഔട്ട് ചെയ്യുക"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "സൂളു"
-

--- a/apps/web/locales/mr-IN.po
+++ b/apps/web/locales/mr-IN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" आणि त्याची पूर्ण टाइम
 msgid "(opens in new tab)"
 msgstr "(नवीन टॅबमध्ये उघडतो)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "एआय प्रोव्हायडर्सना REDIS_URL आण
 msgid "Albanian"
 msgstr "अल्बेनियन"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "सार्वजनिक अ‍ॅक्सेस परवानगी द्या"
@@ -618,6 +627,14 @@ msgstr "तुमच्या पाइपलाइनमध्ये अर्�
 msgid "Application Copilot"
 msgstr "अर्ज सहपायलट"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "काळानुसार अर्ज"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "दर आठवड्याला पाठवलेले अर्ज (मागील 8 आठवडे)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "मी माझा रेझ्युमे PDF मध्ये नि�
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "क्रॉप चित्र"
 msgid "CSV data"
 msgstr "CSV डेटा"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "वर्तमान पासवर्ड"
@@ -1793,6 +1819,14 @@ msgstr "डाउनलोड"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "तुमच्या प्रोफाइल आणि प्रत्येक रिझ्युमेसह तुमच्या सर्व डेटाची एक प्रत JSON फाइल म्हणून डाउनलोड करा."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0} रोजी कालबाह्य होते"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "निर्यात करा"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "काय लिहावे हे सुचत नाहीये?"
 msgid "Note"
 msgstr "नोंद"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "रेझ्युमेला नाव देऊन तो बनव�
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "शून्यापासून तुमचा रेझ्युमे बनवायला सुरू करा"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "बाहेर झूम करा"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "झुलू"
-

--- a/apps/web/locales/ms-MY.po
+++ b/apps/web/locales/ms-MY.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" dan garis masa penuhnya akan dipadamkan secara kekal. Tin
 msgid "(opens in new tab)"
 msgstr "(dibuka dalam tab baharu)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Penyedia AI memerlukan REDIS_URL dan ENCRYPTION_SECRET dikonfigurasikan.
 msgid "Albanian"
 msgstr "Albanian"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Benarkan Akses Awam"
@@ -618,6 +627,14 @@ msgstr "Permohonan ditambahkan ke pipeline anda."
 msgid "Application Copilot"
 msgstr "Copilot Permohonan"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Permohonan mengikut masa"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Permohonan dihantar setiap minggu (8 minggu lepas)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Bolehkah saya mengeksport resume saya ke PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Pangkas gambar"
 msgid "CSV data"
 msgstr "Data CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Kata Laluan Semasa"
@@ -1793,6 +1819,14 @@ msgstr "Muat turun"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Muat turun salinan semua data anda, termasuk profil dan setiap resume anda, sebagai fail JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Tamat pada {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Eksport"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Tidak pasti apa yang perlu ditulis?"
 msgid "Note"
 msgstr "Nota"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Mula bina resume anda dengan memberinya nama."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Mula bina resume anda dari awal"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Zum keluar"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/ne-NP.po
+++ b/apps/web/locales/ne-NP.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" र यसको पूरा टाइमलाइन �
 msgid "(opens in new tab)"
 msgstr "(नयाँ ट्याबमा खुल्छ)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI प्रदायकहरूलाई REDIS_URL र ENCRYPTION_SECR
 msgid "Albanian"
 msgstr "अल्बानियन"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "सार्वजनिक पहुँच अनुमति दिनुहोस्"
@@ -618,6 +627,14 @@ msgstr "तपाईंको पाइपलाइनमा आवेदन थ
 msgid "Application Copilot"
 msgstr "आवेदन सहपायलट"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "समयसँगै आवेदनहरू"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "प्रति हप्ता पठाइएका आवेदनहरू (पछिल्ला 8 हप्ता)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "के म आफ्नो बायोडाटा PDF मा निर
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "तस्बिर क्रप गर्नुहोस्"
 msgid "CSV data"
 msgstr "CSV डाटा"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "हालको पासवर्ड"
@@ -1793,6 +1819,14 @@ msgstr "डाउनलोड गर्नुहोस्"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "तपाईंको प्रोफाइल र प्रत्येक रिजुमे सहित तपाईंको सबै डेटाको प्रतिलिपि JSON फाइलको रूपमा डाउनलोड गर्नुहोस्।"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0} मा समाप्त हुन्छ"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "निर्यात"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "के लेख्ने भनेर निश्चित हुन�
 msgid "Note"
 msgstr "नोट"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "नाम राखेर आफ्नो बायोडाटा ब�
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "सुरुदेखि नयाँ बायोडाटा बनाउन सुरु गर्नुहोस्"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "जूम आउट"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "जुलु"
-

--- a/apps/web/locales/nl-NL.po
+++ b/apps/web/locales/nl-NL.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" en de volledige tijdlijn worden permanent verwijderd. Dit
 msgid "(opens in new tab)"
 msgstr "(opent in nieuw tabblad)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI-providers vereisen dat REDIS_URL en ENCRYPTION_SECRET geconfigureerd 
 msgid "Albanian"
 msgstr "Albanees"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Openbare toegang toestaan"
@@ -618,6 +627,14 @@ msgstr "Sollicitatie toegevoegd aan uw pijplijn."
 msgid "Application Copilot"
 msgstr "Sollicitatie-copiloot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Sollicitaties in de tijd"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Sollicitaties per week verstuurd (laatste 8 weken)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Kan ik mijn cv naar PDF exporteren?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Afbeelding bijsnijden"
 msgid "CSV data"
 msgstr "CSV-gegevens"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Huidige wachtwoord"
@@ -1793,6 +1819,14 @@ msgstr "Downloaden"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Download een kopie van al uw gegevens, inclusief uw profiel en al uw cv's, als een JSON-bestand."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Verloopt op {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exporteren"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Weet je niet wat je moet schrijven?"
 msgid "Note"
 msgstr "Notitie"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Begin het opstellen van uw cv door het een naam te geven."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Begin met het opstellen van uw cv vanaf nul"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Uitzoomen"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/no-NO.po
+++ b/apps/web/locales/no-NO.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" og hele tidslinjen slettes permanent. Dette kan ikke angr
 msgid "(opens in new tab)"
 msgstr "(åpnes i ny fane)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI-leverandører krever at REDIS_URL og ENCRYPTION_SECRET konfigureres."
 msgid "Albanian"
 msgstr "Albansk"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Tillat offentlig tilgang"
@@ -618,6 +627,14 @@ msgstr "Søknad lagt til i pipelinen din."
 msgid "Application Copilot"
 msgstr "Søknads-Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Søknader over tid"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Søknader sendt per uke (siste 8 uker)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Kan jeg eksportere CV-en min til PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Beskjær bilde"
 msgid "CSV data"
 msgstr "CSV-data"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Nåværende passord"
@@ -1793,6 +1819,14 @@ msgstr "Last ned"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Last ned en kopi av alle dataene dine, inkludert profilen din og alle CV-ene dine, som en JSON-fil."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Utløper {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Eksporter"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Usikker på hva du skal skrive?"
 msgid "Note"
 msgstr "Merknad"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Begynn å bygge CV-en din ved å gi den et navn."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Begynn å bygge CV-en din fra bunnen av"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Zoom ut"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/or-IN.po
+++ b/apps/web/locales/or-IN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" ଏବଂ ଏହାର ସମ୍ପୂର୍ଣ୍ଣ ସ
 msgid "(opens in new tab)"
 msgstr "(ନୂତନ ଟାବ୍‌ରେ ଖୋଲେ)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI ପ୍ରଦାନକାରୀମାନଙ୍କୁ REDIS_URL ଏବ�
 msgid "Albanian"
 msgstr "ଆଲବାନିଆନ୍"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "ସାର୍ବଜନିକ ଆକ୍ସେସ୍ ଅନୁମତି ଦିଅନ୍ତୁ"
@@ -618,6 +627,14 @@ msgstr "ଆପଣଙ୍କର ପାଇପଲାଇନରେ ଆବେଦନ ଯ
 msgid "Application Copilot"
 msgstr "ଆବେଦନ କପିଲଟ୍ |"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "ସମୟ ସହିତ ଆବେଦନଗୁଡ଼ିକ"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "ପ୍ରତି ସପ୍ତାହରେ ପଠାଯାଇଥିବା ଆବେଦନ (ଗତ 8 ସପ୍ତାହ)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "ମୁଁ ମୋର ରେଜ୍ୟୁମେକୁ PDF କୁ ନିର�
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "ଫଟୋ କ୍ରପ୍ କରନ୍ତୁ"
 msgid "CSV data"
 msgstr "CSV ତଥ୍ୟ |"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "ବର୍ତ୍ତମାନର ପାସୱାର୍ଡ"
@@ -1793,6 +1819,14 @@ msgstr "ଡାଉନଲୋଡ୍"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "ଆପଣଙ୍କର ପ୍ରୋଫାଇଲ୍ ଏବଂ ପ୍ରତ୍ୟେକ ରିଜ୍ୟୁମ୍ ସମେତ ଆପଣଙ୍କର ସମସ୍ତ ଡାଟାର ଏକ କପିକୁ ଏକ JSON ଫାଇଲ୍ ଭାବରେ ଡାଉନଲୋଡ୍ କରନ୍ତୁ।"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0} ରେ ମେୟାଦ ସମାପ୍ତ ହେବ"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "ନିର୍ଯ୍ୟାତ"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "କଣ ଲେଖିବେ ନିଶ୍ଚିତ ନୁହଁନ୍ତି
 msgid "Note"
 msgstr "ଟିପ୍ପଣୀ"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "ଆପଣଙ୍କ ରେଜ୍ୟୁମେକୁ ଗୋଟିଏ ନା
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "ଶୂନ୍ୟରୁ ଆପଣଙ୍କ ରେଜ୍ୟୁମେ ତିଆରି କରିବା ଆରମ୍ଭ କରନ୍ତୁ"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "ଜୁମ୍ ଆଉଟ୍ କରନ୍ତୁ"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "ଜୁଲୁ"
-

--- a/apps/web/locales/pl-PL.po
+++ b/apps/web/locales/pl-PL.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" i pełna oś czasu zostaną trwale usunięte. Tej operacj
 msgid "(opens in new tab)"
 msgstr "(otwiera się w nowej karcie)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Dostawcy sztucznej inteligencji wymagają skonfigurowania parametrów RE
 msgid "Albanian"
 msgstr "Albański"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Zezwól na publiczny dostęp"
@@ -618,6 +627,14 @@ msgstr "Aplikacja dodana do Twojego procesu."
 msgid "Application Copilot"
 msgstr "Aplikacja Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Aplikacje w czasie"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Aplikacje wysłane tygodniowo (ostatnie 8 tygodni)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Czy mogę wyeksportować swoje CV do PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Przytnij zdjęcie"
 msgid "CSV data"
 msgstr "Dane CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Obecne hasło"
@@ -1793,6 +1819,14 @@ msgstr "Pobierz"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Pobierz kopię wszystkich swoich danych, łącznie z profilem i każdym CV, w postaci pliku JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Wygasa dnia {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Eksportuj"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nie wiesz co napisać?"
 msgid "Note"
 msgstr "Notatka"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Zacznij tworzyć swoje CV, nadając mu nazwę."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Zacznij tworzyć swoje CV od zera"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Pomniejsz"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/pt-BR.po
+++ b/apps/web/locales/pt-BR.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" e toda a sua linha do tempo serão excluídos permanentem
 msgid "(opens in new tab)"
 msgstr "(abre em uma nova aba)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Os provedores de IA exigem que REDIS_URL e ENCRYPTION_SECRET sejam confi
 msgid "Albanian"
 msgstr "Albanês"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Permitir acesso público"
@@ -618,6 +627,14 @@ msgstr "Candidatura adicionada ao seu pipeline."
 msgid "Application Copilot"
 msgstr "Copiloto de Candidaturas"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Candidaturas ao longo do tempo"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Candidaturas enviadas por semana (últimas 8 semanas)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Posso exportar meu currículo para PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Recortar imagem"
 msgid "CSV data"
 msgstr "Dados CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Senha atual"
@@ -1793,6 +1819,14 @@ msgstr "Baixar"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Faça o download de uma cópia de todos os seus dados, incluindo seu perfil e todos os seus currículos, em formato JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Expira em {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exportar"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Não sabe o que escrever?"
 msgid "Note"
 msgstr "Observação"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Comece a construir seu currículo dando um nome ao arquivo."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Comece a construir seu currículo do zero"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Diminuir zoom"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/pt-PT.po
+++ b/apps/web/locales/pt-PT.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" e a sua cronologia completa serão eliminados permanentem
 msgid "(opens in new tab)"
 msgstr "(abre num novo separador)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Os fornecedores de IA exigem que REDIS_URL e ENCRYPTION_SECRET estejam c
 msgid "Albanian"
 msgstr "Albanês"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Permitir acesso público"
@@ -618,6 +627,14 @@ msgstr "Candidatura adicionada ao seu pipeline."
 msgid "Application Copilot"
 msgstr "Copiloto de Candidaturas"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Candidaturas ao longo do tempo"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Candidaturas enviadas por semana (últimas 8 semanas)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Posso exportar o meu currículo para PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Recortar imagem"
 msgid "CSV data"
 msgstr "Dados CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Senha atual"
@@ -1793,6 +1819,14 @@ msgstr "Descarregar"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Faça o download de uma cópia de todos os seus dados, incluindo o seu perfil e todos os seus currículos, em formato JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Expira em {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exportar"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Não sabe o que escrever?"
 msgid "Note"
 msgstr "Observação"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Comece a criar seu currículo dando um nome a ele."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Comece a criar o seu currículo do zero"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Afastar"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/ro-RO.po
+++ b/apps/web/locales/ro-RO.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" și istoricul său complet vor fi șterse definitiv. Acea
 msgid "(opens in new tab)"
 msgstr "(se deschide într-o filă nouă)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Furnizorii de inteligență artificială necesită configurarea REDIS_UR
 msgid "Albanian"
 msgstr "Albaneză"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Permite acces public"
@@ -618,6 +627,14 @@ msgstr "Candidatură adăugată în fluxul dvs."
 msgid "Application Copilot"
 msgstr "Copilot pentru candidaturi"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Candidaturi în timp"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Candidaturi trimise pe săptămână (ultimele 8 săptămâni)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Pot să-mi export CV-ul în PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Decupează imaginea"
 msgid "CSV data"
 msgstr "date CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Parolă curentă"
@@ -1793,6 +1819,14 @@ msgstr "Descarcă"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Descarcă o copie a tuturor datelor tale, inclusiv profilul și fiecare CV, ca fișier JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Expiră la {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exportă"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nu ești sigur ce să scrii?"
 msgid "Note"
 msgstr "Notă"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Începeți să vă creați CV-ul dându-i un nume."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Începeți să vă creați CV-ul de la zero"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Micșorează"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/ru-RU.po
+++ b/apps/web/locales/ru-RU.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" и вся хронология будут безвозв�
 msgid "(opens in new tab)"
 msgstr "(открывается в новой вкладке)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Для работы с системами искусственного �
 msgid "Albanian"
 msgstr "Албанский"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Разрешить публичный доступ"
@@ -618,6 +627,14 @@ msgstr "Заявка добавлена в вашу воронку."
 msgid "Application Copilot"
 msgstr "Копилот для заявок"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Заявки во времени"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Заявки, отправленные за неделю (последние 8 недель)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Могу ли я экспортировать свое резюме в P
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Обрезанное изображение"
 msgid "CSV data"
 msgstr "CSV-данные"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Текущий пароль"
@@ -1793,6 +1819,14 @@ msgstr "Скачать"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Скачайте копию всех своих данных, включая ваш профиль и все резюме, в формате JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Истекает {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Экспорт"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Не знаете, что написать?"
 msgid "Note"
 msgstr "Примечание"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Начните составлять свое резюме, дав ему
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Начните делать свое резюме с нуля"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Уменьшить"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Зулу"
-

--- a/apps/web/locales/sk-SK.po
+++ b/apps/web/locales/sk-SK.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" a celá časová os budú natrvalo odstránené. Túto ak
 msgid "(opens in new tab)"
 msgstr "(otvorí sa na novej karte)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Poskytovatelia umelej inteligencie vyžadujú konfiguráciu REDIS_URL a 
 msgid "Albanian"
 msgstr "Albánčina"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Povoliť verejný prístup"
@@ -618,6 +627,14 @@ msgstr "Žiadosť bola pridaná do vášho procesu."
 msgid "Application Copilot"
 msgstr "Kopilot žiadostí"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Žiadosti v čase"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Žiadosti odoslané za týždeň (posledných 8 týždňov)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Môžem svoj životopis exportovať do PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Orezať obrázok"
 msgid "CSV data"
 msgstr "údaje CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Aktuálne heslo"
@@ -1793,6 +1819,14 @@ msgstr "Stiahnuť"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Stiahnite si kópiu všetkých svojich údajov vrátane profilu a každého životopisu ako súbor JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Platnosť uplynie {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Export"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nie ste si istí, čo napísať?"
 msgid "Note"
 msgstr "Poznámka"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Začni vytvárať svoj životopis tým, že mu dáš názov."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Začni vytvárať svoj životopis od nuly"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Oddialiť"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/sl-SI.po
+++ b/apps/web/locales/sl-SI.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" in celotna časovnica bosta trajno izbrisana. Tega ni mog
 msgid "(opens in new tab)"
 msgstr "(odpre se v novem zavihku)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Ponudniki umetne inteligence zahtevajo konfiguracijo REDIS_URL in ENCRYP
 msgid "Albanian"
 msgstr "Albanščina"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Dovoli javni dostop"
@@ -618,6 +627,14 @@ msgstr "Prijava je dodana v vaš postopek."
 msgid "Application Copilot"
 msgstr "Copilot za prijave"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Prijave skozi čas"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Prijave, poslane na teden (zadnjih 8 tednov)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Ali lahko izvozite svoj življenjepis v PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Obrezovanje slike"
 msgid "CSV data"
 msgstr "podatki CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Trenutno geslo"
@@ -1793,6 +1819,14 @@ msgstr "Prenesi"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Prenesite kopijo vseh svojih podatkov, vključno s profilom in vsakim življenjepisom, kot datoteko JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Poteče {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Izvozi"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Niste prepričani, kaj naj napišete?"
 msgid "Note"
 msgstr "Opomba"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Začnite graditi svoj življenjepis tako, da mu dodelite ime."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Začnite graditi svoj življenjepis iz nič"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Oddalji"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zuluščina"
-

--- a/apps/web/locales/sq-AL.po
+++ b/apps/web/locales/sq-AL.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" dhe e gjithë kronologjia e saj do të fshihen përgjithm
 msgid "(opens in new tab)"
 msgstr "(hapet në skedë të re)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Ofruesit e inteligjencës artificiale kërkojnë që REDIS_URL dhe ENCRY
 msgid "Albanian"
 msgstr "Shqip"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Lejo akses publik"
@@ -618,6 +627,14 @@ msgstr "Aplikimi u shtua në procesin tuaj."
 msgid "Application Copilot"
 msgstr "Kopilot i aplikimeve"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Aplikimet me kalimin e kohës"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Aplikimet e dërguara për javë (8 javët e fundit)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "A mund ta eksportoj CV-në time në PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Prit foton"
 msgid "CSV data"
 msgstr "Të dhënat CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Fjalëkalimi aktual"
@@ -1793,6 +1819,14 @@ msgstr "Shkarko"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Shkarkoni një kopje të të gjitha të dhënave tuaja, duke përfshirë profilin tuaj dhe çdo CV, si skedar JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Skadon më {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exporto"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nuk jeni i sigurt se çfarë të shkruani?"
 msgid "Note"
 msgstr "Shënim"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Filloni të ndërtoni CV-në tuaj duke i dhënë një emër."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Filloni të ndërtoni CV-në tuaj nga e para"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Zvogëlo"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/sr-SP.po
+++ b/apps/web/locales/sr-SP.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" и цела временска линија биће тр
 msgid "(opens in new tab)"
 msgstr "(отвара се у новом језичку)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Добављачи вештачке интелигенције захт�
 msgid "Albanian"
 msgstr "Албански"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Дозволи јавни приступ"
@@ -618,6 +627,14 @@ msgstr "Пријава је додата у ваш процес."
 msgid "Application Copilot"
 msgstr "Copilot за пријаве"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Пријаве током времена"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Пријаве послате недељно (последњих 8 недеља)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Могу ли да извезем свој резиме у PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Обрезивање слике"
 msgid "CSV data"
 msgstr "ЦСВ подаци"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Тренутна лозинка"
@@ -1793,6 +1819,14 @@ msgstr "Преузми"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Преузмите копију свих ваших података, укључујући ваш профил и сваки животопис, као JSON датотеку."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Истиче {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Извоз"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Нисте сигурни шта да напишете?"
 msgid "Note"
 msgstr "Напомена"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Почните да креирате свој резиме тако шт
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Почните да креирате свој резиме од нуле"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Умањи"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Зулу"
-

--- a/apps/web/locales/sv-SE.po
+++ b/apps/web/locales/sv-SE.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" och hela tidslinjen tas bort permanent. Detta går inte a
 msgid "(opens in new tab)"
 msgstr "(öppnas i ny flik)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI-leverantörer kräver att REDIS_URL och ENCRYPTION_SECRET konfigurera
 msgid "Albanian"
 msgstr "Albanska"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Tillåt offentlig åtkomst"
@@ -618,6 +627,14 @@ msgstr "Ansökan har lagts till i din pipeline."
 msgid "Application Copilot"
 msgstr "Ansökningsassistent"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Ansökningar över tid"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Ansökningar skickade per vecka (senaste 8 veckorna)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Kan jag exportera mitt CV till PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Beskär bild"
 msgid "CSV data"
 msgstr "CSV-data"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Nuvarande lösenord"
@@ -1793,6 +1819,14 @@ msgstr "Ladda ner"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Ladda ner en kopia av all din data, inklusive din profil och alla CV, som en JSON-fil."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Förfaller den {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Exportera"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Osäker på vad du ska skriva?"
 msgid "Note"
 msgstr "Notering"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Börja bygga ditt CV genom att ge det ett namn."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Börja bygga ditt CV från grunden"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Zooma ut"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/ta-IN.po
+++ b/apps/web/locales/ta-IN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" மற்றும் அதன் முழு கால
 msgid "(opens in new tab)"
 msgstr "(புதிய தாவலில் திறக்கிறது)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI வழங்குநர்களுக்கு REDIS_URL மற்�
 msgid "Albanian"
 msgstr "அல்பேனியன்"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "பொது அணுகலை அனுமதிக்கவும்"
@@ -618,6 +627,14 @@ msgstr "உங்கள் பைப்லைனில் விண்ணப்�
 msgid "Application Copilot"
 msgstr "விண்ணப்ப காபிலட்"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "காலப்போக்கில் விண்ணப்பங்�
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "வாரத்திற்கு அனுப்பப்பட்ட விண்ணப்பங்கள் (கடைசி 8 வாரங்கள்)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "என் ரெஸ்யூமியை PDF ஆக ஏற்றும�
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "பயிர் படம்"
 msgid "CSV data"
 msgstr "CSV தரவு"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "தற்போதைய கடவுச்சொல்"
@@ -1793,6 +1819,14 @@ msgstr "பதிவிறக்கு"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "உங்கள் சுயவிவரம் மற்றும் ஒவ்வொரு ரெஸ்யூம் உட்பட, உங்களின் அனைத்துத் தரவுகளின் நகலையும் ஒரு JSON கோப்பாகப் பதிவிறக்கம் செய்துகொள்ளுங்கள்."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0} அன்று காலாவதியாகும்"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "ஏற்றுமதி"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "என்ன எழுதுவது என்று தெரியவ
 msgid "Note"
 msgstr "குறிப்பு"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "ஒரு பெயர் கொடுத்து உங்கள் �
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "அடிப்படையில் இருந்து உங்கள் ரெஸ்யூமியை உருவாக்கத் தொடங்குங்கள்"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "சிறிதாக்கு"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "ஜூலு"
-

--- a/apps/web/locales/te-IN.po
+++ b/apps/web/locales/te-IN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" మరియు దాని పూర్తి టైమ
 msgid "(opens in new tab)"
 msgstr "(కొత్త ట్యాబ్‌లో తెరవబడుతుంది)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI ప్రొవైడర్లకు REDIS_URL మరియు ENCRYP
 msgid "Albanian"
 msgstr "అల్బేనియన్"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "ప్రజా యాక్సెస్‌ని అనుమతించండి"
@@ -618,6 +627,14 @@ msgstr "దరఖాస్తు మీ పైప్‌లైన్‌కు జ
 msgid "Application Copilot"
 msgstr "దరఖాస్తు కోపైలట్"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "కాలక్రమంలో దరఖాస్తులు"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "వారానికి పంపిన దరఖాస్తులు (చివరి 8 వారాలు)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "నేను నా రిజ్యూమ్‌ని PDFగా ఎగ�
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "చిత్రాన్ని కత్తిరించండి"
 msgid "CSV data"
 msgstr "CSV డేటా"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "ప్రస్తుత పాస్‌వర్డ్"
@@ -1793,6 +1819,14 @@ msgstr "డౌన్‌లోడ్ చేయండి"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "మీ ప్రొఫైల్ మరియు ప్రతి రెజ్యూమెతో సహా మీ మొత్తం డేటా కాపీని JSON ఫైల్‌గా డౌన్‌లోడ్ చేసుకోండి."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "{0}న గడువు ముగుస్తుంది"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "ఎగుమతి"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "ఏం రాయాలో తెలియడం లేదా?"
 msgid "Note"
 msgstr "గమనిక"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "మీ రెజ్యూమేను పేరు పెట్టడం
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "స్క్రాచ్ నుండి మీ రెజ్యూమే నిర్మించడం ప్రారంభించండి"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "జూమ్ అవుట్ చేయండి"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "జులు"
-

--- a/apps/web/locales/th-TH.po
+++ b/apps/web/locales/th-TH.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" และไทม์ไลน์ทั้งหมดจ
 msgid "(opens in new tab)"
 msgstr "(เปิดในแท็บใหม่)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "ผู้ให้บริการ AI ต้องการให้�
 msgid "Albanian"
 msgstr "แอลเบเนีย"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "อนุญาตให้เข้าถึงแบบสาธารณะ"
@@ -618,6 +627,14 @@ msgstr "เพิ่มใบสมัครไปยังไปป์ไลน
 msgid "Application Copilot"
 msgstr "โคไพลอตใบสมัคร"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "ใบสมัครตามเวลา"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "ใบสมัครที่ส่งต่อสัปดาห์ (8 สัปดาห์ล่าสุด)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "ฉันสามารถส่งออกเรซูเม่ขอ
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "รูปภาพครอป"
 msgid "CSV data"
 msgstr "ข้อมูล CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "รหัสผ่านเดิม"
@@ -1793,6 +1819,14 @@ msgstr "ดาวน์โหลด"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "ดาวน์โหลดสำเนาข้อมูลทั้งหมดของคุณ รวมถึงข้อมูลส่วนตัวและประวัติการทำงานทั้งหมด ในรูปแบบไฟล์ JSON"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "หมดอายุเมื่อ {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "ส่งออก"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "ไม่แน่ใจว่าจะเขียนอะไรดี
 msgid "Note"
 msgstr "หมายเหตุ"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "เริ่มสร้างเรซูเม่ของคุณด
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "เริ่มสร้างเรซูเม่ตั้งแต่ต้น"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "ซูมออก"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "ซูลู"
-

--- a/apps/web/locales/tr-TR.po
+++ b/apps/web/locales/tr-TR.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" ve tüm zaman çizelgesi kalıcı olarak silinecek. Bu i�
 msgid "(opens in new tab)"
 msgstr "(yeni sekmede açılır)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Yapay zeka sağlayıcılarının REDIS_URL ve ENCRYPTION_SECRET'in yapı
 msgid "Albanian"
 msgstr "Arnavutça"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Herkese Açık Erişime İzin Ver"
@@ -618,6 +627,14 @@ msgstr "Başvuru hattınıza eklendi."
 msgid "Application Copilot"
 msgstr "Başvuru Copilot'u"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Zamana göre başvurular"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Haftalık gönderilen başvurular (son 8 hafta)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Özgeçmişimi PDF olarak dışa aktarabilir miyim?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Kırpılmış resim"
 msgid "CSV data"
 msgstr "CSV verileri"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Geçerli Parola"
@@ -1793,6 +1819,14 @@ msgstr "İndir"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Profiliniz ve tüm özgeçmişleriniz de dahil olmak üzere tüm verilerinizin bir kopyasını JSON dosyası olarak indirin."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Bitiş tarihi {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Dışa aktar"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Ne yazacağınızdan emin değil misiniz?"
 msgid "Note"
 msgstr "Not"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Bir ad vererek özgeçmişinizi oluşturmaya başlayın."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Özgeçmişinizi sıfırdan oluşturmaya başlayın"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Uzaklaştır"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/uk-UA.po
+++ b/apps/web/locales/uk-UA.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" і всю хронологію буде назавжди 
 msgid "(opens in new tab)"
 msgstr "(відкриється у новій вкладці)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Постачальники штучного інтелекту вима�
 msgid "Albanian"
 msgstr "Албанська"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Дозволити Загальний Доступ"
@@ -618,6 +627,14 @@ msgstr "Заявку додано до вашої воронки."
 msgid "Application Copilot"
 msgstr "Копілот заявки"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Заявки з часом"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Заявки, надіслані за тиждень (останні 8 тижнів)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Чи можу я експортувати своє резюме у PDF?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Обрізати зображення"
 msgid "CSV data"
 msgstr "Дані CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Поточний пароль"
@@ -1793,6 +1819,14 @@ msgstr "Завантажити"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Завантажте копію всіх своїх даних, включаючи ваш профіль та кожне резюме, у форматі JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Закінчується {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Експорт"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Не знаєте, що написати?"
 msgid "Note"
 msgstr "Примітка"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Почніть створення резюме з назви."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Почати створення резюме з нуля"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Зменшити"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Зулу"
-

--- a/apps/web/locales/uz-UZ.po
+++ b/apps/web/locales/uz-UZ.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" va uning to‘liq xronologiyasi butunlay o‘chiriladi. B
 msgid "(opens in new tab)"
 msgstr "(yangi tabda ochiladi)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Sun'iy intellekt provayderlari REDIS_URL va ENCRYPTION_SECRET ni sozlash
 msgid "Albanian"
 msgstr "Alban tili"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Ommaviy kirishga ruxsat berish"
@@ -618,6 +627,14 @@ msgstr "Ariza pipeline'ingizga qo'shildi."
 msgid "Application Copilot"
 msgstr "Ariza Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Vaqt bo‘yicha arizalar"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Haftasiga yuborilgan arizalar (so‘nggi 8 hafta)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Rezyumeni PDF ga eksport qila olamanmi?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Rasmni qirqish"
 msgid "CSV data"
 msgstr "CSV ma'lumotlari"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Joriy parol"
@@ -1793,6 +1819,14 @@ msgstr "Yuklab olish"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Profilingiz va har bir rezyumeni o'z ichiga olgan barcha ma'lumotlaringizning nusxasini JSON fayli sifatida yuklab oling."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Tugash sanasi: {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Eksport"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Nima yozishni bilmayapsizmi?"
 msgid "Note"
 msgstr "Eslatma"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Rezyumeni yaratishni unga nom berishdan boshlang."
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Rezyumeni nolldan boshlang va yarating"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Kichraytirish"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/vi-VN.po
+++ b/apps/web/locales/vi-VN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" và toàn bộ dòng thời gian sẽ bị xóa vĩnh vi�
 msgid "(opens in new tab)"
 msgstr "(mở ở tab mới)"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "Các nhà cung cấp AI yêu cầu cấu hình REDIS_URL và ENCRYPTION_
 msgid "Albanian"
 msgstr "Tiếng Albania"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "Cho phép truy cập công khai"
@@ -618,6 +627,14 @@ msgstr "Đã thêm hồ sơ ứng tuyển vào quy trình của bạn."
 msgid "Application Copilot"
 msgstr "Copilot hồ sơ ứng tuyển"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "Đơn ứng tuyển theo thời gian"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "Đơn ứng tuyển đã gửi mỗi tuần (8 tuần gần nhất)"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "Tôi có thể xuất sơ yếu lý lịch của mình ra PDF không?"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "Ảnh cắt"
 msgid "CSV data"
 msgstr "Dữ liệu CSV"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "Mật khẩu hiện tại"
@@ -1793,6 +1819,14 @@ msgstr "Tải về"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "Tải xuống bản sao tất cả dữ liệu của bạn, bao gồm hồ sơ và mọi CV, dưới dạng tệp JSON."
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "Hết hạn vào {0}"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "Xuất"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "Không biết nên viết gì?"
 msgid "Note"
 msgstr "Lưu ý"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "Bắt đầu xây dựng hồ sơ của bạn bằng cách đặt tên c
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "Bắt đầu xây dựng hồ sơ từ đầu"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "Thu nhỏ"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
-

--- a/apps/web/locales/zh-CN.po
+++ b/apps/web/locales/zh-CN.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" 及其完整时间线将被永久删除。此操作无法
 msgid "(opens in new tab)"
 msgstr "（在新标签页中打开）"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI 提供商需要配置 REDIS_URL 和 ENCRYPTION_SECRET。"
 msgid "Albanian"
 msgstr "阿尔巴尼亚语"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "允许公开访问"
@@ -618,6 +627,14 @@ msgstr "申请已添加到你的流程。"
 msgid "Application Copilot"
 msgstr "申请 Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "申请随时间变化"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "每周发送的申请（最近 8 周）"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "我可以把简历导出为 PDF 吗？"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "裁剪图片"
 msgid "CSV data"
 msgstr "CSV 数据"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "当前密码"
@@ -1793,6 +1819,14 @@ msgstr "下载"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "下载包含您的个人资料和所有简历在内的所有数据的副本，格式为 JSON 文件。"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "将于 {0} 过期"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "导出"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "不知道该写些什么？"
 msgid "Note"
 msgstr "注意"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "从给简历命名开始构建你的简历。"
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "从头开始构建你的简历"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "缩小"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "祖鲁语"
-

--- a/apps/web/locales/zh-TW.po
+++ b/apps/web/locales/zh-TW.po
@@ -32,6 +32,11 @@ msgstr "\"{0} · {1}\" 及其完整時間軸將被永久刪除。此操作無法
 msgid "(opens in new tab)"
 msgstr "（在新分頁中開啟）"
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -519,6 +524,10 @@ msgstr "AI 供應商需要配置 REDIS_URL 和 ENCRYPTION_SECRET。"
 msgid "Albanian"
 msgstr "阿爾巴尼亞語"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr "允許公開存取"
@@ -618,6 +627,14 @@ msgstr "應徵紀錄已加入你的流程。"
 msgid "Application Copilot"
 msgstr "應徵 Copilot"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -645,6 +662,10 @@ msgstr "申請隨時間變化"
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
 msgstr "每週送出的申請（最近 8 週）"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
+msgstr ""
 
 #: src/features/applications/components/table-view.tsx
 msgid "Applied"
@@ -921,6 +942,7 @@ msgstr "我可以把履歷匯出成 PDF 嗎？"
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1520,6 +1542,10 @@ msgstr "裁切圖片"
 msgid "CSV data"
 msgstr "CSV 資料"
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr "目前密碼"
@@ -1793,6 +1819,14 @@ msgstr "下載"
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
 msgstr "下載包含您的個人資料和所有簡歷在內的所有資料的副本，格式為 JSON 檔案。"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
+msgstr ""
 
 #. Primary action in the builder header to open resume download options
 #: src/routes/builder/$resumeId/-components/header.tsx
@@ -2075,6 +2109,14 @@ msgstr "將於 {0} 到期"
 #: src/libs/resume/section.tsx
 msgid "Export"
 msgstr "導出"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
+msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
 msgid "Export Data"
@@ -3534,6 +3576,7 @@ msgstr "不知道該寫些什麼？"
 msgid "Note"
 msgstr "注意"
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5037,6 +5080,10 @@ msgstr "為您的履歷命名，開始建立您的履歷。"
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
 msgstr "從零開始建立您的履歷"
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
+msgstr ""
 
 #: src/features/ats-checker/messages.ts
 msgid "Start each one with a concrete verb: built, led, reduced, migrated."
@@ -6569,4 +6616,3 @@ msgstr "縮小"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "祖魯語"
-

--- a/apps/web/locales/zu-ZA.po
+++ b/apps/web/locales/zu-ZA.po
@@ -27,6 +27,11 @@ msgstr ""
 msgid "(opens in new tab)"
 msgstr ""
 
+#. placeholder {0}: selected.length
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "{0, plural, one {# application to export} other {# applications to export}}"
+msgstr ""
+
 #. placeholder {0}: section.items.length
 #: src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
 msgid "{0, plural, one {# item} other {# items}}"
@@ -514,6 +519,10 @@ msgstr ""
 msgid "Albanian"
 msgstr ""
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "All applications (including archived)"
+msgstr ""
+
 #: src/routes/builder/$resumeId/-sidebar/right/sections/sharing.tsx
 msgid "Allow Public Access"
 msgstr ""
@@ -613,6 +622,14 @@ msgstr ""
 msgid "Application Copilot"
 msgstr ""
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date from"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Application date to"
+msgstr ""
+
 #: src/features/applications/components/application-actions-menu.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 msgid "Application deleted."
@@ -639,6 +656,10 @@ msgstr ""
 
 #: src/features/applications/components/insights-view.tsx
 msgid "Applications sent per week (last 8 weeks)"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Applications to export"
 msgstr ""
 
 #: src/features/applications/components/table-view.tsx
@@ -916,6 +937,7 @@ msgstr ""
 #: src/dialogs/resume/sections/section-item-dialog.tsx
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
+#: src/features/applications/components/export-applications-sheet.tsx
 #: src/features/applications/components/import-applications-sheet.tsx
 #: src/features/settings/integrations/components/ai-section.tsx
 #: src/features/settings/pages/account.tsx
@@ -1515,6 +1537,10 @@ msgstr ""
 msgid "CSV data"
 msgstr ""
 
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Current filters"
+msgstr ""
+
 #: src/dialogs/auth/change-password.tsx
 msgid "Current Password"
 msgstr ""
@@ -1787,6 +1813,14 @@ msgstr ""
 
 #: src/features/settings/pages/account.tsx
 msgid "Download a copy of all your data, including your profile and every resume, as a JSON file."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download application details, contacts, notes, and timeline history as CSV."
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Download CSV"
 msgstr ""
 
 #. Primary action in the builder header to open resume download options
@@ -2069,6 +2103,14 @@ msgstr ""
 
 #: src/libs/resume/section.tsx
 msgid "Export"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Export applications"
+msgstr ""
+
+#: src/routes/dashboard/applications/index.tsx
+msgid "Export CSV"
 msgstr ""
 
 #: src/features/command-palette/pages/navigation.tsx
@@ -3529,6 +3571,7 @@ msgstr ""
 msgid "Note"
 msgstr ""
 
+#: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/libs/resume/section.tsx
 msgid "Notes"
@@ -5031,6 +5074,10 @@ msgstr ""
 #: src/routes/dashboard/resumes/-components/cards/create-card.tsx
 #: src/routes/dashboard/resumes/-components/list-view.tsx
 msgid "Start building your resume from scratch"
+msgstr ""
+
+#: src/features/applications/components/export-applications-sheet.tsx
+msgid "Start date must be on or before end date."
 msgstr ""
 
 #: src/features/ats-checker/messages.ts

--- a/apps/web/src/features/applications/components/export-applications-sheet.tsx
+++ b/apps/web/src/features/applications/components/export-applications-sheet.tsx
@@ -1,0 +1,120 @@
+import type { ApplicationExportOptions } from "../csv";
+import type { Application } from "../types";
+import { t } from "@lingui/core/macro";
+import { Plural, Trans } from "@lingui/react/macro";
+import { useId, useState } from "react";
+import { Button } from "@reactive-resume/ui/components/button";
+import { Input } from "@reactive-resume/ui/components/input";
+import { Label } from "@reactive-resume/ui/components/label";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+} from "@reactive-resume/ui/components/sheet";
+import { downloadWithAnchor } from "@reactive-resume/utils/file";
+import { Combobox } from "@/components/ui/combobox";
+import { exportApplicationsCsv, selectApplicationsForExport } from "../csv";
+
+type ExportApplicationsSheetProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	applications: Application[];
+	filtered: Application[];
+};
+
+export function ExportApplicationsSheet({ open, onOpenChange, applications, filtered }: ExportApplicationsSheetProps) {
+	const id = useId();
+	const [scope, setScope] = useState<ApplicationExportOptions["scope"]>("filtered");
+	const [from, setFrom] = useState("");
+	const [to, setTo] = useState("");
+	const validRange = !from || !to || from <= to;
+	const selected = selectApplicationsForExport(applications, filtered, { scope, from, to });
+
+	return (
+		<Sheet open={open} onOpenChange={onOpenChange}>
+			<SheetContent side="right" className="w-full gap-0 data-[side=right]:sm:max-w-lg">
+				<SheetHeader>
+					<SheetTitle>
+						<Trans>Export applications</Trans>
+					</SheetTitle>
+					<SheetDescription>
+						<Trans>Download application details, contacts, notes, and timeline history as CSV.</Trans>
+					</SheetDescription>
+				</SheetHeader>
+				<form
+					className="flex min-h-0 flex-1 flex-col"
+					onSubmit={(event) => {
+						event.preventDefault();
+						if (!validRange || selected.length === 0) return;
+						const blob = new Blob([exportApplicationsCsv(selected)], { type: "text/csv;charset=utf-8" });
+						downloadWithAnchor(blob, `applications-${new Date().toISOString().slice(0, 10)}.csv`);
+						onOpenChange(false);
+					}}
+				>
+					<div className="flex flex-1 flex-col gap-4 overflow-y-auto px-4 pb-4">
+						<div className="space-y-1.5">
+							<Label htmlFor={`${id}-scope`}>
+								<Trans>Applications to export</Trans>
+							</Label>
+							<Combobox
+								id={`${id}-scope`}
+								className="w-full"
+								value={scope}
+								onValueChange={(value) => value && setScope(value)}
+								options={[
+									{ value: "filtered", label: t`Current filters` },
+									{ value: "all", label: t`All applications (including archived)` },
+								]}
+							/>
+						</div>
+						<div className="grid grid-cols-2 items-end gap-3">
+							<div className="space-y-1.5">
+								<Label htmlFor={`${id}-from`}>
+									<Trans>Application date from</Trans>
+								</Label>
+								<Input
+									id={`${id}-from`}
+									type="date"
+									value={from}
+									max={to || undefined}
+									onChange={(event) => setFrom(event.target.value)}
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor={`${id}-to`}>
+									<Trans>Application date to</Trans>
+								</Label>
+								<Input
+									id={`${id}-to`}
+									type="date"
+									value={to}
+									min={from || undefined}
+									onChange={(event) => setTo(event.target.value)}
+								/>
+							</div>
+						</div>
+						{!validRange && (
+							<p role="alert" className="text-destructive text-sm">
+								<Trans>Start date must be on or before end date.</Trans>
+							</p>
+						)}
+						<p className="text-muted-foreground text-sm">
+							<Plural value={selected.length} one="# application to export" other="# applications to export" />
+						</p>
+					</div>
+					<SheetFooter className="flex-row justify-end gap-2">
+						<Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+							<Trans>Cancel</Trans>
+						</Button>
+						<Button type="submit" disabled={!validRange || selected.length === 0}>
+							<Trans>Download CSV</Trans>
+						</Button>
+					</SheetFooter>
+				</form>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/apps/web/src/features/applications/csv-export.test.ts
+++ b/apps/web/src/features/applications/csv-export.test.ts
@@ -91,6 +91,18 @@ describe("application CSV export", () => {
 		const value = `${company},"next"`;
 		expect(exportedRecord({ ...application, company }).Company).toBe(`'${company}`);
 		expect(exportedRecord({ ...application, company: value }).Company).toBe(`'${value}`);
+		// The apostrophe is the export's own guard, so re-importing must not keep it.
+		const csv = exportApplicationsCsv([{ ...application, company, notes: company }]);
+		expect(mapCsvToApplications(parseCsv(csv)).rows[0]).toMatchObject({
+			company: company.trim(),
+			notes: company.trim(),
+		});
+	});
+
+	it("keeps an apostrophe the user typed themselves", () => {
+		expect(mapCsvToApplications(parseCsv(`Company,Role\r\n"'Tis Inc","Engineer"\r\n`)).rows).toEqual([
+			{ company: "'Tis Inc", role: "Engineer" },
+		]);
 	});
 
 	it("exports headers for empty results and empty optional values without inventing history", () => {

--- a/apps/web/src/features/applications/csv-export.test.ts
+++ b/apps/web/src/features/applications/csv-export.test.ts
@@ -105,6 +105,18 @@ describe("application CSV export", () => {
 		]);
 	});
 
+	it("keeps an authored apostrophe before formula-like text in ordinary imports", () => {
+		expect(mapCsvToApplications(parseCsv(`Company,Role\r\n"'=1+1","Engineer"\r\n`)).rows).toEqual([
+			{ company: "'=1+1", role: "Engineer" },
+		]);
+	});
+
+	it("round-trips tags containing supported legacy delimiters", () => {
+		const tags = ["customer, success", "typescript|react", "remote;eu"];
+		const csv = exportApplicationsCsv([{ ...application, tags }]);
+		expect(mapCsvToApplications(parseCsv(csv)).rows[0]?.tags).toEqual(tags);
+	});
+
 	it("exports headers for empty results and empty optional values without inventing history", () => {
 		expect(parseCsv(exportApplicationsCsv([]))).toHaveLength(1);
 		expect(exportedRecord({ ...application, activity: [], contacts: [], notes: null, sourceUrl: null })).toMatchObject({

--- a/apps/web/src/features/applications/csv-export.test.ts
+++ b/apps/web/src/features/applications/csv-export.test.ts
@@ -1,0 +1,125 @@
+import type { Application } from "./types";
+import { describe, expect, it } from "vitest";
+import { exportApplicationsCsv, mapCsvToApplications, parseCsv, selectApplicationsForExport } from "./csv";
+
+const application: Application = {
+	id: "application",
+	company: 'Müller, "Partners"',
+	role: "Engineer",
+	status: "interview",
+	archived: false,
+	location: "Berlin",
+	salary: "€70,000",
+	source: "Referral",
+	sourceUrl: "https://example.com/job",
+	notes: "First line\nSecond line",
+	tags: ["remote", "typescript"],
+	contacts: [{ name: "Ada", role: "Recruiter", type: "Referral" }],
+	activity: [
+		{ id: "interview", type: "stage", stage: "interview", at: new Date("2026-08-12T12:00:00Z") },
+		{ id: "note", type: "note", text: "Called recruiter", at: new Date("2026-08-08T12:00:00Z") },
+		{ id: "applied", type: "stage", stage: "applied", at: new Date("2026-08-03T12:00:00Z") },
+	],
+	appliedAt: new Date("2026-08-03T12:00:00Z"),
+	createdAt: new Date("2026-08-01T12:00:00Z"),
+	updatedAt: new Date("2026-08-12T12:00:00Z"),
+	resumeId: null,
+	jobDescription: null,
+	matchScore: null,
+	aiMetadata: null,
+	resumeFileUrl: null,
+	resumeFileName: null,
+	coverLetterUrl: null,
+	coverLetterName: null,
+	followUpAt: null,
+	followUpNote: null,
+};
+
+function exportedRecord(value: Application) {
+	const [headers = [], values = []] = parseCsv(exportApplicationsCsv([value]));
+	return Object.fromEntries(headers.map((header, index) => [header, values[index]]));
+}
+
+describe("application CSV export", () => {
+	it("round-trips quoted Unicode, commas and multiline notes through existing import fields", () => {
+		const csv = exportApplicationsCsv([application]);
+		expect(csv.startsWith("\uFEFF")).toBe(true);
+		expect(csv).toContain('"Müller, ""Partners"""');
+		expect(csv).toContain("\r\n");
+		expect(mapCsvToApplications(parseCsv(csv)).rows).toEqual([
+			{
+				company: 'Müller, "Partners"',
+				role: "Engineer",
+				status: "interview",
+				stageEnteredAt: "2026-08-12",
+				location: "Berlin",
+				salary: "€70,000",
+				source: "Referral",
+				sourceUrl: "https://example.com/job",
+				notes: "First line\nSecond line",
+				tags: ["remote", "typescript"],
+			},
+		]);
+	});
+
+	it("preserves application date and chronological stage and note history separately", () => {
+		expect(exportedRecord(application)).toMatchObject({
+			"Application Date": "2026-08-03",
+			"Stage Date": "2026-08-12",
+			"Stage History": "Applied (2026-08-03) → Interview (2026-08-12)",
+			Timeline: "2026-08-03: Applied\n2026-08-08: Called recruiter\n2026-08-12: Interview",
+			Contacts: "Ada (Recruiter, Referral)",
+			Archived: "false",
+		});
+		expect(application.activity[0]?.id).toBe("interview");
+	});
+
+	it.each([
+		"=1+1",
+		"+1+1",
+		"-1+1",
+		"@SUM(A1)",
+		"\t=1+1",
+		"\r=1+1",
+		"\n=1+1",
+		"  =1+1",
+		"＝1+1",
+		"＋1+1",
+		"－1+1",
+		"＠SUM(A1)",
+	])("neutralizes spreadsheet formula prefix %j without introducing another cell", (company) => {
+		const value = `${company},"next"`;
+		expect(exportedRecord({ ...application, company }).Company).toBe(`'${company}`);
+		expect(exportedRecord({ ...application, company: value }).Company).toBe(`'${value}`);
+	});
+
+	it("exports headers for empty results and empty optional values without inventing history", () => {
+		expect(parseCsv(exportApplicationsCsv([]))).toHaveLength(1);
+		expect(exportedRecord({ ...application, activity: [], contacts: [], notes: null, sourceUrl: null })).toMatchObject({
+			"Stage Date": "",
+			"Stage History": "",
+			Timeline: "",
+			Contacts: "",
+			Notes: "",
+			URL: "",
+		});
+	});
+});
+
+describe("application export selection", () => {
+	const early = { ...application, id: "early", appliedAt: new Date("2026-08-02T23:59:59Z") };
+	const late = { ...application, id: "late", archived: true, appliedAt: new Date("2026-08-03T23:59:59Z") };
+	const all = [early, application, late];
+
+	it("exports exactly current filtered rows, or all rows including archived", () => {
+		expect(selectApplicationsForExport(all, [application], { scope: "filtered" })).toEqual([application]);
+		expect(selectApplicationsForExport(all, [application], { scope: "all" })).toEqual(all);
+	});
+	it("applies inclusive UTC date boundaries to selected scope without mutating source rows", () => {
+		expect(
+			selectApplicationsForExport(all, [application], { scope: "all", from: "2026-08-03", to: "2026-08-03" }),
+		).toEqual([application, late]);
+		expect(selectApplicationsForExport(all, [application], { scope: "all", to: "2026-08-02" })).toEqual([early]);
+		expect(all).toHaveLength(3);
+	});
+});

--- a/apps/web/src/features/applications/csv.ts
+++ b/apps/web/src/features/applications/csv.ts
@@ -101,6 +101,19 @@ const HEADER_ALIASES: Record<string, keyof ParsedApplication> = {
 	tags: "tags",
 };
 
+// Values a spreadsheet would evaluate as a formula: leading =, +, -, @ (and full-width variants),
+// possibly hidden behind whitespace/control characters, or a leading tab/newline.
+function isFormulaLike(value: string) {
+	return /^[\s\p{Cc}]*[=+@\-＝＋－＠]/u.test(value) || /^[\t\r\n]/.test(value);
+}
+
+// Drops the apostrophe the export adds as a CSV-injection guard, so a re-imported cell reads back
+// as the value that was exported. A user value that genuinely starts with an apostrophe is only
+// touched when the rest would also have been guarded — the same ambiguity spreadsheets have.
+function stripFormulaGuard(value: string) {
+	return value.startsWith("'") && isFormulaLike(value.slice(1)) ? value.slice(1) : value;
+}
+
 export type CsvMapResult = {
 	rows: ParsedApplication[];
 	skipped: number;
@@ -125,7 +138,7 @@ export function mapCsvToApplications(table: string[][]): CsvMapResult {
 		const record: Partial<ParsedApplication> = {};
 		fieldFor.forEach((field, i) => {
 			if (!field) return;
-			const value = (raw[i] ?? "").trim();
+			const value = stripFormulaGuard(raw[i] ?? "").trim();
 			if (!value) return;
 			if (field === "tags")
 				record.tags = value
@@ -170,7 +183,7 @@ export function selectApplicationsForExport(
 function csvCell(value: string): string {
 	// Quote every cell to contain separators/newlines. Prefix formula-triggering values,
 	// including whitespace-obscured and full-width variants, so spreadsheets read text.
-	const safe = /^[\s\p{Cc}]*[=+@\-＝＋－＠]/u.test(value) || /^[\t\r\n]/.test(value) ? `'${value}` : value;
+	const safe = isFormulaLike(value) ? `'${value}` : value;
 	return `"${safe.replaceAll('"', '""')}"`;
 }
 

--- a/apps/web/src/features/applications/csv.ts
+++ b/apps/web/src/features/applications/csv.ts
@@ -1,5 +1,6 @@
 import type { ApplicationStatus } from "@reactive-resume/schema/applications/data";
-import { applicationStatusSchema } from "@reactive-resume/schema/applications/data";
+import type { Application } from "./types";
+import { applicationStatusSchema, STAGES } from "@reactive-resume/schema/applications/data";
 
 // Minimal RFC-4180-ish CSV parser: handles quoted fields, escaped quotes (""), commas and
 // newlines inside quotes, and \r\n. Enough for spreadsheet exports; not a full streaming parser.
@@ -147,4 +148,85 @@ export function mapCsvToApplications(table: string[][]): CsvMapResult {
 	}
 
 	return { rows, skipped, headers, recognized };
+}
+
+export type ApplicationExportOptions = {
+	scope: "filtered" | "all";
+	from?: string;
+	to?: string;
+};
+
+export function selectApplicationsForExport(
+	applications: readonly Application[],
+	filtered: readonly Application[],
+	{ scope, from, to }: ApplicationExportOptions,
+): Application[] {
+	return (scope === "all" ? applications : filtered).filter((application) => {
+		const date = new Date(application.appliedAt).toISOString().slice(0, 10);
+		return (!from || date >= from) && (!to || date <= to);
+	});
+}
+
+function csvCell(value: string): string {
+	// Quote every cell to contain separators/newlines. Prefix formula-triggering values,
+	// including whitespace-obscured and full-width variants, so spreadsheets read text.
+	const safe = /^[\s\p{Cc}]*[=+@\-＝＋－＠]/u.test(value) || /^[\t\r\n]/.test(value) ? `'${value}` : value;
+	return `"${safe.replaceAll('"', '""')}"`;
+}
+
+export function exportApplicationsCsv(applications: readonly Application[]): string {
+	const headers = [
+		"Company",
+		"Role",
+		"Stage",
+		"Stage Date",
+		"Application Date",
+		"Location",
+		"Salary",
+		"Source",
+		"URL",
+		"Tags",
+		"Contacts",
+		"Notes",
+		"Stage History",
+		"Timeline",
+		"Archived",
+		"Created At",
+		"Updated At",
+	];
+	const dateOnly = (date: Date) => new Date(date).toISOString().slice(0, 10);
+	const stageLabel = (stage: ApplicationStatus) => STAGES.find((item) => item.value === stage)?.label ?? stage;
+	const rows = applications.map((application) => {
+		const timeline = [...application.activity].sort((a, b) => new Date(a.at).getTime() - new Date(b.at).getTime());
+		const stages = timeline.filter((entry) => entry.type === "stage");
+		const currentStage = stages.findLast((entry) => entry.stage === application.status);
+		return [
+			application.company,
+			application.role,
+			application.status,
+			currentStage ? dateOnly(currentStage.at) : "",
+			dateOnly(application.appliedAt),
+			application.location ?? "",
+			application.salary ?? "",
+			application.source ?? "",
+			application.sourceUrl ?? "",
+			application.tags.join(";"),
+			application.contacts
+				.map(({ name, role, type }) => {
+					const details = [role, type].filter(Boolean).join(", ");
+					return details ? `${name} (${details})` : name;
+				})
+				.join("\n"),
+			application.notes ?? "",
+			stages.map((entry) => `${stageLabel(entry.stage)} (${dateOnly(entry.at)})`).join(" → "),
+			timeline
+				.map((entry) => `${dateOnly(entry.at)}: ${entry.type === "stage" ? stageLabel(entry.stage) : entry.text}`)
+				.join("\n"),
+			String(application.archived),
+			new Date(application.createdAt).toISOString(),
+			new Date(application.updatedAt).toISOString(),
+		];
+	});
+	// UTF-8 BOM lets spreadsheet apps recognize international names without an import wizard.
+	return `\uFEFF${[headers, ...rows].map((row) => row.map(csvCell).join(",")).join("\r\n")}\r\n`;
 }

--- a/apps/web/src/features/applications/csv.ts
+++ b/apps/web/src/features/applications/csv.ts
@@ -114,6 +114,22 @@ function stripFormulaGuard(value: string) {
 	return value.startsWith("'") && isFormulaLike(value.slice(1)) ? value.slice(1) : value;
 }
 
+function parseTags(value: string) {
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (Array.isArray(parsed) && parsed.every((tag): tag is string => typeof tag === "string")) {
+			return parsed.map((tag) => tag.trim()).filter(Boolean);
+		}
+	} catch {
+		// Preserve support for existing comma, semicolon, and pipe-delimited imports.
+	}
+
+	return value
+		.split(/[;,|]/)
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
 export type CsvMapResult = {
 	rows: ParsedApplication[];
 	skipped: number;
@@ -130,6 +146,9 @@ export function mapCsvToApplications(table: string[][]): CsvMapResult {
 	const headers = headerRow.map((h) => h.trim());
 	const fieldFor = headers.map((h) => HEADER_ALIASES[h.toLowerCase()]);
 	const recognized = [...new Set(fieldFor.filter((f): f is keyof ParsedApplication => !!f))];
+	const isReactiveResumeExport = ["Stage History", "Timeline", "Archived", "Created At", "Updated At"].every((header) =>
+		headers.includes(header),
+	);
 
 	const rows: ParsedApplication[] = [];
 	let skipped = 0;
@@ -138,13 +157,10 @@ export function mapCsvToApplications(table: string[][]): CsvMapResult {
 		const record: Partial<ParsedApplication> = {};
 		fieldFor.forEach((field, i) => {
 			if (!field) return;
-			const value = stripFormulaGuard(raw[i] ?? "").trim();
+			const rawValue = raw[i] ?? "";
+			const value = (isReactiveResumeExport ? stripFormulaGuard(rawValue) : rawValue).trim();
 			if (!value) return;
-			if (field === "tags")
-				record.tags = value
-					.split(/[;,|]/)
-					.map((t) => t.trim())
-					.filter(Boolean);
+			if (field === "tags") record.tags = parseTags(value);
 			else if (field === "status") {
 				const parsed = applicationStatusSchema.safeParse(value.toLowerCase());
 				if (parsed.success) record.status = parsed.data;
@@ -223,7 +239,7 @@ export function exportApplicationsCsv(applications: readonly Application[]): str
 			application.salary ?? "",
 			application.source ?? "",
 			application.sourceUrl ?? "",
-			application.tags.join(";"),
+			application.tags.length > 0 ? JSON.stringify(application.tags) : "",
 			application.contacts
 				.map(({ name, role, type }) => {
 					const details = [role, type].filter(Boolean).join(", ");

--- a/apps/web/src/routes/dashboard/applications/index.tsx
+++ b/apps/web/src/routes/dashboard/applications/index.tsx
@@ -27,6 +27,7 @@ import { Combobox } from "@/components/ui/combobox";
 import { ApplicationDetailSheet } from "@/features/applications/components/application-detail-sheet";
 import { ApplicationFormSheet } from "@/features/applications/components/application-form-sheet";
 import { ApplicationBoard } from "@/features/applications/components/board";
+import { ExportApplicationsSheet } from "@/features/applications/components/export-applications-sheet";
 import { ImportApplicationsSheet } from "@/features/applications/components/import-applications-sheet";
 import { ApplicationInsights } from "@/features/applications/components/insights-view";
 import { ApplicationTable } from "@/features/applications/components/table-view";
@@ -68,6 +69,7 @@ function RouteComponent() {
 
 	const [addOpen, setAddOpen] = useState(false);
 	const [importOpen, setImportOpen] = useState(false);
+	const [exportOpen, setExportOpen] = useState(false);
 	const [editing, setEditing] = useState<Application | null>(null);
 	const [selected, setSelected] = useState<Application | null>(null);
 
@@ -120,11 +122,16 @@ function RouteComponent() {
 	return (
 		<div className="flex h-[calc(100dvh-2rem)] flex-col gap-4">
 			<DashboardHeader
+				className="max-sm:flex-col max-sm:gap-y-3"
 				icon={BriefcaseIcon}
 				title={t`Applications`}
 				actions={
 					!isEmpty ? (
 						<>
+							<Button size="sm" variant="outline" onClick={() => setExportOpen(true)}>
+								<DownloadSimpleIcon />
+								<Trans>Export CSV</Trans>
+							</Button>
 							<Button size="sm" variant="outline" onClick={() => setImportOpen(true)}>
 								<DownloadSimpleIcon />
 								<Trans>Import CSV</Trans>
@@ -311,6 +318,12 @@ function RouteComponent() {
 			<ApplicationFormSheet open={addOpen} onOpenChange={setAddOpen} />
 			<ApplicationFormSheet open={!!editing} application={editing} onOpenChange={(open) => !open && setEditing(null)} />
 			<ImportApplicationsSheet open={importOpen} onOpenChange={setImportOpen} />
+			<ExportApplicationsSheet
+				open={exportOpen}
+				onOpenChange={setExportOpen}
+				applications={applications ?? []}
+				filtered={filtered}
+			/>
 			<ApplicationDetailSheet
 				application={selected}
 				onOpenChange={(open) => !open && setSelected(null)}

--- a/tests/e2e/specs/applications-export.spec.ts
+++ b/tests/e2e/specs/applications-export.spec.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Pool } from "pg";
+import { createAuthenticatedContext } from "../fixtures/auth";
+import { createAccount } from "../fixtures/data";
+import { deleteE2EUser } from "../fixtures/db";
+import { expect, test } from "../fixtures/test";
+
+test("exports filtered or all owned applications with an inclusive date range", async ({
+	authPage: page,
+	account,
+	browser,
+	request,
+}, testInfo) => {
+	const foreign = createAccount(testInfo);
+	const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+	try {
+		const otherContext = await createAuthenticatedContext(
+			browser,
+			request,
+			foreign,
+			String(testInfo.project.use.baseURL),
+		);
+		await otherContext.close();
+		for (const [email, company, date, archived] of [
+			[account.email, "Alpha Company", "2026-08-03T00:00:00Z", false],
+			[account.email, "Beta Archived", "2026-08-03T23:59:59Z", true],
+			[account.email, "Gamma Later", "2026-08-04T00:00:00Z", false],
+			[foreign.email, "Foreign Secret", "2026-08-03T12:00:00Z", false],
+		] as const) {
+			await pool.query(
+				`INSERT INTO application (id,user_id,company,role,status,applied_at,archived,notes,activity)
+				 SELECT $1,id,$2,'Engineer','applied',$3,$4,$5,$6 FROM "user" WHERE email=$7`,
+				[
+					randomUUID(),
+					company,
+					date,
+					archived,
+					'Quoted "note"\nSecond line',
+					JSON.stringify([{ id: randomUUID(), type: "stage", stage: "applied", at: date }]),
+					email,
+				],
+			);
+		}
+		await page.goto("/dashboard/applications");
+		await page.getByPlaceholder("Search applications…").fill("Alpha");
+		await page.getByRole("button", { name: "Export CSV", exact: true }).click();
+		const sheet = page.getByRole("dialog", { name: "Export applications" });
+		await sheet.getByLabel("Application date from").fill("2026-08-03");
+		await sheet.getByLabel("Application date to").fill("2026-08-03");
+		await expect(sheet.getByText("1 application to export")).toBeVisible();
+		let downloadPromise = page.waitForEvent("download");
+		await sheet.getByRole("button", { name: "Download CSV" }).click();
+		let download = await downloadPromise;
+		let path = await download.path();
+		if (!path) throw new Error("CSV download was not saved");
+		let csv = await readFile(path, "utf8");
+		expect(csv).toContain('"Alpha Company"');
+		expect(csv).not.toMatch(/Beta Archived|Gamma Later|Foreign Secret/);
+		expect(csv).toContain('"Applied (2026-08-03)"');
+		expect(csv).toContain('"Quoted ""note""\nSecond line"');
+
+		await page.getByRole("button", { name: "Export CSV", exact: true }).click();
+		await sheet.getByLabel("Applications to export").click();
+		await page.getByRole("option", { name: "All applications (including archived)" }).click();
+		await expect(sheet.getByText("2 applications to export")).toBeVisible();
+		await sheet.getByLabel("Application date from").fill("2026-08-04");
+		await expect(sheet.getByRole("button", { name: "Download CSV" })).toBeDisabled();
+		await sheet.getByLabel("Application date from").fill("2026-08-03");
+		downloadPromise = page.waitForEvent("download");
+		await sheet.getByRole("button", { name: "Download CSV" }).click();
+		download = await downloadPromise;
+		path = await download.path();
+		if (!path) throw new Error("CSV download was not saved");
+		csv = await readFile(path, "utf8");
+		expect(csv).toContain('"Alpha Company"');
+		expect(csv).toContain('"Beta Archived"');
+		expect(csv).not.toMatch(/Gamma Later|Foreign Secret/);
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.reload();
+		await expect(page.getByRole("heading", { name: "Applications", exact: true })).toBeVisible();
+		const title = await page.getByRole("heading", { name: "Applications", exact: true }).boundingBox();
+		const exportButton = await page.getByRole("button", { name: "Export CSV", exact: true }).boundingBox();
+		if (!title || !exportButton) throw new Error("Application header is not visible");
+		const overlaps =
+			title.x < exportButton.x + exportButton.width &&
+			title.x + title.width > exportButton.x &&
+			title.y < exportButton.y + exportButton.height &&
+			title.y + title.height > exportButton.y;
+		expect(overlaps).toBe(false);
+		await page.screenshot({ path: testInfo.outputPath("mobile-header.png"), animations: "disabled" });
+		await page.getByRole("button", { name: "Export CSV", exact: true }).click();
+		await expect(sheet.getByRole("button", { name: "Download CSV" })).toBeVisible();
+		await page.screenshot({ path: testInfo.outputPath("mobile-export.png"), animations: "disabled" });
+	} finally {
+		await pool.end();
+		await deleteE2EUser(foreign);
+	}
+});


### PR DESCRIPTION
Application Tracker now exports CSV from current search/tag/archive filters or all owned applications, with an optional inclusive application-date range. Exports include application and stage dates, chronological stage history and timeline notes, contacts, source URLs, tags, and archive metadata.

CSV uses UTF-8 with BOM, quoted cells, escaped quotes, and text prefixes for formula-triggering values. Core column names match the existing importer; history and context columns serve reporting. The export uses the existing authenticated application query. Mobile header actions stack below the title.

This is a reporting export, not a lossless backup: formula-leading values retain a protective apostrophe on re-import, and tags containing semicolons, commas, or vertical bars follow the existing importer’s delimiter splitting. Stage history and contact context are reporting columns.

Validation: 611 web tests (including 23 CSV/import cases); production Chromium flow covering filters, archived rows, date boundaries, invalid ranges, foreign-account exclusion, downloaded content, and mobile header visibility; web typecheck, production build, package boundaries, and repository checks.

Fixes #3393.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSV export for applications from the dashboard.
  * Export currently filtered applications or all applications, including archived entries.
  * Filter exports by an inclusive application date range and view the selected count.
  * CSV files include application details, history, contacts, notes, and metadata.
  * Added validation preventing downloads when dates are invalid or no applications are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->






<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds filtered or complete application CSV export, inclusive date selection, reporting columns, formula protection, delimiter-safe tag serialization, localized UI, and end-to-end coverage.
- Adds an export sheet connected to current application filters and all-owned-application scope.
- Serializes application details, history, contacts, notes, tags, archive state, and timestamps.
- Extends CSV import handling to recognize generated exports and JSON-encoded tags.
- Updates application dashboard actions, responsive layout, locale catalogs, and tests.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because exporting and re-importing an authored apostrophe before formula-like text still silently changes the stored value.

The generated-export header fingerprint causes `stripFormulaGuard` to remove an apostrophe that `csvCell` did not add, leaving the previously reported round-trip data corruption outstanding.

**Files Needing Attention:** apps/web/src/features/applications/csv.ts
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/features/applications/csv.ts | Adds export serialization and importer compatibility handling, but the generated-export heuristic still removes genuine apostrophes from formula-like authored values. |
| apps/web/src/features/applications/components/export-applications-sheet.tsx | Adds scope and inclusive date controls, selected-row feedback, validation, and CSV download behavior. |
| apps/web/src/routes/dashboard/applications/index.tsx | Integrates the export action and sheet while adapting the dashboard header for mobile layouts. |
| apps/web/src/features/applications/csv-export.test.ts | Covers export formatting, filtering, formula guards, tags, and history, but misses the authored-apostrophe generated-export round trip. |
| tests/e2e/specs/applications-export.spec.ts | Exercises filtering, archived scope, date boundaries, ownership isolation, downloads, and mobile visibility. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20amruthpillai%2Freactive-resume%20PR%20%233426%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=3426&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fapplications%2Fcsv.ts%3A149-161%0A**Authored%20apostrophes%20remain%20stripped**%0A%0AWhen%20an%20application%20field%20genuinely%20begins%20with%20an%20apostrophe%20followed%20by%20formula-like%20text%2C%20such%20as%20%60'%3D1%2B1%60%2C%20%60csvCell%60%20leaves%20that%20apostrophe%20unchanged%20but%20the%20generated%20export%20headers%20cause%20%60stripFormulaGuard%60%20to%20remove%20it%20during%20re-import%2C%20storing%20%60%3D1%2B1%60%20instead%20of%20the%20authored%20value.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fapplications%2Fcsv.ts%3A149-161%0A**Authored%20apostrophes%20remain%20stripped**%0A%0AWhen%20an%20application%20field%20genuinely%20begins%20with%20an%20apostrophe%20followed%20by%20formula-like%20text%2C%20such%20as%20%60'%3D1%2B1%60%2C%20%60csvCell%60%20leaves%20that%20apostrophe%20unchanged%20but%20the%20generated%20export%20headers%20cause%20%60stripFormulaGuard%60%20to%20remove%20it%20during%20re-import%2C%20storing%20%60%3D1%2B1%60%20instead%20of%20the%20authored%20value.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amruthpillai%2Freactive-resume%22%20on%20the%20existing%20branch%20%22codex%2Fissue-3393-application-csv%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fissue-3393-application-csv%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fweb%2Fsrc%2Ffeatures%2Fapplications%2Fcsv.ts%3A149-161%0A**Authored%20apostrophes%20remain%20stripped**%0A%0AWhen%20an%20application%20field%20genuinely%20begins%20with%20an%20apostrophe%20followed%20by%20formula-like%20text%2C%20such%20as%20%60'%3D1%2B1%60%2C%20%60csvCell%60%20leaves%20that%20apostrophe%20unchanged%20but%20the%20generated%20export%20headers%20cause%20%60stripFormulaGuard%60%20to%20remove%20it%20during%20re-import%2C%20storing%20%60%3D1%2B1%60%20instead%20of%20the%20authored%20value.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/web/src/features/applications/csv.ts:149-161
**Authored apostrophes remain stripped**

When an application field genuinely begins with an apostrophe followed by formula-like text, such as `'=1+1`, `csvCell` leaves that apostrophe unchanged but the generated export headers cause `stripFormulaGuard` to remove it during re-import, storing `=1+1` instead of the authored value.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(applications): preserve CSV import v..."](https://github.com/amruthpillai/reactive-resume/commit/670189ebe4d12a5c7d6aa394e65939d0f5717ef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60749637)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->