### PR TITLE
fix(pdf): align Ditgar item headers with body text

### DIFF
--- a/packages/pdf/src/templates/ditgar/DitgarPage.test.tsx
+++ b/packages/pdf/src/templates/ditgar/DitgarPage.test.tsx
@@ -1,0 +1,116 @@
+import type { ResumeData } from "@reactive-resume/schema/resume/data";
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+
+type FixtureOptions = {
+	mode: "legacy" | "semantic";
+	columns: number;
+	gapX: number;
+	rtl?: boolean;
+	sidebar?: boolean;
+	longTitle?: boolean;
+	experience?: boolean;
+	css?: string;
+};
+
+type TextRun = { text: string; x: number; right: number; y: number };
+
+function fixture({ mode, columns, gapX, rtl, sidebar, longTitle, experience, css = "" }: FixtureOptions): ResumeData {
+	const data = structuredClone(defaultResumeData);
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.page.gapX = gapX;
+	data.metadata.page.hideIcons = true;
+	if (rtl) data.metadata.page.locale = "ar-SA";
+	const section = experience ? "experience" : "projects";
+	data.metadata.layout.pages = [
+		{ fullWidth: false, main: sidebar ? [] : [section], sidebar: sidebar ? [section] : [] },
+	];
+	data.metadata.stylesheet = { mode, source: { languageVersion: 1, text: `@version 1; ${css}` } };
+	data.sections.projects.columns = columns;
+	data.sections.experience.columns = columns;
+	for (let index = 0; index < 3; index++) {
+		const name = `Project${index}${longTitle ? " wrapping project title with several additional words" : ""}`;
+		const shared = {
+			id: `project-${index}`,
+			hidden: false,
+			period: "",
+			description: `<p>Description${index} with enough words to wrap across the narrower column and preserve alignment.</p>`,
+			website: { url: `https://example.com/${index}`, label: `Website${index}`, inlineLink: false },
+		};
+		if (experience) {
+			data.sections.experience.items.push({ ...shared, company: name, position: "", location: "", roles: [] });
+		} else data.sections.projects.items.push({ ...shared, name });
+	}
+	return data;
+}
+
+async function renderText(options: FixtureOptions): Promise<TextRun[]> {
+	const bytes = await act(() => renderToBuffer(<ResumeDocument data={fixture(options)} template="ditgar" />));
+	const loading = getDocument({ data: new Uint8Array(bytes), useSystemFonts: true });
+	try {
+		const document = await loading.promise;
+		expect(document.numPages).toBe(1);
+		const page = await document.getPage(1);
+		return (await page.getTextContent()).items.flatMap((item) =>
+			"str" in item && item.str
+				? [{ text: item.str, x: item.transform[4], right: item.transform[4] + item.width, y: item.transform[5] }]
+				: [],
+		);
+	} finally {
+		await loading.destroy();
+	}
+}
+
+function assertAligned(runs: TextRun[], rtl = false, expectedOffset = 0) {
+	for (let index = 0; index < 3; index++) {
+		const title = runs.find((run) => run.text.startsWith(`Project${index}`));
+		const description = runs.find((run) => run.text.startsWith(`Description${index}`));
+		const website = runs.find((run) => run.text === `Website${index}`);
+		if (!title || !description || !website) throw new Error(`Missing project ${index} text`);
+		const edge = rtl ? "right" : "x";
+		expect(title[edge] - description[edge]).toBeCloseTo(expectedOffset, 3);
+		// Ditgar's separate website links stay left-aligned in RTL layouts.
+		if (!rtl) expect(title.x - website.x).toBeCloseTo(expectedOffset, 3);
+		else expect(website.right).toBeLessThanOrEqual(title.right);
+		expect(title.y).toBeGreaterThan(description.y);
+	}
+}
+
+describe("Ditgar item-header alignment (#3068)", () => {
+	for (const mode of ["legacy", "semantic"] as const) {
+		for (const columns of [1, 2]) {
+			it.each([0, 4, 12])(`aligns ${mode} Projects in ${columns} columns at gapX %i`, async (gapX) => {
+				assertAligned(await renderText({ mode, columns, gapX }));
+			});
+		}
+		it(`aligns wrapped ${mode} project titles with their descriptions and links`, async () => {
+			assertAligned(await renderText({ mode, columns: 2, gapX: 4, longTitle: true }));
+		});
+		it(`aligns the shared ${mode} Experience header`, async () => {
+			assertAligned(await renderText({ mode, columns: 2, gapX: 4, experience: true }));
+		});
+		it(`preserves ${mode} sidebar alignment`, async () => {
+			assertAligned(await renderText({ mode, columns: 1, gapX: 4, sidebar: true }));
+		});
+		it(`preserves ${mode} RTL alignment`, async () => {
+			assertAligned(await renderText({ mode, columns: 2, gapX: 4, rtl: true }), true);
+		});
+	}
+	it("retains an authored Semantic CSS header inset", async () => {
+		assertAligned(
+			await renderText({
+				mode: "semantic",
+				columns: 2,
+				gapX: 4,
+				css: "item-header { margin-left: 7pt; padding-left: 3pt; border-left: 2pt solid #0000ff; }",
+			}),
+			false,
+			12,
+		);
+	});
+});

