### PR TITLE
fix(builder): center preview in RTL interfaces

### DIFF
--- a/apps/web/src/routes/builder/$resumeId/-components/preview-page.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-components/preview-page.tsx
@@ -32,7 +32,8 @@ export function PreviewPage() {
 					wheel={{ step: 0.001 }}
 					onPanningStart={blurFocusedElementOnPan}
 				>
-					<TransformComponent wrapperClass="h-full! w-full!">
+					{/* Zoom transforms use left-origin coordinates, regardless of the interface language. */}
+					<TransformComponent wrapperClass="h-full! w-full!" wrapperProps={{ dir: "ltr" }}>
 						<ResumePreview showPageNumbers pageLayout={pageLayout} />
 					</TransformComponent>
 

--- a/tests/e2e/specs/preview-direction.spec.ts
+++ b/tests/e2e/specs/preview-direction.spec.ts
@@ -1,0 +1,77 @@
+import type { Page } from "@playwright/test";
+import { Pool } from "pg";
+import { expect, test } from "../fixtures/test";
+
+async function expectCenteredPreview(page: Page) {
+	const canvas = page.locator('[aria-hidden="false"] canvas').first();
+	await expect(canvas).toBeVisible();
+	await expect
+		.poll(async () => {
+			const bounds = await canvas.boundingBox();
+			if (!bounds) return Number.POSITIVE_INFINITY;
+			return Math.abs(bounds.x + bounds.width / 2 - (page.viewportSize()?.width ?? 0) / 2);
+		})
+		.toBeLessThan(1);
+}
+
+for (const uiLanguage of ["English", "Arabic"]) {
+	for (const resumeLocale of ["en-US", "ar-SA"]) {
+		test(`centers preview with ${uiLanguage} UI and ${resumeLocale} resume`, async ({ authPage: page }, info) => {
+			test.setTimeout(60_000);
+			await page.setViewportSize({ width: 1920, height: 950 });
+			await page.goto("/dashboard/resumes");
+			await page.getByText("Create a new resume", { exact: true }).click();
+			const dialog = page.getByRole("dialog", { name: "Create a new resume" });
+			await dialog.getByLabel("Name", { exact: true }).fill("Preview direction fixture");
+			await dialog.getByRole("button", { name: "Create", exact: true }).click();
+			await page.waitForURL(/\/builder\/.+/);
+			const builderUrl = page.url();
+			const resumeId = builderUrl.split("/").at(-1);
+			await page.goto("/dashboard/resumes");
+			const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+			try {
+				await pool.query(
+					`update resume set data = jsonb_set(jsonb_set(data, '{metadata,page,locale}', $2::jsonb), '{basics,name}', '"Preview direction fixture"'::jsonb) where id = $1`,
+					[resumeId, JSON.stringify(resumeLocale)],
+				);
+			} finally {
+				await pool.end();
+			}
+			await page.goto(builderUrl);
+			if (uiLanguage === "Arabic") {
+				await page.getByRole("button", { name: "Account menu", exact: true }).click();
+				await page.getByRole("menuitem", { name: "Language", exact: true }).click();
+				await page.getByRole("menuitemradio", { name: "Arabic", exact: true }).click();
+				await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+				await page.reload();
+			}
+			await expectCenteredPreview(page);
+			const zoom = page.getByRole("button", {
+				name: uiLanguage === "Arabic" ? "مستوى التكبير" : "Zoom level",
+				exact: true,
+			});
+			await expect(zoom).toHaveCSS("direction", uiLanguage === "Arabic" ? "rtl" : "ltr");
+			await zoom.click();
+			await page
+				.getByRole("menuitem", {
+					name: uiLanguage === "Arabic" ? "الحجم الفعلي (100%)" : "Actual size (100%)",
+					exact: true,
+				})
+				.click();
+			await expect(zoom).toHaveText("100%");
+			await expectCenteredPreview(page);
+			await zoom.click();
+			await page
+				.getByRole("menuitem", { name: uiLanguage === "Arabic" ? "مناسب للعرض" : "Fit to view", exact: true })
+				.click();
+			await expect(zoom).toHaveText("75%");
+			await expectCenteredPreview(page);
+			const direction = await page
+				.locator('[aria-hidden="false"] canvas')
+				.first()
+				.evaluate((canvas) => canvas.closest("[dir]")?.getAttribute("dir"));
+			expect(direction).toBe(resumeLocale === "ar-SA" ? "rtl" : "ltr");
+			await page.screenshot({ path: info.outputPath("centered-preview.png") });
+		});
+	}
+}


### PR DESCRIPTION
With an Arabic interface, the builder preview starts beyond the right edge of the screen, and selecting Actual size does not bring it back. The zoom container inherits RTL positioning even though its transforms use coordinates measured from the left.

Give only the zoom container an LTR coordinate system. The surrounding Arabic interface, dock controls and each resume’s text direction retain their existing direction.

Fixes #2745.

Validation: reproduced on current main in a production Chromium build, with a 1,324.8px centering error while the English control passed. Four browser regressions cover English/Arabic interfaces crossed with English/Arabic resumes at initial load, Actual size and Fit to view. Web typecheck, production build and package boundaries pass; the baseline web suite passes 762 tests.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR gives the builder’s zoom wrapper an LTR coordinate system so left-origin transforms remain centered in RTL interfaces, while preserving the surrounding interface and resume-specific text directions.
- Sets `dir="ltr"` only on the `TransformComponent` wrapper.
- Adds browser coverage for English and Arabic interfaces crossed with English and Arabic resumes.
- Verifies initial, actual-size, and fit-to-view centering as well as UI and resume directionality.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the coordinate-system fix narrowly scoped and its direction-preservation behavior covered by browser tests.

The zoom wrapper now uses the left-to-right coordinate system expected by its transforms, while active resume pages explicitly retain locale-derived direction and the surrounding controls continue inheriting the interface direction.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/routes/builder/$resumeId/-components/preview-page.tsx | Isolates the zoom transform from inherited RTL coordinates while the preview page continues to establish direction from the resume locale. |
| tests/e2e/specs/preview-direction.spec.ts | Adds focused coverage for centering and direction preservation across all English/Arabic UI and resume combinations. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(builder): center preview in RTL inte..."](https://github.com/amruthpillai/reactive-resume/commit/ab0a47bf2311815aa5eedd5406bd8ae623d21adf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60783721)</sub>

<!-- /greptile_comment -->