### PR TITLE
fix(build): invalidate cached tasks for workspace source changes

### DIFF
--- a/tooling/turbo/source-cache.test.ts
+++ b/tooling/turbo/source-cache.test.ts
@@ -1,0 +1,117 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, expect, it } from "vitest";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const turbo = join(root, "node_modules", ".bin", process.platform === "win32" ? "turbo.cmd" : "turbo");
+const tasks = ["build", "check", "typecheck", "test", "test:coverage", "test:ci", "test:agent"];
+type DryTask = { taskId: string; task: string; hash: string; command: string; dependencies: string[] };
+let directory: string;
+let baseline: Map<string, DryTask>;
+
+function dryRun() {
+	const output = execFileSync(turbo, ["run", ...tasks, "--dry=json"], {
+		cwd: directory,
+		encoding: "utf8",
+		maxBuffer: 8 * 1024 * 1024,
+		env: { ...process.env, TURBO_TELEMETRY_DISABLED: "1" },
+	});
+	const result = JSON.parse(output) as { tasks: DryTask[] };
+	return new Map(result.tasks.map((task) => [task.taskId, task]));
+}
+
+beforeAll(async () => {
+	directory = await mkdtemp(join(tmpdir(), "reactive-resume-turbo-cache-"));
+	const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+	await writeFile(
+		join(directory, "package.json"),
+		JSON.stringify({ private: true, packageManager: packageJson.packageManager }),
+	);
+	await writeFile(join(directory, "pnpm-workspace.yaml"), 'packages: ["packages/*"]\n');
+	await writeFile(join(directory, ".gitignore"), "node_modules/\n.turbo/\n");
+	await writeFile(join(directory, "turbo.json"), await readFile(join(root, "turbo.json")));
+
+	// app -> api -> pdf mirrors a source-consumed dependency with no build script.
+	const dependencies: Record<string, string[]> = { app: ["api"], api: ["pdf"], pdf: [], unrelated: [] };
+	let lock = "lockfileVersion: '9.0'\nimporters:\n  .: {}\n";
+	for (const [name, deps] of Object.entries(dependencies)) {
+		const packageDirectory = join(directory, "packages", name);
+		await mkdir(packageDirectory, { recursive: true });
+		await writeFile(join(packageDirectory, "source.ts"), "export const value = 1;\n");
+		await writeFile(
+			join(packageDirectory, "package.json"),
+			JSON.stringify({
+				name,
+				version: "0.0.0",
+				private: true,
+				dependencies: Object.fromEntries(deps.map((dependency) => [dependency, "workspace:*"])),
+				scripts: name === "pdf" ? {} : Object.fromEntries(tasks.map((task) => [task, "node -e ''"])),
+			}),
+		);
+		lock += `  packages/${name}:`;
+		lock += deps.length
+			? `\n    dependencies:\n${deps.map((dependency) => `      ${dependency}:\n        specifier: workspace:*\n        version: link:../${dependency}\n`).join("")}`
+			: " {}\n";
+	}
+	await writeFile(join(directory, "pnpm-lock.yaml"), lock);
+	baseline = dryRun();
+});
+
+afterAll(async () => {
+	if (directory) await rm(directory, { recursive: true, force: true });
+});
+
+async function withChangedSource(name: string, check: (result: Map<string, DryTask>) => void) {
+	const path = join(directory, "packages", name, "source.ts");
+	const original = await readFile(path);
+	try {
+		await writeFile(path, "export const value = 2;\n");
+		check(dryRun());
+	} finally {
+		await writeFile(path, original);
+	}
+}
+
+it("invalidates every cached consumer task after a transitive source-only package changes", async () => {
+	await withChangedSource("pdf", (result) => {
+		for (const name of ["app", "api"]) {
+			for (const task of tasks) {
+				const id = `${name}#${task}`;
+				expect(result.get(id)?.hash, id).not.toBe(baseline.get(id)?.hash);
+			}
+		}
+	});
+});
+
+it("invalidates direct consumers while retaining unrelated package cache keys", async () => {
+	await withChangedSource("api", (result) => {
+		for (const task of tasks) {
+			expect(result.get(`app#${task}`)?.hash, task).not.toBe(baseline.get(`app#${task}`)?.hash);
+			expect(result.get(`unrelated#${task}`)?.hash, task).toBe(baseline.get(`unrelated#${task}`)?.hash);
+		}
+	});
+});
+
+it("keeps cache keys stable when sources are unchanged", () => {
+	expect(dryRun()).toEqual(baseline);
+});
+
+it("propagates dependency hashes without ordering runnable tasks between packages", () => {
+	for (const task of tasks) {
+		const app = baseline.get(`app#${task}`);
+		expect(app?.dependencies.length, task).toBeGreaterThan(0);
+		const pending = [...(app?.dependencies ?? [])];
+		const visited = new Set<string>();
+		while (pending.length > 0) {
+			const id = pending.pop();
+			if (!id || visited.has(id)) continue;
+			visited.add(id);
+			const dependency = baseline.get(id);
+			expect(dependency?.command, id).toBe("<NONEXISTENT>");
+			pending.push(...(dependency?.dependencies ?? []));
+		}
+	}
+});

