### PR TITLE
fix(pdf): align skill ratings within grid rows

### DIFF
--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -1191,10 +1191,12 @@ const LanguagesSection = ({ sectionId = "languages", sectionData }: ItemSectionP
 			<SectionItems columns={languages.columns}>
 				{items.map((item) => (
 					<SectionItem key={item.id} itemId={item.id}>
-						<SectionItemHeader>
-							<Bold semanticField="language">{item.language}</Bold>
-							<Text semanticField="fluency">{item.fluency}</Text>
-						</SectionItemHeader>
+						<View style={{ flexGrow: languages.columns > 1 ? 1 : 0 }}>
+							<SectionItemHeader>
+								<Bold semanticField="language">{item.language}</Bold>
+								<Text semanticField="fluency">{item.fluency}</Text>
+							</SectionItemHeader>
+						</View>
 						<LevelDisplay level={item.level} />
 					</SectionItem>
 				))}

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -1166,7 +1166,7 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 							</View>
 						</SectionItemHeader>
 
-						<View>
+						<View style={{ flexGrow: skills.columns > 1 ? 1 : 0 }}>
 							{hasSplitRowText(item.proficiency) && <Text semanticField="proficiency">{item.proficiency}</Text>}
 							<Small semanticField="keywords">{item.keywords.join(", ")}</Small>
 						</View>

--- a/packages/pdf/src/templates/shared/skill-level-alignment.test.tsx
+++ b/packages/pdf/src/templates/shared/skill-level-alignment.test.tsx
@@ -130,6 +130,33 @@ describe("skill rating alignment (#3343)", () => {
 		expect(rows).toHaveLength(2);
 		expect(text).toContain("Keyword11");
 	});
+	it("aligns language ratings in multi-column rows with unequal fluency text", async () => {
+		const {
+			rows: [rows],
+			text,
+		} = await renderRatings({
+			columns: 2,
+			count: 0,
+			configure: (data) => {
+				data.metadata.layout.pages = [{ fullWidth: true, main: ["languages"], sidebar: [] }];
+				data.sections.languages.columns = 2;
+				data.sections.languages.items = [
+					{ id: "english", hidden: false, language: "English", fluency: "Native", level: 5 },
+					{
+						id: "german",
+						hidden: false,
+						language: "German",
+						fluency:
+							"Professional working proficiency with deliberately long wrapping text across several lines in the language grid",
+						level: 5,
+					},
+				];
+			},
+		});
+		expect(rows).toHaveLength(1);
+		expect(rows?.[0]?.circles).toBe(10);
+		expect(text).toContain("Professional working proficiency");
+	});
 	it("does not add a rating for a skill with level zero", async () => {
 		const {
 			rows: [rows],

--- a/packages/pdf/src/templates/shared/skill-level-alignment.test.tsx
+++ b/packages/pdf/src/templates/shared/skill-level-alignment.test.tsx
@@ -1,0 +1,192 @@
+import type { ResumeData } from "@reactive-resume/schema/resume/data";
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+import { resolveResumeRuntime } from "../../semantic/resolve";
+import { rasterizePdf } from "../../semantic/test/rasterize-pdf";
+
+type FixtureOptions = {
+	columns: number;
+	count: number;
+	mode?: "semantic" | "legacy";
+	configure?: (data: ResumeData) => void;
+};
+
+function setCss(data: ResumeData, css: string) {
+	data.metadata.stylesheet = { mode: "semantic", source: { languageVersion: 1, text: `@version 1; ${css}` } };
+}
+
+async function renderRatings({ columns, count, mode = "semantic", configure }: FixtureOptions) {
+	const data = structuredClone(defaultResumeData);
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.page.hideIcons = true;
+	data.metadata.design.colors.primary = "rgba(255, 0, 0, 1)";
+	data.metadata.layout.pages = [{ fullWidth: true, main: ["skills"], sidebar: [] }];
+	data.metadata.stylesheet = { mode, source: { languageVersion: 1, text: "@version 1;" } };
+	data.sections.skills.columns = columns;
+	data.sections.skills.items = Array.from({ length: count }, (_, index) => ({
+		id: `skill-${index}`,
+		hidden: false,
+		icon: "",
+		iconColor: "",
+		name: `Skill ${index}`,
+		proficiency: index === 1 ? "Experienced" : "",
+		level: 5,
+		keywords: index === 1 ? Array.from({ length: 12 }, (_, word) => `Keyword${word}`) : ["Short"],
+	}));
+	configure?.(data);
+	expect(resolveResumeRuntime({ data, template: "onyx", mode }).diagnostics).toEqual([]);
+	const bytes = await act(() => renderToBuffer(<ResumeDocument data={data} template="onyx" />));
+	const pages = await rasterizePdf(new Uint8Array(bytes));
+	const loading = getDocument({ data: new Uint8Array(bytes) });
+	const text: string[] = [];
+	try {
+		const pdf = await loading.promise;
+		for (let number = 1; number <= pdf.numPages; number++) {
+			const page = await pdf.getPage(number);
+			text.push((await page.getTextContent()).items.flatMap((item) => ("str" in item ? [item.str] : [])).join(" "));
+		}
+	} finally {
+		await loading.destroy();
+	}
+	const rows = pages.map((page) => {
+		const rows: { top: number; bottom: number; circles: number }[] = [];
+		for (let y = 0; y < page.height; y++) {
+			let redPixels = 0;
+			let segments = 0;
+			let previousRed = false;
+			for (let x = 0; x < page.width; x++) {
+				const offset = (y * page.width + x) * 4;
+				const red = (page.data[offset] ?? 0) > 200 && (page.data[offset + 1] ?? 255) < 100;
+				if (red) {
+					redPixels++;
+					if (!previousRed) segments++;
+				}
+				previousRed = red;
+			}
+			if (redPixels === 0) continue;
+			const previous = rows.at(-1);
+			if (previous && previous.bottom === y - 1) {
+				previous.bottom = y;
+				previous.circles = Math.max(previous.circles, segments);
+			} else rows.push({ top: y, bottom: y, circles: segments });
+		}
+		// Onyx's thin section separator is red too; retain only the circle bands.
+		return rows.filter((row) => row.bottom - row.top > 5);
+	});
+	return { rows, text: text.join(" ") };
+}
+
+describe("skill rating alignment (#3343)", () => {
+	it.each(["semantic", "legacy"] as const)(
+		"aligns mixed-height skills and preserves an incomplete row in %s mode",
+		async (mode) => {
+			const {
+				rows: [rows],
+				text,
+			} = await renderRatings({ columns: 2, count: 3, mode });
+			expect(rows).toHaveLength(2);
+			if (!rows?.[0] || !rows[1]) throw new Error("Missing rating rows");
+			// Ten circles share the first row; the remaining skill has five.
+			expect(rows.map((row) => row.circles)).toEqual([10, 5]);
+			expect(text).toContain("Keyword11");
+			expect(text).toContain("Skill 2");
+		},
+	);
+	it("aligns three columns and preserves an incomplete row", async () => {
+		const {
+			rows: [rows],
+		} = await renderRatings({ columns: 3, count: 4 });
+		expect(rows).toHaveLength(2);
+		if (!rows?.[0] || !rows[1]) throw new Error("Missing rating rows");
+		expect(rows.map((row) => row.circles)).toEqual([15, 5]);
+	});
+	it("retains every single-column rating beside its own content", async () => {
+		const {
+			rows: [rows],
+			text,
+		} = await renderRatings({ columns: 1, count: 3 });
+		expect(rows).toHaveLength(3);
+		for (const name of ["Skill 0", "Skill 1", "Skill 2", "Keyword11"]) expect(text).toContain(name);
+	});
+	it("aligns custom skill sections using their own column count", async () => {
+		const {
+			rows: [rows],
+			text,
+		} = await renderRatings({
+			columns: 3,
+			count: 4,
+			configure: (data) => {
+				data.customSections = [{ ...data.sections.skills, id: "custom-skills", type: "skills" }];
+				data.sections.skills.columns = 1;
+				data.sections.skills.items = [];
+				data.metadata.layout.pages = [{ fullWidth: true, main: ["custom-skills"], sidebar: [] }];
+			},
+		});
+		expect(rows).toHaveLength(2);
+		expect(text).toContain("Keyword11");
+	});
+	it("does not add a rating for a skill with level zero", async () => {
+		const {
+			rows: [rows],
+			text,
+		} = await renderRatings({
+			columns: 2,
+			count: 3,
+			configure: (data) => {
+				const first = data.sections.skills.items[0];
+				if (first) first.level = 0;
+			},
+		});
+		expect(rows).toHaveLength(2);
+		if (!rows?.[0] || !rows[1]) throw new Error("Missing rating rows");
+		expect(rows.map((row) => row.circles)).toEqual([5, 5]);
+		expect(text).toContain("Skill 0");
+	});
+	it("groups visible items after Semantic CSS filtering", async () => {
+		const {
+			rows: [rows],
+			text,
+		} = await renderRatings({
+			columns: 2,
+			count: 3,
+			configure: (data) => setCss(data, 'section[type="skills"] item[id="skill-1"] { display: none; }'),
+		});
+		expect(rows).toHaveLength(1);
+		expect(text).not.toContain("Skill 1");
+		expect(text).toContain("Skill 2");
+	});
+	it("preserves author-specified item padding around aligned ratings", async () => {
+		const baseline = await renderRatings({ columns: 2, count: 3 });
+		const {
+			rows: [rows],
+		} = await renderRatings({
+			columns: 2,
+			count: 3,
+			configure: (data) => setCss(data, 'section[type="skills"] item { padding-bottom: 12pt; }'),
+		});
+		expect(rows).toHaveLength(2);
+		if (!rows?.[0] || !rows[1]) throw new Error("Missing rating rows");
+		expect(rows.map((row) => row.circles)).toEqual([10, 5]);
+		const defaultSecondRow = baseline.rows[0]?.[1];
+		if (!defaultSecondRow) throw new Error("Missing default rating row");
+		// The first row's 12pt bottom padding moves the next row by 18px.
+		expect(Math.abs(rows[1].top - defaultSecondRow.top - 18)).toBeLessThanOrEqual(1);
+	});
+	it("retains aligned ratings and text across automatic page breaks", async () => {
+		const { rows, text } = await renderRatings({
+			columns: 3,
+			count: 12,
+			configure: (data) => setCss(data, "page { size: 300pt 220pt; }"),
+		});
+		expect(rows.length).toBeGreaterThan(1);
+		expect(rows.flat()).toHaveLength(4);
+		for (let index = 0; index < 12; index++) expect(text).toContain(`Skill ${index}`);
+		expect(text).toContain("Keyword11");
+		expect(rows.flat().map((row) => row.circles)).toEqual([15, 15, 15, 15]);
+	});
+});


### PR DESCRIPTION
Skill ratings currently follow each item's own keyword text, so unequal keyword lengths leave the rating bars at different heights. Grow the existing proficiency/keywords block in multi-column skill rows so ratings align at the row bottom by default. Built-in and custom skill sections share the behavior; single-column output remains unchanged.

Closes #3343.

Validation:
- Nine actual-PDF regression cases cover legacy/Semantic CSS, two/three columns, incomplete rows, custom sections, zero ratings, filtering, authored padding, and automatic pagination.
- Before/after PDF rasters visually verified; single-column PNG output is byte-identical.
- Five independent PDF probes preserve content in long Onyx grids and Glalie sidebar layouts.
- All 692 PDF package tests across 58 files, PDF typecheck, formatting, and package-boundary checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alignment of skill details and language information when displayed across multiple columns.
  - Ensured consistent layout for skill ratings across different resume configurations, including custom sections and page breaks.

- **Tests**
  - Added comprehensive PDF rendering coverage for skill-rating alignment in both Semantic and legacy formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR grows the proficiency/keyword area in multi-column skill and language items so rating indicators align at the bottom of each grid row while preserving single-column behavior.
- Applies conditional flex growth to built-in and custom multi-column skill layouts.
- Extends the same alignment behavior to language ratings.
- Adds PDF regression coverage for column counts, incomplete rows, filtering, custom sections, authored padding, legacy rendering, and pagination.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/sections.tsx | Adds conditional flex growth to skill and language content wrappers to align rating displays in multi-column rows. |
| packages/pdf/src/templates/shared/skill-level-alignment.test.tsx | Adds focused PDF rendering regressions covering alignment, content preservation, customization, and page-break behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(pdf): align language ratings in grid..."](https://github.com/amruthpillai/reactive-resume/commit/cf29c4b1d0fa03f35ea7d6f373afe1c1d3fa29ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60762348)</sub>

<!-- /greptile_comment -->