### PR TITLE
fix(pdf): preserve imported rich text without semantic descendants

### DIFF
--- a/packages/pdf/src/semantic/rich-text-table.integration.test.tsx
+++ b/packages/pdf/src/semantic/rich-text-table.integration.test.tsx
@@ -1,0 +1,87 @@
+import type { ResumeData } from "@reactive-resume/schema/resume/data";
+import type { Template } from "@reactive-resume/schema/templates";
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../document";
+
+const table = (paragraphs = false) =>
+	`<table style="width: 240pt; border-collapse: collapse"><tbody>${[
+		["Alpha", "Beta"],
+		["Gamma", "Delta"],
+	]
+		.map(
+			(row) =>
+				`<tr>${row.map((text) => `<td style="width: 120pt; border: 1pt solid black; padding: 4pt">${paragraphs ? `<p>${text}</p>` : text}</td>`).join("")}</tr>`,
+		)
+		.join("")}</tbody></table>`;
+
+const fixture = (html: string, mode: "legacy" | "semantic", css = ""): ResumeData => {
+	const data = structuredClone(defaultResumeData);
+	data.basics.name = "Table probe";
+	data.picture.hidden = true;
+	data.summary.content = html;
+	data.metadata.layout.pages = [{ fullWidth: true, main: ["summary"], sidebar: [] }];
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.stylesheet = { mode, source: { languageVersion: 1, text: `@version 1; ${css}` } };
+	return data;
+};
+
+const readPdf = async (data: ResumeData, template: Template) => {
+	const bytes = new Uint8Array(await act(() => renderToBuffer(<ResumeDocument data={data} template={template} />)));
+	const loading = getDocument({ data: bytes });
+	try {
+		const document = await loading.promise;
+		const page = await document.getPage(1);
+		const content = await page.getTextContent();
+		return content.items.flatMap((item) =>
+			"str" in item ? [{ text: item.str, x: item.transform[4], y: item.transform[5] }] : [],
+		);
+	} finally {
+		await loading.destroy();
+	}
+};
+
+describe("imported rich-text tables", () => {
+	for (const template of ["ditgar", "onyx"] as const) {
+		for (const mode of ["legacy", "semantic"] as const) {
+			it(`${template} ${mode} preserves bare cell text and row/column positions`, async () => {
+				const items = await readPdf(fixture(table(), mode), template);
+				const cell = (text: string) => {
+					const cell = items.find((item) => item.text === text);
+					if (!cell) throw new Error(`Missing table cell ${text}`);
+					return cell;
+				};
+				const alpha = cell("Alpha");
+				const beta = cell("Beta");
+				const gamma = cell("Gamma");
+				const delta = cell("Delta");
+				expect(alpha.y).toBe(beta.y);
+				expect(gamma.y).toBe(delta.y);
+				expect(alpha.y).toBeGreaterThan(gamma.y);
+				expect(alpha.x).toBe(gamma.x);
+				expect(beta.x).toBe(delta.x);
+				expect(beta.x).toBeGreaterThan(alpha.x);
+			});
+		}
+	}
+
+	it("preserves table cells containing recognized paragraphs", async () => {
+		const items = await readPdf(fixture(table(true), "semantic"), "ditgar");
+		expect(items.map((item) => item.text)).toEqual(expect.arrayContaining(["Alpha", "Beta", "Gamma", "Delta"]));
+	});
+
+	it("preserves raw text inside an unrecognized block wrapper", async () => {
+		const items = await readPdf(fixture("<div>Wrapper content</div>", "semantic"), "ditgar");
+		expect(items.map((item) => item.text)).toContain("Wrapper content");
+	});
+
+	it("still honors explicit semantic rich-text hiding", async () => {
+		const items = await readPdf(fixture(table(), "semantic", "rich-text { display: none; }"), "ditgar");
+		expect(items.map((item) => item.text)).toContain("Table probe");
+		expect(items.map((item) => item.text)).not.toContain("Alpha");
+	});
+});