--- a/tooling/turbo/source-cache.test.ts
+++ b/tooling/turbo/source-cache.test.ts
@@ -6,14 +6,14 @@ import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, expect, it } from "vitest";
 
 const root = fileURLToPath(new URL("../../", import.meta.url));
-const turbo = join(root, "node_modules", ".bin", process.platform === "win32" ? "turbo.cmd" : "turbo");
+const turbo = join(root, "node_modules", "turbo", "bin", "turbo");
 const tasks = ["build", "check", "typecheck", "test", "test:coverage", "test:ci", "test:agent"];
 type DryTask = { taskId: string; task: string; hash: string; command: string; dependencies: string[] };
 let directory: string;
 let baseline: Map<string, DryTask>;
 
 function dryRun() {
-	const output = execFileSync(turbo, ["run", ...tasks, "--dry=json"], {
+	const output = execFileSync(process.execPath, [turbo, "run", ...tasks, "--dry=json"], {
 		cwd: directory,
 		encoding: "utf8",
 		maxBuffer: 8 * 1024 * 1024,

--- a/turbo.json
+++ b/turbo.json
@@ -90,19 +90,35 @@
 		"FLAG_ALLOW_UNSAFE_AI_BASE_URL"
 	],
 	"tasks": {
+		"transit": {
+			"dependsOn": ["^transit"]
+		},
 		"build": {
 			"inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/.env*"],
-			"outputs": ["dist/**", ".vercel/**"]
+			"outputs": ["dist/**", ".vercel/**"],
+			"dependsOn": ["transit"]
 		},
-		"check": {},
-		"typecheck": {},
-		"test": {},
-		"test:coverage": {},
-		"test:ci": {},
+		"check": {
+			"dependsOn": ["transit"]
+		},
+		"typecheck": {
+			"dependsOn": ["transit"]
+		},
+		"test": {
+			"dependsOn": ["transit"]
+		},
+		"test:coverage": {
+			"dependsOn": ["transit"]
+		},
+		"test:ci": {
+			"dependsOn": ["transit"]
+		},
 		"test:e2e": {
 			"cache": false
 		},
-		"test:agent": {},
+		"test:agent": {
+			"dependsOn": ["transit"]
+		},
 		"dev": {
 			"cache": false,
 			"persistent": true


### PR DESCRIPTION
Changes in source-consumed workspace packages could leave application builds, typechecks, and tests cached against older code. A PDF source edit, for example, left the server build hash at `ebb7b7346d4859d7` because no task dependency connected the two packages.

Add a scriptless `transit` task that follows workspace dependencies, and connect cached tasks to it. Dependency source changes now propagate into consumer cache keys without forcing builds, typechecks, or tests to wait for other runnable tasks. Existing environment inputs and non-cached task overrides remain unchanged. This follows [Turborepo’s documented transit-node pattern](https://turborepo.dev/docs/crafting-your-repository/configuring-tasks#dependent-tasks-that-can-be-run-in-parallel).

Validation: four regressions run the installed Turbo CLI against a disposable workspace, covering transitive packages without scripts, direct dependency changes, unrelated cache stability, repeated hashes, and runnable-task parallelism. All 13 tooling tests, tooling typecheck, boundaries, and repository checks passed. Real repository PDF/API source probes invalidate the expected application hashes; production build passed, and an unchanged rebuild reused all three cached outputs.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds transit tasks so source changes in workspace dependencies contribute to cached consumer-task hashes without imposing execution ordering.
- Connects cached build, check, typecheck, and test tasks to the transit dependency graph.
- Adds regression coverage for direct and transitive invalidation, unrelated-package stability, stable repeated hashes, and runnable-task parallelism.
- Uses Node to invoke Turbo’s JavaScript entry point portably across platforms.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| turbo.json | Adds a scriptless transit dependency graph to propagate workspace-source changes into cached task hashes without serializing runnable tasks. |
| tooling/turbo/source-cache.test.ts | Adds disposable-workspace regression tests and fixes the previously nonportable Windows launcher by invoking Turbo’s JavaScript entry point with Node. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  PDF[pdf source] --> APITransit[api#transit]
  APITransit --> AppTransit[app#transit]
  AppTransit --> CachedTask[app cached task hash]
  APITransit --> APICachedTask[api cached task hash]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(build): launch Turbo portably throu..."](https://github.com/amruthpillai/reactive-resume/commit/ddf1bb9cd14f288d29f2bbe38ff857ecbfb3454f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60751066)</sub>

<!-- /greptile_comment -->