### PR TITLE
fix(stylesheet): allow gaps between level decorations

### DIFF
--- a/docs/applying-custom-styles.mdx
+++ b/docs/applying-custom-styles.mdx
@@ -213,6 +213,21 @@ list-item-content {
 }
 ```
 
+### Space level indicators
+
+Target `level` to adjust the space between a skill's circles, icons, or other level decorations:
+
+```css
+@version 1;
+
+section[type="skills"] level {
+	column-gap: 4pt;
+}
+```
+
+This sets a 4pt horizontal gap between decorations. `gap: 4pt` also works; `gap: 0` removes the gap.
+`row-gap` does not change horizontal spacing within the single level row.
+
 ### Style fields inside an item
 
 Named fields let you make a focused change without styling every item value. Use the selector only where that field

--- a/packages/pdf/src/templates/shared/level-gap.test.tsx
+++ b/packages/pdf/src/templates/shared/level-gap.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { act } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+import { resolveResumeRuntime } from "../../semantic/resolve";
+import { rasterizePdf } from "../../semantic/test/rasterize-pdf";
+
+async function circlePositions(declaration = "", mode: "semantic" | "legacy" = "semantic") {
+	const data = structuredClone(defaultResumeData);
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.page.hideIcons = true;
+	data.metadata.design.colors.primary = "rgba(255, 0, 0, 1)";
+	data.metadata.layout.pages = [{ fullWidth: true, main: ["skills"], sidebar: [] }];
+	data.metadata.stylesheet = {
+		mode,
+		source: { languageVersion: 1, text: `@version 1; section[type="skills"] level { ${declaration} }` },
+	};
+	data.sections.skills.items = [
+		{
+			id: "skill",
+			hidden: false,
+			icon: "",
+			iconColor: "",
+			name: "Skill",
+			proficiency: "",
+			level: 5,
+			keywords: [],
+		},
+	];
+	const runtime = resolveResumeRuntime({ data, template: "onyx", mode });
+	const bytes = await act(() => renderToBuffer(<ResumeDocument data={data} template="onyx" />));
+	const [page] = await rasterizePdf(new Uint8Array(bytes));
+	if (!page) throw new Error("Missing PDF page");
+	// Scan the actual circle raster for a row with five separate red segments.
+	// The curved tops remain separate even when the circles have zero gap.
+	for (let y = 0; y < page.height; y++) {
+		const segments: { start: number; end: number }[] = [];
+		let segment: { start: number; end: number } | undefined;
+		for (let x = 0; x < page.width; x++) {
+			const offset = (y * page.width + x) * 4;
+			const red = (page.data[offset] ?? 0) > 200 && (page.data[offset + 1] ?? 255) < 100;
+			if (red) {
+				if (segment) segment.end = x;
+				else segment = { start: x, end: x };
+			} else if (segment) {
+				segments.push(segment);
+				segment = undefined;
+			}
+		}
+		if (segment) segments.push(segment);
+		if (segments.length === 5)
+			return {
+				centers: segments.map(({ start, end }) => (start + end) / 2),
+				y,
+				diagnostics: runtime.diagnostics,
+			};
+	}
+	throw new Error("Missing five level circles in PDF raster");
+}
+
+describe("semantic level gaps (#3040)", () => {
+	it("preserves default circle geometry in legacy and semantic modes", async () => {
+		expect(await circlePositions()).toEqual(await circlePositions("", "legacy"));
+	});
+	it.each([
+		["gap: 0;", 0],
+		["gap: 4pt;", 4],
+		["gap: 3pt 5pt;", 5],
+		["column-gap: 6pt;", 6],
+		["row-gap: 9pt;", 4 / 3],
+		["gap: 4pt; column-gap: 0;", 0],
+	] as const)("renders %s on the level row", async (declaration, expectedGap) => {
+		const baseline = await circlePositions();
+		const actual = await circlePositions(declaration);
+		expect(actual.y).toBe(baseline.y);
+		expect(actual.centers[0]).toBe(baseline.centers[0]);
+		for (let index = 1; index < actual.centers.length; index++) {
+			const previous = actual.centers[index - 1];
+			const current = actual.centers[index];
+			if (previous === undefined || current === undefined) throw new Error("Missing circle center");
+			expect(Math.abs(current - previous - (8 + expectedGap) * 1.5)).toBeLessThanOrEqual(0.5);
+		}
+		expect(actual.diagnostics).toEqual([]);
+	});
+});

--- a/packages/pdf/src/templates/shared/level-gap.test.tsx
+++ b/packages/pdf/src/templates/shared/level-gap.test.tsx
@@ -6,6 +6,11 @@ import { ResumeDocument } from "../../document";
 import { resolveResumeRuntime } from "../../semantic/resolve";
 import { rasterizePdf } from "../../semantic/test/rasterize-pdf";
 
+// rasterizePdf renders at 1.5 pixels per PDF point. The default 10pt body
+// font produces 8pt level circles via resolveLevelDisplaySizes.
+const pdfRasterScale = 1.5;
+const circleDiameterPt = 8;
+
 async function circlePositions(declaration = "", mode: "semantic" | "legacy" = "semantic") {
 	const data = structuredClone(defaultResumeData);
 	data.metadata.typography.body.fontFamily = "Helvetica";
@@ -40,6 +45,7 @@ async function circlePositions(declaration = "", mode: "semantic" | "legacy" = "
 		let segment: { start: number; end: number } | undefined;
 		for (let x = 0; x < page.width; x++) {
 			const offset = (y * page.width + x) * 4;
+			// Select the red decorations while excluding black text and white/antialiased background.
 			const red = (page.data[offset] ?? 0) > 200 && (page.data[offset + 1] ?? 255) < 100;
 			if (red) {
 				if (segment) segment.end = x;
@@ -80,7 +86,7 @@ describe("semantic level gaps (#3040)", () => {
 			const previous = actual.centers[index - 1];
 			const current = actual.centers[index];
 			if (previous === undefined || current === undefined) throw new Error("Missing circle center");
-			expect(Math.abs(current - previous - (8 + expectedGap) * 1.5)).toBeLessThanOrEqual(0.5);
+			expect(Math.abs(current - previous - (circleDiameterPt + expectedGap) * pdfRasterScale)).toBeLessThanOrEqual(0.5);
 		}
 		expect(actual.diagnostics).toEqual([]);
 	});

--- a/packages/resume/src/stylesheet/registry/properties.test.ts
+++ b/packages/resume/src/stylesheet/registry/properties.test.ts
@@ -211,11 +211,13 @@ const expectedPropertyGroups = [
 			"flex-shrink",
 			"flex-basis",
 			"justify-content",
-			"gap",
-			"row-gap",
-			"column-gap",
 		],
 		appliesTo: linkContainerNodes,
+		inheritable: false,
+	},
+	{
+		names: ["gap", "row-gap", "column-gap"],
+		appliesTo: [...linkContainerNodes, "level"],
 		inheritable: false,
 	},
 	{

--- a/packages/resume/src/stylesheet/registry/properties.ts
+++ b/packages/resume/src/stylesheet/registry/properties.ts
@@ -213,12 +213,14 @@ const properties = {
 			"flex-shrink",
 			"flex-basis",
 			"justify-content",
-			"gap",
-			"row-gap",
-			"column-gap",
 		],
 		{ category: "flexbox", inheritable: false, appliesTo: linkContainerNodes },
 	),
+	...entries(["gap", "row-gap", "column-gap"], {
+		category: "flexbox",
+		inheritable: false,
+		appliesTo: [...linkContainerNodes, "level"],
+	}),
 	...entries(["aspect-ratio", "bottom"], {
 		category: "layout",
 		inheritable: false,


### PR DESCRIPTION
Semantic CSS rejected `gap`, `row-gap`, and `column-gap` on level indicators, so authors could not adjust the spacing between a skill’s circles or icons. Allow these three properties on `level` nodes and document a focused rule:

```css
section[type="skills"] level {
  column-gap: 4pt;
}
```

The existing PDF row already consumes the resolved gap. Other container properties retain their existing applicability.

Validation:
- Actual PDF regression failed before the fix: a 6pt column gap left circle centers 14px apart instead of 21px at 1.5× scale. All seven raster tests now pass, covering zero gap, scalar/two-value shorthand, overrides, row-gap semantics, and unchanged legacy/default geometry.
- The exact reported fixture with a 4pt gap changes circle positions from 21/35/49/63/77px to 21/39/57/75/93px, retaining its two pages and text content.
- Full suites: 690 PDF tests and 1,349 resume-domain tests passed. Both package typechecks, formatting/Markdown checks, package boundaries, and frozen offline install passed. Ran the tooling documentation generator; its JSON Schema references remained unchanged.

Relates to #3040. This addresses the later request to control gaps between level decorations. The original vertical-clipping report was not reproduced with the current attached fixture, and this change does not alter automatic item pagination. Keep the issue open for those remaining distinctions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing horizontal spacing between skill-level indicators using `gap` or `column-gap`.
  - Skill-level spacing can be removed with `gap: 0`; `row-gap` does not affect horizontal spacing.

- **Documentation**
  - Added guidance and examples for configuring skill-level indicator spacing with Semantic CSS.

- **Tests**
  - Added coverage for spacing behavior across semantic and legacy rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR permits `gap`, `row-gap`, and `column-gap` on semantic `level` nodes so skill-level decorations can be spaced through custom CSS.
- Expands the stylesheet property registry and its applicability tests.
- Adds rasterized PDF coverage for shorthand behavior, overrides, defaults, and legacy compatibility.
- Documents level-indicator spacing with a focused `column-gap` example.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/resume/src/stylesheet/registry/properties.ts | Extends gap-property applicability to level nodes while retaining existing link-container support. |
| packages/resume/src/stylesheet/registry/properties.test.ts | Updates registry expectations to cover the expanded level-node applicability. |
| packages/pdf/src/templates/shared/level-gap.test.tsx | Adds raster regression coverage for level-decoration gap resolution and preserved default geometry. |
| docs/applying-custom-styles.mdx | Documents supported horizontal spacing behavior for skill-level indicators. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(pdf): explain level gap raster meas..."](https://github.com/amruthpillai/reactive-resume/commit/2e29a4412f2ae3ac8ca61db028ba3e2a213b989a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60758528)</sub>

<!-- /greptile_comment -->