### PR TITLE
docs: explain current AI tailoring workflow

### DIFF
--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -763,7 +763,7 @@ rss: true
   - **No more Browserless / Chromium dependency.** From v5.1.0 onwards, you do **not** need to run a `printer`, Browserless, or headless Chrome service alongside Reactive Resume. PDF generation is now performed entirely in your browser via `@react-pdf/renderer`. The `BROWSERLESS_TOKEN`, `PRINTER_ENDPOINT`, `PRINTER_APP_URL`, and `FLAG_DEBUG_PRINTER` environment variables are no longer read and can be removed from your `.env`.
   - **Database migrations.** This release ships several new schema migrations to bring the resume model up to date. They run automatically on container start, but you should **back up your PostgreSQL database before upgrading** in case rollback is needed.
   - **Custom CSS has been removed.** Because the resume PDF is no longer produced by a headless browser, raw CSS no longer applies to the exported document. A first-class template-customization story is on the roadmap for a future release.
-  - **Job Listings has been removed.** The JSearch/RapidAPI-backed job listings feature and its settings were removed in the v5.1.0 transition. The old job-search settings path now redirects to **Integrations**. To tailor a resume, supply a job description to the AI Agent by pasting or attaching it; see [Using the AI Agent workspace](/guides/using-ai-agent#tailor-a-resume-to-a-supplied-job-description).
+  - **Job Listings has been removed.** The JSearch/RapidAPI-backed job listings feature and its settings were removed in the v5.1.0 transition. The old job-search settings path now redirects to **Integrations**. To tailor a resume, paste a job description into the AI Agent; see [Using the AI Agent workspace](/guides/using-ai-agent#tailor-a-resume-to-a-supplied-job-description).
 </Note>
 
 ## Highlights

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -763,6 +763,7 @@ rss: true
   - **No more Browserless / Chromium dependency.** From v5.1.0 onwards, you do **not** need to run a `printer`, Browserless, or headless Chrome service alongside Reactive Resume. PDF generation is now performed entirely in your browser via `@react-pdf/renderer`. The `BROWSERLESS_TOKEN`, `PRINTER_ENDPOINT`, `PRINTER_APP_URL`, and `FLAG_DEBUG_PRINTER` environment variables are no longer read and can be removed from your `.env`.
   - **Database migrations.** This release ships several new schema migrations to bring the resume model up to date. They run automatically on container start, but you should **back up your PostgreSQL database before upgrading** in case rollback is needed.
   - **Custom CSS has been removed.** Because the resume PDF is no longer produced by a headless browser, raw CSS no longer applies to the exported document. A first-class template-customization story is on the roadmap for a future release.
+  - **Job Listings has been removed.** The JSearch/RapidAPI-backed job listings feature and its settings were removed in the v5.1.0 transition. The old job-search settings path now redirects to **Integrations**. To tailor a resume, supply a job description to the AI Agent by pasting or attaching it; see [Using the AI Agent workspace](/guides/using-ai-agent#tailor-a-resume-to-a-supplied-job-description).
 </Note>
 
 ## Highlights

--- a/docs/guides/ai-agent-tools.mdx
+++ b/docs/guides/ai-agent-tools.mdx
@@ -45,7 +45,11 @@ Restoring an older patch rolls back that patch and any patches applied after it.
 
 Live web research is handled only by the selected AI provider's native web search tool. When the provider/model supports it, the agent can use `web_search` for current company, industry, role, or URL-based context.
 
+Provider-native `web_search` is not JSearch and does not restore the removed structured job-listings experience. It supplies web context to the agent; it does not provide a structured job-results API or guarantee that a provider/model can search.
+
 When the provider/model does not support native web search, the agent still works for normal resume editing. If you ask it to browse, search the web, fetch a URL, or use current online context, it should tell you that live web research is unavailable with the selected provider/model and ask you to paste or attach the relevant content instead.
+
+For a controlled workflow that works without live research, follow [Tailor a resume to a supplied job description](/guides/using-ai-agent#tailor-a-resume-to-a-supplied-job-description). Configure, test, and enable providers as described in [Using artificial intelligence](/guides/using-ai).
 
 For self-hosted deployments:
 

--- a/docs/guides/using-ai-agent.mdx
+++ b/docs/guides/using-ai-agent.mdx
@@ -107,8 +107,8 @@ Use this controlled workflow to test tailoring without relying on live web resea
     Then ask: "Tailor the existing experience for this role. Do not invent qualifications or experience."
   </Step>
 
-  <Step title="Review and restore if needed">
-    Before sending the request, open the thread menu and enable **Review edits** if you want to approve or deny each proposed patch. After a patch is applied, review the updated draft and open **Patch applied** to inspect it. Use **Restore** to roll the draft back to the state before that patch; restoring an older patch also rolls back later patches.
+  <Step title="Review the draft">
+    Review the updated draft. To approve patches before they are applied, inspect their JSON, or restore an earlier state, follow [Review patches](#review-patches).
   </Step>
 </Steps>
 

--- a/docs/guides/using-ai-agent.mdx
+++ b/docs/guides/using-ai-agent.mdx
@@ -78,13 +78,45 @@ The agent works best with concrete instructions:
 
 You can attach files or images from the composer. The agent reads uploaded attachments when they are relevant to your request.
 
+For supplied text, paste the content directly into the chat. Plain text, Markdown, and JSON attachments are available to the agent as extracted text. Images and supported files such as PDFs are passed directly to the selected provider when it can use them. If an attachment format is unsupported by the selected provider, paste the relevant text instead.
+
 <Note>
   Text input is supported. Voice input is not supported in the agent workspace yet.
 </Note>
 
+## Tailor a resume to a supplied job description
+
+Use this controlled workflow to test tailoring without relying on live web research:
+
+<Steps>
+  <Step title="Set up an AI provider">
+    In **Dashboard → Settings → Integrations**, configure a supported AI provider, test it, and make sure it is enabled. Then return to **Agents**.
+  </Step>
+
+  <Step title="Open a synthetic resume draft">
+    Start a new thread and select a resume containing synthetic experience data. The agent creates an isolated AI draft, so the source resume remains unchanged.
+  </Step>
+
+  <Step title="Supply the target role">
+    Paste this synthetic job description into the chat:
+
+    ```text
+    Target role: backend engineer. Required: TypeScript and PostgreSQL.
+    ```
+
+    Then ask: "Tailor the existing experience for this role. Do not invent qualifications or experience."
+  </Step>
+
+  <Step title="Review and restore if needed">
+    Before sending the request, open the thread menu and enable **Review edits** if you want to approve or deny each proposed patch. After a patch is applied, review the updated draft and open **Patch applied** to inspect it. Use **Restore** to roll the draft back to the state before that patch; restoring an older patch also rolls back later patches.
+  </Step>
+</Steps>
+
+This workflow also works when the selected provider/model has no live web search. Supplying the job description gives the agent the context it needs for ordinary resume editing.
+
 ## Review patches
 
-When the agent edits the resume, the patch is applied immediately to the AI draft. The chat shows a small **Patch applied** line.
+By default, the agent applies resume patches immediately to the AI draft. Turn on **Review edits** in the thread menu if you want to approve or deny patches before they are applied. Applied patches appear in chat as a small **Patch applied** line.
 
 Open the line to inspect the raw JSON Patch and use **Restore** if you want to roll the draft back to the state before that patch. Restoring an older patch also rolls back patches applied after it.
 

--- a/docs/guides/using-ai-agent.mdx
+++ b/docs/guides/using-ai-agent.mdx
@@ -93,12 +93,12 @@ Use this controlled workflow to test tailoring without relying on live web resea
     In **Dashboard → Settings → Integrations**, configure a supported AI provider, test it, and make sure it is enabled. Then return to **Agents**.
   </Step>
 
-  <Step title="Open a synthetic resume draft">
-    Start a new thread and select a resume containing synthetic experience data. The agent creates an isolated AI draft, so the source resume remains unchanged.
+  <Step title="Open a sample resume draft">
+    Start a new thread and select a resume containing sample experience data. The agent creates an isolated AI draft, so the source resume remains unchanged.
   </Step>
 
   <Step title="Supply the target role">
-    Paste this synthetic job description into the chat:
+    Paste this sample job description into the chat:
 
     ```text
     Target role: backend engineer. Required: TypeScript and PostgreSQL.
@@ -108,13 +108,13 @@ Use this controlled workflow to test tailoring without relying on live web resea
   </Step>
 
   <Step title="Review the draft">
-    Review the updated draft. To approve patches before they are applied, inspect their JSON, or restore an earlier state, follow [Review patches](#review-patches).
+    Review the updated draft. To approve patches before they are applied, inspect their JSON, or restore an earlier state, follow [Review edits and patches](#review-edits-and-patches).
   </Step>
 </Steps>
 
 This workflow also works when the selected provider/model has no live web search. Supplying the job description gives the agent the context it needs for ordinary resume editing.
 
-## Review patches
+## Review edits and patches
 
 By default, the agent applies resume patches immediately to the AI draft. Turn on **Review edits** in the thread menu if you want to approve or deny patches before they are applied. Applied patches appear in chat as a small **Patch applied** line.
 


### PR DESCRIPTION
## Summary

- record JSearch removal timing without inventing a maintainer motive
- document current job-description tailoring through isolated AI Draft resumes
- clarify provider-native web search, attachment support, patch review, and restore boundaries

## Validation

- 52 focused API and web tests passed
- Markdown lint passed
- independent full-diff review passed with no findings
- fresh base, scope, and diff checks passed

Relates to #3010

This PR is intentionally left unmerged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated upgrade notes to document the removal of the structured Job Listings feature and related settings, including the redirect to Integrations.
  - Clarified that provider-native web search does not restore the former job-listings experience.
  - Added guidance for tailoring resumes to supplied job descriptions without live research.
  - Documented handling of text, image, and file attachments based on provider support.
  - Explained patch review controls, including reviewing, approving, or denying edits before application, with immediate application as the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the current AI-assisted resume-tailoring workflow and records the removal of structured Job Listings.
- Explains that provider-native web search does not recreate JSearch-backed listings.
- Adds a controlled job-description tailoring workflow using an isolated AI draft.
- Clarifies attachment handling, patch approval, inspection, and restoration behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/changelog/index.mdx | Documents the v5.1.0 removal of Job Listings, the surviving settings redirect, and the replacement AI Agent workflow. |
| docs/guides/ai-agent-tools.mdx | Clarifies the distinction between provider-native web context and structured job listings and links to the controlled tailoring workflow. |
| docs/guides/using-ai-agent.mdx | Adds attachment guidance, a supplied-job-description tailoring walkthrough, and documentation for optional patch approval. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: align AI review terminology"](https://github.com/amruthpillai/reactive-resume/commit/1d0397884c2d1b31e8a723c2b2c206bdd41a1128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60834406)</sub>

<!-- /greptile_comment -->