--- a/packages/pdf/src/semantic/tree.ts
+++ b/packages/pdf/src/semantic/tree.ts
@@ -204,8 +204,10 @@ const buildField = ({
 					direction,
 				)
 			: [];
+	// Imported HTML may contain only text inside wrappers without semantic kinds (for example table cells).
+	// Keep its rich-text host visible even when it has no individually addressable descendants.
 	const children =
-		RICH_TEXT_FIELDS.has(name) && typeof value === "string" && richTextChildren.length > 0
+		RICH_TEXT_FIELDS.has(name) && typeof value === "string"
 			? [
 					semanticNode({
 						key: semanticNodeKeys.richText(key, name),


### PR DESCRIPTION
Imported table cells and text inside unsupported HTML wrappers disappear when Semantic CSS is active. The semantic tree omitted the rich-text host whenever its HTML contained no individually addressable descendants, causing the renderer to hide the entire field. Keep the host for nonempty rich-text fields while preserving explicit CSS hiding.

Found while investigating #3196. The original screenshot shows missing table borders with text still visible; this fixes a separate content-loss regression and does not close that report without its original markup.

Validation:
- Seven actual-PDF cases cover bare table cells and row/column coordinates in Ditgar/Onyx and legacy/Semantic CSS modes, paragraph-wrapped cells, raw wrapper text, and explicit hiding.
- Production Chromium JSON import, unrelated edit, save/reload, and PDF download reproduce the failure before the fix and pass afterward; exported cell coordinates checked and browser preview visually verified.
- All 690 PDF tests across 58 files, PDF typecheck, package boundaries, formatting, and production web/server builds pass.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves nonempty imported rich text when unsupported HTML wrappers produce no individually addressable semantic descendants.
- Retains the rich-text semantic host for all string-valued rich-text fields.
- Adds actual-PDF coverage for table coordinates, unsupported wrappers, paragraph descendants, legacy and semantic modes, and explicit hiding.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the new integration test is formatted to the repository's line-width convention.

The semantic-tree change has targeted PDF coverage for the reported content-loss path and explicit hiding behavior; the only accepted issue is non-blocking formatting in the new test.

**Files Needing Attention:** packages/pdf/src/semantic/rich-text-table.integration.test.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/semantic/tree.ts | Retains the rich-text host when imported HTML has no recognized semantic descendants while preserving semantic visibility controls. |
| packages/pdf/src/semantic/rich-text-table.integration.test.tsx | Adds comprehensive PDF-level regression coverage, with several lines that should be wrapped to satisfy the repository formatting limit. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Imported rich-text HTML] --> B[Build semantic descendants]
  B --> C{String-valued rich-text field?}
  C -->|Yes| D[Keep rich-text host]
  D --> E[Render original HTML content]
  C -->|No| F[Use ordinary field handling]
  D --> G{Semantic CSS hides host?}
  G -->|Yes| H[Suppress content]
  G -->|No| E
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20amruthpillai%2Freactive-resume%20PR%20%233438%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=3438&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Fsemantic%2Frich-text-table.integration.test.tsx%3A14%0A**Test%20lines%20exceed%20formatting%20limit**%0A%0ASeveral%20statements%20in%20this%20new%20test%2C%20including%20the%20table%20mapping%2C%20stylesheet%20assignment%2C%20PDF%20rendering%20call%2C%20and%20assertion%2C%20exceed%20the%20repository's%20120-character%20line-width%20limit%2C%20creating%20formatter%20churn%20or%20a%20formatting-check%20failure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Fsemantic%2Frich-text-table.integration.test.tsx%3A14%0A**Test%20lines%20exceed%20formatting%20limit**%0A%0ASeveral%20statements%20in%20this%20new%20test%2C%20including%20the%20table%20mapping%2C%20stylesheet%20assignment%2C%20PDF%20rendering%20call%2C%20and%20assertion%2C%20exceed%20the%20repository's%20120-character%20line-width%20limit%2C%20creating%20formatter%20churn%20or%20a%20formatting-check%20failure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amruthpillai%2Freactive-resume%22%20on%20the%20existing%20branch%20%22codex%2Fissue-3196-table-content%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fissue-3196-table-content%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Fsemantic%2Frich-text-table.integration.test.tsx%3A14%0A**Test%20lines%20exceed%20formatting%20limit**%0A%0ASeveral%20statements%20in%20this%20new%20test%2C%20including%20the%20table%20mapping%2C%20stylesheet%20assignment%2C%20PDF%20rendering%20call%2C%20and%20assertion%2C%20exceed%20the%20repository's%20120-character%20line-width%20limit%2C%20creating%20formatter%20churn%20or%20a%20formatting-check%20failure.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3438&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/pdf/src/semantic/rich-text-table.integration.test.tsx:14
**Test lines exceed formatting limit**

Several statements in this new test, including the table mapping, stylesheet assignment, PDF rendering call, and assertion, exceed the repository's 120-character line-width limit, creating formatter churn or a formatting-check failure.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pdf): preserve imported rich text wi..."](https://github.com/amruthpillai/reactive-resume/commit/165535b5f493dd1ca4176c800f40dfbdcbcf44b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60766050)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/amruthpillai/reactive-resume/blob/main/CLAUDE.md))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF rendering for rich-text fields containing plain text inside table cells and other unrecognized wrappers.
  - Preserved rich-text content when semantic parsing finds no structured descendants.
  - Maintained expected handling for hidden semantic content.

- **Tests**
  - Added coverage for rich-text tables across templates and stylesheet modes.
  - Verified table cell content and row/column alignment in generated PDFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->