### PR TITLE
docs: clarify separate PostgreSQL self-hosting

### DIFF
--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -11,6 +11,10 @@ description: "How to self-host Reactive Resume with Docker (Postgres only), with
 
 Reactive Resume can be self-hosted with Docker. These are the services you'll need:
 
+The official image runs one application container that serves both the web app and API. PostgreSQL must run as a
+separate service and the app connects to it through `DATABASE_URL`; no all-in-one image with an embedded database is
+planned. Follow the [Docker Compose quickstart](#quickstart-using-docker-compose) below for the supported setup.
+
 <CardGroup cols={2}>
   <Card title="PostgreSQL">Stores accounts, resumes, and application data.</Card>
   <Card title="Email (optional)">
@@ -33,6 +37,20 @@ You can pull the latest app image from:
   <Card title="Compute">1 vCPU / 1 GB RAM minimum (2 GB recommended if Postgres runs on the same host).</Card>
   <Card title="Storage">Enough for Postgres + uploads (start with 10-20 GB and scale as needed).</Card>
 </CardGroup>
+
+## Smallest supported setup
+
+1. Provide a separate, healthy PostgreSQL service. In the example below, its service name is `postgres`.
+2. Put `APP_URL`, `DATABASE_URL`, and `AUTH_SECRET` in a private `.env` file. Set the database host in `DATABASE_URL`
+   to a name or address reachable from the app container.
+3. If S3 is disabled, mount persistent storage for app uploads at `/app/data`.
+4. Attach the `reactive-resume` app service and PostgreSQL service to the intended private container network. Do not
+   expose PostgreSQL to the public internet.
+5. Launch the services with the existing [Docker Compose quickstart](#quickstart-using-docker-compose).
+6. Wait for PostgreSQL, automatic migrations, and the app health check before opening the UI.
+
+The repository's full `compose.yml` also defines optional Redis and S3-compatible storage services. Those services are
+not required for the core resume workflow; use the two-service example below when you only need the app and PostgreSQL.
 
 ## Quickstart using Docker Compose
 
@@ -230,6 +248,28 @@ docker compose logs -f reactive-resume
   </Step>
 </Steps>
 
+## Unraid and other homelab platforms
+
+Use your platform's generic container configuration to create two separately managed containers: one for Reactive
+Resume and one for PostgreSQL. No official Unraid Community Applications template is provided.
+
+- Use the official `amruthpillai/reactive-resume:latest` or `ghcr.io/amruthpillai/reactive-resume:latest` image for the
+  app container.
+- Map the app's container port `3000` to the host port you want to use.
+- Connect both containers to a private container network. Set the host in `DATABASE_URL` to the PostgreSQL container or
+  service name reachable on that network.
+- Set `APP_URL`, `DATABASE_URL`, and `AUTH_SECRET` as private environment variables.
+- When S3 is disabled, map persistent app upload storage to `/app/data`.
+- Give PostgreSQL its own persistent data volume and manage it independently from the app container.
+
+<Warning>
+  `localhost` inside the Reactive Resume container refers to that app container. It cannot reach a separate PostgreSQL
+  container. Use the PostgreSQL container or service name on the private network instead.
+</Warning>
+
+After starting both containers, wait for PostgreSQL to become healthy and check the app logs while automatic migrations
+run. Open the UI only after the app health check succeeds.
+
 ## How startup works (database migrations)
 
 <Info>
@@ -373,6 +413,9 @@ To update your Reactive Resume installation to the latest version:
 
 1. **Back up your database and uploads first.** Do this before every update.
 
+   The database and upload storage are independent resources. Recreating the app container must preserve both the
+   PostgreSQL data volume or managed database and the `/app/data` mount or S3 bucket.
+
 2. **Pull the latest images** for all services defined in your Docker Compose file.
 
    ```bash
@@ -398,9 +441,15 @@ To update your Reactive Resume installation to the latest version:
 
 This process updates app services and automatically runs DB migrations on startup. If migration fails, restore from backup and fix configuration before retrying.
 
+Update PostgreSQL separately from the app. For a PostgreSQL major-version upgrade, follow the upgrade procedure for your
+database image, host, or managed provider; pulling a new app image does not upgrade or migrate the PostgreSQL server.
+
 ## Backups (recommended)
 
 Reactive Resume stores data in two places: the PostgreSQL database and file uploads (either local storage or S3). Back up both on a regular schedule.
+
+Test restores for both resources. An app container backup alone does not include the separate database or uploads, and
+recreating the app container must not replace either persistent resource.
 
 ### Database backups
 

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -46,11 +46,13 @@ You can pull the latest app image from:
 3. If S3 is disabled, mount persistent storage for app uploads at `/app/data`.
 4. Attach the `reactive-resume` app service and PostgreSQL service to the intended private container network. Do not
    expose PostgreSQL to the public internet.
-5. Launch the services with the existing [Docker Compose quickstart](#quickstart-using-docker-compose).
+5. Launch the services with the [Docker Compose quickstart](#quickstart-using-docker-compose) below.
 6. Wait for PostgreSQL, automatic migrations, and the app health check before opening the UI.
 
 The repository's full `compose.yml` also defines optional Redis and S3-compatible storage services. Those services are
 not required for the core resume workflow; use the two-service example below when you only need the app and PostgreSQL.
+The repository file is a broader source-build stack and publishes administration ports for local use. Before using it
+on an internet-facing host, remove those host port mappings, bind them to loopback, or restrict them with a firewall.
 
 ## Quickstart using Docker Compose
 
@@ -174,7 +176,7 @@ FLAG_ALLOW_UNSAFE_AI_BASE_URL="false"
 ```yaml compose.yml
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:17
     restart: unless-stopped
     environment:
       POSTGRES_DB: postgres
@@ -409,7 +411,7 @@ openssl rand -hex 32
 
 ## Updating your installation
 
-To update your Reactive Resume installation to the latest version:
+To update an installation created from the image-based quickstart above to the latest version:
 
 1. **Back up your database and uploads first.** Do this before every update.
 
@@ -427,6 +429,11 @@ To update your Reactive Resume installation to the latest version:
    ```bash
    docker compose up -d --no-deps reactive-resume
    ```
+
+   These commands target the `reactive-resume` image service from the quickstart. The repository's full `compose.yml`
+   instead names its build-only app service `reactive_resume`; after confirming its dependencies are healthy, rebuild
+   only that service with `docker compose up -d --build --no-deps reactive_resume`. Do not run `docker compose pull`
+   for that build-only service.
 
 4. **Check migration/startup logs** after deploy.
 

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -416,16 +416,16 @@ To update your Reactive Resume installation to the latest version:
    The database and upload storage are independent resources. Recreating the app container must preserve both the
    PostgreSQL data volume or managed database and the `/app/data` mount or S3 bucket.
 
-2. **Pull the latest images** for all services defined in your Docker Compose file.
+2. **Pull the latest app image.** Leave the PostgreSQL service unchanged.
 
    ```bash
-   docker compose pull
+   docker compose pull reactive-resume
    ```
 
-3. **Restart the containers** to run the new images.
+3. **Recreate only the app container** to run the new image.
 
    ```bash
-   docker compose up -d
+   docker compose up -d --no-deps reactive-resume
    ```
 
 4. **Check migration/startup logs** after deploy.
@@ -439,10 +439,12 @@ To update your Reactive Resume installation to the latest version:
    docker image prune -f
    ```
 
-This process updates app services and automatically runs DB migrations on startup. If migration fails, restore from backup and fix configuration before retrying.
+This process updates the app container and automatically runs DB migrations on startup. If migration fails, restore from backup and fix configuration before retrying.
 
-Update PostgreSQL separately from the app. For a PostgreSQL major-version upgrade, follow the upgrade procedure for your
-database image, host, or managed provider; pulling a new app image does not upgrade or migrate the PostgreSQL server.
+Update PostgreSQL separately from the app. Choose a supported, major-pinned PostgreSQL image or select the target version
+through your managed provider, then follow that image's, host's, or provider's upgrade procedure. Back up the database
+and verify that the backup can be restored before a major-version upgrade. Pulling a new app image and running app
+migrations do not upgrade the PostgreSQL server.
 
 ## Backups (recommended)
 

--- a/docs/self-hosting/docker.mdx
+++ b/docs/self-hosting/docker.mdx
@@ -411,7 +411,8 @@ openssl rand -hex 32
 
 ## Updating your installation
 
-To update an installation created from the image-based quickstart above to the latest version:
+To update an installation created from the image-based quickstart above to the latest version, follow only the numbered
+steps below. If you use the repository's full `compose.yml`, use the separate source-build path after these steps.
 
 1. **Back up your database and uploads first.** Do this before every update.
 
@@ -430,11 +431,6 @@ To update an installation created from the image-based quickstart above to the l
    docker compose up -d --no-deps reactive-resume
    ```
 
-   These commands target the `reactive-resume` image service from the quickstart. The repository's full `compose.yml`
-   instead names its build-only app service `reactive_resume`; after confirming its dependencies are healthy, rebuild
-   only that service with `docker compose up -d --build --no-deps reactive_resume`. Do not run `docker compose pull`
-   for that build-only service.
-
 4. **Check migration/startup logs** after deploy.
 
    ```bash
@@ -445,6 +441,18 @@ To update an installation created from the image-based quickstart above to the l
    ```bash
    docker image prune -f
    ```
+
+### Update from the repository Compose file
+
+The repository's full `compose.yml` names its build-only app service `reactive_resume`. After confirming its dependencies
+are healthy, rebuild that service and follow its migration/startup logs with:
+
+```bash
+docker compose up -d --build --no-deps reactive_resume
+docker compose logs -f reactive_resume
+```
+
+Do not run `docker compose pull` for this build-only service.
 
 This process updates the app container and automatically runs DB migrations on startup. If migration fails, restore from backup and fix configuration before retrying.
 

--- a/docs/self-hosting/examples.mdx
+++ b/docs/self-hosting/examples.mdx
@@ -20,6 +20,21 @@ They go further than the basic setup in the [Self-hosting with Docker](/self-hos
 
 ---
 
+## Reuse an existing PostgreSQL service
+
+Reactive Resume always uses a separate PostgreSQL service; do not embed another database server in the app container.
+If your homelab or hosting platform already manages PostgreSQL, reuse it by setting `DATABASE_URL` to that service and
+allowing the app container to reach it over the intended private network. Keep database credentials private and do not
+expose PostgreSQL to the public internet.
+
+For generic Unraid and homelab container fields, including the `localhost` networking warning, see
+[Unraid and other homelab platforms](/self-hosting/docker#unraid-and-other-homelab-platforms). The core resume workflow
+does not require Redis or S3. Redis is a separate optional dependency for the AI Agent workspace, while S3-compatible
+storage is optional unless you need features that require private object storage; see the
+[environment variable reference](/self-hosting/docker#environment-variables) for those boundaries.
+
+---
+
 ## Docker with Traefik
 
 This example uses [Traefik](https://traefik.io/) as a reverse proxy with automatic SSL certificate management via Let's Encrypt. Postgres stays on an internal network. The Traefik dashboard is also routed, at `traefik.${DOMAIN}` behind basic auth — drop those labels if you do not want it reachable.

--- a/docs/self-hosting/examples.mdx
+++ b/docs/self-hosting/examples.mdx
@@ -27,6 +27,10 @@ If your homelab or hosting platform already manages PostgreSQL, reuse it by sett
 allowing the app container to reach it over the intended private network. Keep database credentials private and do not
 expose PostgreSQL to the public internet.
 
+When the database connection crosses a host or network boundary, require TLS with certificate and hostname verification.
+Use `sslmode=verify-full` in `DATABASE_URL` where the provider supports it, or the provider's equivalent verified-TLS
+configuration. Private routing limits exposure, but does not itself verify the database server's identity.
+
 For generic Unraid and homelab container fields, including the `localhost` networking warning, see
 [Unraid and other homelab platforms](/self-hosting/docker#unraid-and-other-homelab-platforms). The core resume workflow
 does not require Redis or S3. Redis is a separate optional dependency for the AI Agent workspace, while S3-compatible


### PR DESCRIPTION
## Summary

- document supported app-container plus separate PostgreSQL topology
- add minimal Docker and generic Unraid/homelab guidance
- separate app updates from major-pinned PostgreSQL upgrade procedures
- clarify managed PostgreSQL reuse, optional services, and backup ownership

Relates to #2722. This documents supported topology; it does not implement an all-in-one image.

## Verification

- docker compose -f compose.yml config --quiet
- markdownlint-cli2 on both changed guides
- focused runtime-claim and internal-link inspection
- git diff --check and two-file scope gate
- independent review completed; update-safety finding fixed and re-reviewed clean

Intentionally unmerged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the smallest supported self-hosting setup, including separate PostgreSQL requirements.
  * Added guidance for Unraid and other homelab platforms.
  * Simplified app update instructions and documented independent PostgreSQL upgrades.
  * Added backup and restore guidance for databases and uploads.
  * Documented how to reuse an externally managed PostgreSQL service.
  * Clarified that Redis and S3-compatible storage are optional for specific features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the supported application-container and separate-PostgreSQL topology, including minimal Docker and homelab deployment guidance.
- Separates image-based application updates from repository source-build updates.
- Adds PostgreSQL upgrade, backup, restore, managed-service, and TLS guidance.
- Clarifies when Redis, S3-compatible storage, and persistent local uploads are required.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/self-hosting/docker.mdx | Expands deployment and maintenance guidance while correctly separating the `reactive-resume` image service from the repository's `reactive_resume` build service. |
| docs/self-hosting/examples.mdx | Adds guidance for reusing separately managed PostgreSQL with private networking and verified TLS. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: separate repository update instruc..."](https://github.com/amruthpillai/reactive-resume/commit/171637526de4bb0d0e4320ebb85048675b92f1c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60830604)</sub>

<!-- /greptile_comment -->