--- a/packages/pdf/src/templates/ditgar/DitgarPage.tsx
+++ b/packages/pdf/src/templates/ditgar/DitgarPage.tsx
@@ -66,6 +66,8 @@ const ditgarFeatures = {
 	stackSidebarItemHeader: true,
 } satisfies TemplateFeatures;
 
+const ditgarItemHeaderBorderWidth = 2;
+
 export const DitgarPage = ({ page, pageSize, pageMinHeightStyle, showHeader, pageNumber }: TemplatePageProps) => {
 	const data = useRender();
 	const pageNodeKey = semanticNodeKeys.page(pageNumber);
@@ -331,12 +333,12 @@ const useDitgarTemplate = (): DitgarTemplate => {
 					rowGap: 0,
 					...(context.placement === "main"
 						? {
-								borderLeftWidth: 2,
+								borderLeftWidth: ditgarItemHeaderBorderWidth,
 								borderLeftColor: accentFor(context),
 								paddingLeft: metrics.gapX(0.5),
 								paddingVertical: metrics.gapY(0.125),
 								// Keep header text aligned with the body after its border and padding.
-								marginLeft: -(2 + metrics.gapX(0.5)),
+								marginLeft: -(ditgarItemHeaderBorderWidth + metrics.gapX(0.5)),
 							}
 						: {}),
 				}),

--- a/packages/pdf/src/templates/ditgar/DitgarPage.tsx
+++ b/packages/pdf/src/templates/ditgar/DitgarPage.tsx
@@ -335,7 +335,8 @@ const useDitgarTemplate = (): DitgarTemplate => {
 								borderLeftColor: accentFor(context),
 								paddingLeft: metrics.gapX(0.5),
 								paddingVertical: metrics.gapY(0.125),
-								marginLeft: -metrics.gapX(0.625),
+								// Keep header text aligned with the body after its border and padding.
+								marginLeft: -(2 + metrics.gapX(0.5)),
 							}
 						: {}),
 				}),


### PR DESCRIPTION
Ditgar project titles appeared slightly indented relative to their descriptions and website links, especially in multi-column sections. Its header margin scaled with horizontal spacing even though the accent border has a fixed width. At default spacing, this left titles 1.5pt out of alignment.

Compensate for the template’s default border and padding so decorated main-section headers align with their body text. This also corrects the shared Experience header style while preserving sidebar layouts and RTL behavior. Explicit authored Semantic CSS margins remain authoritative; changing only an authored border or padding does not automatically recompute the margin.

Fixes #3068.

Validation: 21 actual-PDF geometry cases covering one/two columns, three spacing values, wrapped titles, both stylesheet modes, Experience, sidebar, RTL and authored overrides. Baseline failed 16 alignment cases; all cases pass with the correction. Full PDF suite passes 879 tests on updated main; PDF typecheck, workspace boundaries and repository checks pass. Before/after PDF crops inspected.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alignment of Ditgar PDF section headers and body content across one- and two-column layouts.
  - Improved consistency for wrapped titles, experience sections, sidebars, varying spacing, and right-to-left rendering.
  - Preserved accurate alignment when using legacy styles, semantic styles, and custom CSS insets.
  - Ensured affected PDF layouts maintain correct text positioning and single-page output where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects Ditgar main-section item-header alignment by compensating for both the fixed accent border and horizontal padding.
- Shares the default border width between the rendered border and margin compensation.
- Adds actual-PDF geometry coverage for layout columns, spacing, wrapped titles, stylesheet modes, Experience, sidebars, RTL, and authored CSS overrides.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/ditgar/DitgarPage.tsx | Aligns decorated main-section headers with body text while preserving independent authored CSS inset overrides. |
| packages/pdf/src/templates/ditgar/DitgarPage.test.tsx | Adds comprehensive PDF-coordinate regression coverage for the corrected header geometry across supported layout variants. |

</details>

<sub>Reviews (4): Last reviewed commit: ["refactor(pdf): share Ditgar header borde..."](https://github.com/amruthpillai/reactive-resume/commit/5a3eff9850bf447945b4dfe121b975fb94e19fab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60781478)</sub>

<!-- /greptile_comment -->