### PR TITLE
fix(pdf): keep ordered list markers clear of body text

### DIFF
--- a/packages/pdf/src/templates/shared/ordered-marker.test.tsx
+++ b/packages/pdf/src/templates/shared/ordered-marker.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+import { resolveResumeRuntime } from "../../semantic/resolve";
+
+type Options = {
+	font: string;
+	rtl?: boolean;
+	columns?: number;
+	count?: number;
+	css?: string;
+	nested?: boolean;
+	sidebar?: boolean;
+};
+type Run = { text: string; x: number; right: number; y: number; page: number };
+
+async function renderList({
+	font,
+	rtl = false,
+	columns = 1,
+	count = 102,
+	css = "",
+	nested = false,
+	sidebar = false,
+}: Options) {
+	const data = structuredClone(defaultResumeData);
+	data.metadata.typography.body.fontFamily = font;
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.page.hideIcons = true;
+	if (rtl) data.metadata.page.locale = "ar-SA";
+	data.metadata.layout.pages = [
+		{ fullWidth: !sidebar, main: sidebar ? [] : ["projects"], sidebar: sidebar ? ["projects"] : [] },
+	];
+	data.metadata.stylesheet = { mode: "semantic", source: { languageVersion: 1, text: `@version 1; ${css}` } };
+	data.sections.projects.columns = columns;
+	data.sections.projects.items = Array.from({ length: columns }, (_, column) => ({
+		id: `project-${column}`,
+		hidden: false,
+		name: `Project${column}`,
+		period: "",
+		website: { url: "", label: "", inlineLink: false },
+		// Distinct body weight keeps marker and content separate in PDF.js text runs.
+		description: `${nested ? "<ul><li>Outer" : ""}<ol>${Array.from({ length: count }, (_, index) => `<li><strong>ITEM${column}_${String(index + 1).padStart(3, "0")}</strong></li>`).join("")}</ol>${nested ? "</li></ul>" : ""}`,
+	}));
+	expect(resolveResumeRuntime({ data, template: "rhyhorn", mode: "semantic" }).diagnostics).toEqual([]);
+	const bytes = await act(() => renderToBuffer(<ResumeDocument data={data} template="rhyhorn" />));
+	const loading = getDocument({ data: new Uint8Array(bytes), useSystemFonts: true });
+	try {
+		const document = await loading.promise;
+		const runs: Run[] = [];
+		for (let page = 1; page <= document.numPages; page++) {
+			const text = await (await document.getPage(page)).getTextContent();
+			for (const item of text.items) {
+				if ("str" in item && item.str)
+					runs.push({
+						text: item.str,
+						x: item.transform[4],
+						right: item.transform[4] + item.width,
+						y: item.transform[5],
+						page,
+					});
+			}
+		}
+		return { runs, pages: document.numPages };
+	} finally {
+		await loading.destroy();
+	}
+}
+
+function assertGutters(runs: Run[], { count = 102, columns = 1, rtl = false }: Options) {
+	for (let column = 0; column < columns; column++) {
+		const edges: number[] = [];
+		for (let index = 1; index <= count; index++) {
+			const bodies = runs.filter((run) => run.text === `ITEM${column}_${String(index).padStart(3, "0")}`);
+			expect(bodies).toHaveLength(1);
+			const body = bodies[0];
+			if (!body) throw new Error(`Missing body ${index}`);
+			const marker = runs
+				.filter(
+					(run) =>
+						run.text === (rtl ? `.${index}` : `${index}.`) && run.page === body.page && Math.abs(run.y - body.y) < 10,
+				)
+				.sort((a, b) => Math.abs(a.x - body.x) - Math.abs(b.x - body.x))[0];
+			expect(marker, `missing marker ${index} on content page`).toBeDefined();
+			if (!marker) throw new Error(`Missing marker ${index}`);
+			expect(rtl ? marker.x - body.right : body.x - marker.right, `marker ${index} gutter`).toBeGreaterThan(0.5);
+			edges.push(rtl ? body.right : body.x);
+		}
+		expect(Math.max(...edges) - Math.min(...edges)).toBeLessThan(0.01);
+	}
+}
+
+describe("ordered marker gutters (#2751)", () => {
+	it.each([false, true])("keeps a common gutter with authored letter spacing (RTL=%s)", async (rtl) => {
+		const options = { font: "Helvetica", count: 12, rtl, css: "list-marker { letter-spacing: 4pt; }" };
+		const bodies = (await renderList(options)).runs.filter((run) => run.text.startsWith("ITEM0_"));
+		expect(bodies).toHaveLength(12);
+		const edges = bodies.map((run) => (rtl ? run.right : run.x));
+		expect(Math.max(...edges) - Math.min(...edges)).toBeLessThan(0.01);
+	});
+	for (const rtl of [false, true]) {
+		for (const count of [9, 12, 102]) {
+			it.each(["Helvetica", "Courier", "Noto Serif SC"])(
+				`keeps %s markers clear in ${rtl ? "RTL" : "LTR"} ${count}-item lists`,
+				async (font) => {
+					const options = { font, count, rtl };
+					const { runs, pages } = await renderList(options);
+					if (count === 102) expect(pages).toBeGreaterThan(1);
+					assertGutters(runs, options);
+				},
+				20000, // Include the first CJK font download during concurrent suite runs.
+			);
+		}
+		it.each([{ columns: 3 }, { sidebar: true }, ...(rtl ? [] : [{ nested: true }])])(
+			`keeps ${rtl ? "RTL" : "LTR"} markers clear in %j`,
+			async (placement) => {
+				const options = { font: "Courier", count: 12, rtl, ...placement };
+				assertGutters((await renderList(options)).runs, options);
+			},
+		);
+	}
+	it("retains every nested RTL item", async () => {
+		// The existing RTL Text wrapper flattens nested lists into inline text.
+		// Preserve their content without asserting unsupported nested row geometry.
+		const { runs } = await renderList({ font: "Courier", rtl: true, nested: true, count: 12 });
+		const items =
+			runs
+				.map((run) => run.text)
+				.join("")
+				.match(/ITEM0_\d{3}/g) ?? [];
+		for (let index = 1; index <= 12; index++) {
+			expect(items.filter((item) => item === `ITEM0_${String(index).padStart(3, "0")}`)).toHaveLength(1);
+		}
+	});
+	it.each(["list-marker { font-size: 20pt; }", "field { font-size: 20pt; } list-marker { font-size: inherit; }"])(
+		"sizes the gutter for authored font size: %s",
+		async (css) => {
+			const options = { font: "Courier", count: 12, css };
+			const { runs } = await renderList(options);
+			// Different font sizes have different baselines; compare horizontal extents.
+			const marker = runs.find((run) => run.text === "10.");
+			const body = runs.find((run) => run.text === "ITEM0_010");
+			if (!marker || !body) throw new Error("Missing tenth item");
+			expect(body.x - marker.right).toBeGreaterThan(0.5);
+		},
+	);
+	it.each([4, 12])("preserves an explicitly authored %ipt row gap", async (gap) => {
+		const { runs } = await renderList({ font: "Helvetica", count: 12, css: `list-item { column-gap: ${gap}pt; }` });
+		const body = runs.find((run) => run.text === "ITEM0_010");
+		const baseline = (await renderList({ font: "Helvetica", count: 12 })).runs.find((run) => run.text === "ITEM0_010");
+		if (!body || !baseline) throw new Error("Missing content");
+		expect(body.x - baseline.x).toBeCloseTo(gap - 4 / 3, 3);
+	});
+});

