### PR TITLE
docs: explain local Git backup workflow

### DIFF
--- a/docs/guides/exporting-your-resume.mdx
+++ b/docs/guides/exporting-your-resume.mdx
@@ -159,10 +159,12 @@ Stable filenames and the exports' two-space indentation make field changes easie
 
 ### Recover an earlier resume without replacing the current one
 
-Choose the committed revision of `resume.json` that you want to recover. You can inspect the currently committed version from the backup folder with:
+Choose the committed revision of `resume.json` that you want to recover. List commits that changed the file, then inspect
+the selected revision from the backup folder:
 
 ```bash
-git show HEAD:resume.json
+git log --oneline -- resume.json
+git show <commit>:resume.json
 ```
 
 Save the selected earlier revision as a JSON file. On the Reactive Resume dashboard, select **Import an existing resume**, choose that file, and complete the import. Import creates a new resume, so the current resume remains available for comparison or further editing.

--- a/docs/guides/exporting-your-resume.mdx
+++ b/docs/guides/exporting-your-resume.mdx
@@ -98,17 +98,78 @@ For examples and common workflows, see [Exporting a resume to Markdown](/guides/
 
 Choose **JSON** when you want a structured backup of your resume.
 
-The JSON export includes your full resume content and settings. You can import it later from the dashboard to restore the resume or create another version.
+The JSON export includes your full resume content and settings, including any cover letter sections embedded in that resume. You can import it later from the dashboard to restore the resume or create another version.
 
 JSON is also useful when working with AI assistants that understand structured data. Export JSON, ask an assistant to review or edit the fields, then import the revised JSON as a new resume.
 
 <Info>
-  JSON export is only available on the **Resume** tab. Cover letters are exported through PDF, DOCX, or Markdown.
+  JSON export in the download dialog is only available on the **Resume** tab. To export an independent letter as JSON, open it from **Cover letters** on the dashboard and select **Export JSON**.
 </Info>
 
 <Warning>
   Review AI-generated changes before importing or using them. AI assistants can make mistakes or add details that do not reflect your experience.
 </Warning>
+
+## Keep JSON backups in a local Git repository
+
+Git can keep owner-controlled versions of your exported resume and cover letter without changing Reactive Resume or connecting it to a Git provider. This workflow is manual and local only: Reactive Resume does not commit, synchronize, or upload the files for you.
+
+### Choose the right exports
+
+Reactive Resume provides three different JSON shapes:
+
+| Export | How to create it | What it contains | Can you import it as one resume? |
+| --- | --- | --- | --- |
+| **Single resume** | In the builder, open **Download**, stay on **Resume**, and download **JSON**. | Resume content and settings, including cover letter sections embedded in that resume. | Yes. |
+| **Independent cover letter** | Open a letter from **Cover letters** on the dashboard and select **Export JSON**. | That letter's content and copied resume styling in the Reactive Resume cover-letter format. | No. Import it through the cover-letter library instead. |
+| **Account archive** | Open **Settings**, go to **Account**, and select **Export my data**. | Account profile metadata, all owned resume records, independent cover letters, and an `exportedAt` timestamp. | No. It is an archive, not a single-resume import file. |
+
+Use the single-resume and independent-cover-letter exports for the Git workflow below. An account archive is an additional portability backup, not a replacement for those files. Because its `exportedAt` timestamp changes on every export, do not expect otherwise unchanged account archives to be byte-for-byte identical.
+
+### Create the local backup
+
+1. Create a folder outside your Reactive Resume source checkout.
+2. Export the resume and each independent cover letter you want to keep.
+3. Give the files stable, descriptive names. The example below uses `resume.json` and `cover-letter.json`; replace each file with its latest export instead of changing its name.
+4. From that folder, initialize Git and inspect exactly what you are about to commit:
+
+```bash
+git init
+git add -- resume.json cover-letter.json
+git diff --cached --stat
+git diff --cached -- resume.json cover-letter.json
+git commit -m "Back up resume and cover letter"
+```
+
+After the first commit, replace the JSON files with fresh exports and inspect the visible changes before committing again:
+
+```bash
+git diff -- resume.json
+```
+
+Stable filenames and the exports' two-space indentation make field changes easier to review. Repeat the add, diff, and commit steps only after the changes look correct.
+
+<Warning>
+  Resume JSON, cover-letter JSON, and especially an account archive can contain private data such as contact details, application text, profile metadata, and email address. A local Git repository does not publish anything. Inspect every diff and decide separately whether to publish it; if you use a remote, make it private and control who can access it.
+</Warning>
+
+<Info>
+  JSON exports store image URLs, not offline copies of image files. An imported backup can show an image only while the referenced storage remains available and accessible.
+</Info>
+
+### Recover an earlier resume without replacing the current one
+
+Choose the committed revision of `resume.json` that you want to recover. You can inspect the currently committed version from the backup folder with:
+
+```bash
+git show HEAD:resume.json
+```
+
+Save the selected earlier revision as a JSON file. On the Reactive Resume dashboard, select **Import an existing resume**, choose that file, and complete the import. Import creates a new resume, so the current resume remains available for comparison or further editing.
+
+Only a single-resume JSON export works for this recovery flow. Import independent cover letters through the cover-letter library. Restoring an account archive wholesale is outside this workflow.
+
+Git backups complement Reactive Resume's rolling snapshots; they do not replace or synchronize with [undo and version history](/guides/undoing-changes-and-version-history).
 
 ## Printing your resume
 

--- a/docs/guides/exporting-your-resume.mdx
+++ b/docs/guides/exporting-your-resume.mdx
@@ -42,7 +42,7 @@ Every export runs from the same **Download** dialog. You can open it two ways.
 
 If your resume includes a [cover letter section](/guides/adding-a-cover-letter), the download dialog treats the resume and cover letter as two distinct documents.
 
-- The **Resume** tab exports only your resume content and excludes cover letter sections.
+- For PDF, DOCX, and Markdown, the **Resume** tab exports only your resume content and excludes cover letter sections. Its JSON export retains embedded cover-letter custom sections; independent cover letters remain separate dashboard exports.
 - The **Cover letter** tab exports only visible cover letter sections, rendered full width on their own page.
 
 You do not need to reorder pages or hide sections by hand to produce a resume-only or cover-letter-only PDF. Select the tab that matches what you want, then pick a format.

--- a/docs/guides/exporting-your-resume.mdx
+++ b/docs/guides/exporting-your-resume.mdx
@@ -160,7 +160,8 @@ Stable filenames and the exports' two-space indentation make field changes easie
 ### Recover an earlier resume without replacing the current one
 
 Choose the committed revision of `resume.json` that you want to recover. List commits that changed the file, then inspect
-the selected revision from the backup folder:
+the selected revision from the backup folder. Choose a fresh, unused output filename; the example assumes
+`recovered-resume.json` does not already exist:
 
 ```bash
 git log --oneline -- resume.json

--- a/docs/guides/exporting-your-resume.mdx
+++ b/docs/guides/exporting-your-resume.mdx
@@ -165,9 +165,10 @@ the selected revision from the backup folder:
 ```bash
 git log --oneline -- resume.json
 git show <commit>:resume.json
+git show <commit>:resume.json > recovered-resume.json
 ```
 
-Save the selected earlier revision as a JSON file. On the Reactive Resume dashboard, select **Import an existing resume**, choose that file, and complete the import. Import creates a new resume, so the current resume remains available for comparison or further editing.
+On the Reactive Resume dashboard, select **Import an existing resume**, choose `recovered-resume.json`, and complete the import. Import creates a new resume, so the current resume remains available for comparison or further editing.
 
 Only a single-resume JSON export works for this recovery flow. Import independent cover letters through the cover-letter library. Restoring an account archive wholesale is outside this workflow.
 

--- a/docs/guides/undoing-changes-and-version-history.mdx
+++ b/docs/guides/undoing-changes-and-version-history.mdx
@@ -50,6 +50,8 @@ Reactive Resume snapshots your resume automatically:
 
 Snapshots are stored on the server, per resume, and are kept across sessions.
 
+Reactive Resume keeps a rolling window of the 30 most recent snapshots for each resume. Periodic editing snapshots are throttled to at most one every two minutes, while milestones such as imports, template changes, AI edits, and restores create their own checkpoints.
+
 ### Open version history
 
 Click the **clock** icon in the builder header, next to the resume name, to open the version history menu.
@@ -83,6 +85,15 @@ Restoring is **non-destructive**: it writes the older snapshot back through the 
   from the dashboard.
 </Info>
 
+## Keep longer owner-managed history with Git
+
+In-app version history and Git backups solve different problems:
+
+- **In-app version history** is automatic, stored by Reactive Resume, and limited to the 30 most recent rolling snapshots for one resume.
+- **Git history** contains only the JSON exports you choose to commit. It is stored in your own local repository, uses your commit messages, and follows the retention you choose.
+
+Git backup is manual. Reactive Resume does not create commits, synchronize with a repository, or upload files to a remote. To set up a local repository and recover a committed export as a new resume, see [Keep JSON backups in a local Git repository](/guides/exporting-your-resume#keep-json-backups-in-a-local-git-repository).
+
 ## Which to use when
 
 | Situation | Use |
@@ -92,3 +103,4 @@ Restoring is **non-destructive**: it writes the older snapshot back through the 
 | You imported a resume and want to compare with what you had before. | Version history |
 | The AI assistant applied edits you no longer want. | Undo the batch, or restore the pre-AI snapshot. |
 | You closed the browser and want to roll back yesterday's changes. | Version history |
+| You want selected backups beyond the 30-snapshot rolling window. | Export JSON and commit it to your own Git repository. |

--- a/docs/guides/undoing-changes-and-version-history.mdx
+++ b/docs/guides/undoing-changes-and-version-history.mdx
@@ -8,7 +8,7 @@ Reactive Resume keeps two layers of change history for every resume:
 - **Undo and redo**: a live timeline of the changes you've made in the current builder session.
 - **Version history**: server-side snapshots taken at meaningful moments, kept even after you close the builder.
 
-Use undo for a quick correction. Use version history to jump back to a template switch, an import, or an AI edit you made earlier.
+Use undo for a quick correction. Use version history to jump back to an earlier editing snapshot, import, or AI/API edit.
 
 ## Undo and redo
 
@@ -44,13 +44,13 @@ Undo history lives in your browser for the current session. Reloading the builde
 Reactive Resume snapshots your resume automatically:
 
 - when you import a resume;
-- when you switch templates;
-- when the AI assistant applies edits;
-- on periodic saves during editing.
+- when the AI assistant or API applies edits;
+- on periodic saves during editing, including template switches;
+- when you restore a version.
 
 Snapshots are stored on the server, per resume, and are kept across sessions.
 
-Reactive Resume keeps a rolling window of the 30 most recent snapshots for each resume. Periodic editing snapshots are throttled to at most one every two minutes, while milestones such as imports, template changes, AI edits, and restores create their own checkpoints.
+Reactive Resume keeps a rolling window of the 30 most recent snapshots for each resume. Periodic editing snapshots, including template changes, are throttled to at most one every two minutes. Imports, AI/API edits, and restores create their own checkpoints.
 
 ### Open version history
 
@@ -99,7 +99,7 @@ Git backup is manual. Reactive Resume does not create commits, synchronize with 
 | Situation | Use |
 | --- | --- |
 | You typed a wrong word or moved an item you didn't mean to. | Undo (`Cmd/Ctrl+Z`) |
-| You just switched templates and want the old one back. | Undo, or version history if you've kept editing since. |
+| You just switched templates and want the old one back. | Undo; version history can help only after a periodic editing snapshot captures the switch. |
 | You imported a resume and want to compare with what you had before. | Version history |
 | The AI assistant applied edits you no longer want. | Undo the batch, or restore the pre-AI snapshot. |
 | You closed the browser and want to roll back yesterday's changes. | Version history |


### PR DESCRIPTION
## Summary

- document stable JSON export files for resume and cover-letter backups
- show a plain local Git workflow for versioning and recovery
- clarify in-app history limits, export scope, image references, and import-as-new behavior

## Validation

- 152 focused API, import, schema, and web tests passed
- Markdown lint passed
- independent full-diff review passed with no findings
- fresh base, scope, and diff checks passed

Relates to #2705

This PR is intentionally left unmerged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified which resume and cover letter sections are included in PDF, DOCX, Markdown, and JSON exports.
  - Documented JSON export availability and the locations for exporting independent cover letters.
  - Added guidance for creating and restoring local Git-based JSON backups.
  - Expanded version history guidance to cover imports, AI/API edits, restores, and template changes.
  - Documented snapshot limits, throttling, and when to use Git for longer-term history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands the export and version-history guides with local Git backup and recovery instructions, clarifies the available JSON export shapes, and documents snapshot retention behavior.
- Explains how to version stable resume and cover-letter JSON files in a local Git repository.
- Documents recovery by importing an earlier committed resume as a new resume.
- Clarifies export scope, image references, snapshot limits, and checkpoint triggers.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the outstanding restore guidance stops claiming that Cmd/Ctrl+Z can reverse a restore.

Restoring a version applies server state through `replaceResumeFromServer`, which clears both history stacks, so the guide’s remaining Cmd/Ctrl+Z recovery instruction does not work; users must restore the generated pre-restore snapshot instead.

**Files Needing Attention:** docs/guides/undoing-changes-and-version-history.mdx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/guides/exporting-your-resume.mdx | Adds detailed JSON export, local Git backup, privacy, and recovery guidance. |
| docs/guides/undoing-changes-and-version-history.mdx | Clarifies snapshot creation, retention, throttling, and the distinction between in-app history and owner-managed Git backups. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: clarify recovered backup filename"](https://github.com/amruthpillai/reactive-resume/commit/4ffdd96bdda668513e26051a52c971d546e01bff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60832564)</sub>

<!-- /greptile_comment -->