--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -251,6 +251,27 @@ export const RichText = ({ children, semanticField }: RichTextProps) => {
 					const contentResolved = resolveNode(contentNodeKey);
 					const isOrderedList = isRichTextElementInsideOrderedList(element);
 					const marker = isOrderedList ? `${element.indexOfType + 1}.` : "•";
+					const listLength =
+						element.parentNode?.childNodes.filter((child) => child.rawTagName?.toLowerCase() === "li").length ?? 1;
+					const markerFontSize =
+						typeof markerResolved.style?.fontSize === "number"
+							? markerResolved.style.fontSize
+							: metadata.typography.body.fontSize;
+					const markerLetterSpacing =
+						typeof markerResolved.style?.letterSpacing === "number"
+							? Math.max(0, markerResolved.style.letterSpacing)
+							: 0;
+					const markerDigits = String(listLength).length;
+					// Reserve the same gutter throughout a list, then let Yoga measure wider
+					// glyphs. An explicit authored width keeps its ordinary CSS geometry.
+					const orderedMarkerStyle: Style | undefined =
+						isOrderedList && markerResolved.style?.width === undefined && markerResolved.style?.flexBasis === undefined
+							? {
+									width: "auto",
+									minWidth: markerDigits * markerFontSize + (markerDigits + 1) * markerLetterSpacing,
+									flexShrink: 0,
+								}
+							: undefined;
 					const itemStyles = toRichTextStyleArray(style);
 					const contentItemStyles = itemStyles.map(stripRichTextVerticalMargins);
 
@@ -261,7 +282,12 @@ export const RichText = ({ children, semanticField }: RichTextProps) => {
 							key="marker"
 							data-resume-list-marker
 							{...resolvedPdfTextProps(markerResolved)}
-							style={composeStyles(richListItemMarkerStyle, { alignSelf: "flex-start" }, markerResolved.style)}
+							style={composeStyles(
+								richListItemMarkerStyle,
+								orderedMarkerStyle,
+								{ alignSelf: "flex-start" },
+								markerResolved.style,
+							)}
 						>
 							{marker}
 						</PdfText>

--- a/packages/pdf/src/templates/shared/rich-text.tsx
+++ b/packages/pdf/src/templates/shared/rich-text.tsx
@@ -122,7 +122,7 @@ export const RichText = ({ children, semanticField }: RichTextProps) => {
 		element.getAttribute(richTextSemanticNodeKeyAttribute) ??
 		(richTextNodeKey ? getRichTextSemanticNodeKey(richTextNodeKey, element, richTextMarkClassName) : undefined);
 	const resolvedFor = (element: Parameters<typeof getRichTextSemanticNodeKey>[1]) => resolveNode(keyFor(element));
-
+	const listLengths = new WeakMap<object, number>();
 	const renderText = ({
 		element,
 		style,
@@ -251,27 +251,35 @@ export const RichText = ({ children, semanticField }: RichTextProps) => {
 					const contentResolved = resolveNode(contentNodeKey);
 					const isOrderedList = isRichTextElementInsideOrderedList(element);
 					const marker = isOrderedList ? `${element.indexOfType + 1}.` : "•";
-					const listLength =
-						element.parentNode?.childNodes.filter((child) => child.rawTagName?.toLowerCase() === "li").length ?? 1;
-					const markerFontSize =
-						typeof markerResolved.style?.fontSize === "number"
-							? markerResolved.style.fontSize
-							: metadata.typography.body.fontSize;
-					const markerLetterSpacing =
-						typeof markerResolved.style?.letterSpacing === "number"
-							? Math.max(0, markerResolved.style.letterSpacing)
-							: 0;
-					const markerDigits = String(listLength).length;
 					// Reserve the same gutter throughout a list, then let Yoga measure wider
 					// glyphs. An explicit authored width keeps its ordinary CSS geometry.
-					const orderedMarkerStyle: Style | undefined =
-						isOrderedList && markerResolved.style?.width === undefined && markerResolved.style?.flexBasis === undefined
-							? {
-									width: "auto",
-									minWidth: markerDigits * markerFontSize + (markerDigits + 1) * markerLetterSpacing,
-									flexShrink: 0,
-								}
-							: undefined;
+					let orderedMarkerStyle: Style | undefined;
+					if (
+						isOrderedList &&
+						markerResolved.style?.width === undefined &&
+						markerResolved.style?.flexBasis === undefined
+					) {
+						const parent = element.parentNode;
+						const listLength = parent
+							? (listLengths.get(parent) ??
+								parent.childNodes.filter((child) => child.rawTagName?.toLowerCase() === "li").length)
+							: 1;
+						if (parent) listLengths.set(parent, listLength);
+						const markerFontSize =
+							typeof markerResolved.style?.fontSize === "number"
+								? markerResolved.style.fontSize
+								: metadata.typography.body.fontSize;
+						const markerLetterSpacing =
+							typeof markerResolved.style?.letterSpacing === "number"
+								? Math.max(0, markerResolved.style.letterSpacing)
+								: 0;
+						const markerDigits = String(listLength).length;
+						orderedMarkerStyle = {
+							width: "auto",
+							minWidth: markerDigits * markerFontSize + (markerDigits + 1) * markerLetterSpacing,
+							flexShrink: 0,
+						};
+					}
 					const itemStyles = toRichTextStyleArray(style);
 					const contentItemStyles = itemStyles.map(stripRichTextVerticalMargins);
 


### PR DESCRIPTION
Ordered list markers could overlap their body text once labels reached two or three digits; even single-digit Courier markers exceeded the fixed gutter. Ordered markers now use intrinsic text width plus a common minimum gutter for each list, accounting for marker font size and letter spacing so body starts stay aligned across 9→10 and 99→100. Existing list pagination tags and behavior are preserved.

This addresses overlap reproduced during the investigation of #2751. The original v5.0.10 missing-leading-digit screenshot was not reproduced, and this PR does not claim to resolve that exact historical symptom. Authored ordered-list start remains unchanged. Existing RTL nested-list flattening also remains unchanged (baseline/fixed PDF coordinates match).

Validation: 30 actual-PDF regression tests cover Helvetica, Courier and Noto Serif SC; one-, two- and three-digit labels; LTR/RTL; narrow columns/sidebar; LTR nesting; page breaks and content retention; authored font size/inheritance, letter spacing and row gaps. All 36 existing list pagination tests pass. Independent review reproduced the letter-spacing edge case and verified the correction.

Full PDF suite: 932 tests passed. PDF typecheck, package boundaries, and repository checks passed.

Refs #2751




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ordered-list formatting in generated PDFs by maintaining consistent spacing between list markers and body text.
  * Marker spacing now adapts across different font sizes, letter spacing, list lengths, layouts, and text directions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes ordered-list marker sizing in generated PDFs so every item reserves a common minimum gutter based on list length, marker font size, and letter spacing.
- Preserves explicit marker widths and existing list pagination behavior.
- Adds PDF regression coverage across multiple fonts, list lengths, directions, layouts, nesting, pagination, and authored typography.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/rich-text.tsx | Computes and caches each ordered list’s marker width floor while preserving authored width and flex-basis overrides. |
| packages/pdf/src/templates/shared/ordered-marker.test.tsx | Adds broad rendered-PDF assertions for marker clearance, aligned body edges, pagination, RTL/LTR output, typography, and row gaps. |

</details>

<sub>Reviews (2): Last reviewed commit: ["perf(pdf): cache ordered list marker siz..."](https://github.com/amruthpillai/reactive-resume/commit/7ac7fd31bd71f180e1d6592fae18c4e541edb102) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60788764)</sub>

<!-- /greptile_comment -->