### PR TITLE
test(recovery): refresh hashes for picture fit default

### DIFF
--- a/tooling/recovery/compare-resume.test.ts
+++ b/tooling/recovery/compare-resume.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import { defaultResumeData } from "@reactive-resume/schema/resume/default";
 import { compareResumeRecovery } from "./compare-resume";
 
-const SYNTHETIC_SOURCE_HASH = "68cbff28a704f3859c7f5385e9e82a3517521374d99ec2f65ca15887f81310cc";
-const RECOVERED_COPY_HASH = "56d3e7d3ecd336b6d910224e2ecb64c7a3c010ff980782f3bea985682018e3a6";
-const CURRENT_COPY_HASH = "40cb0aba1e7b3d0950314c3ad20a74b30785545658b296fea97885d6364c9b2f";
-const DEFAULT_RESUME_HASH = "15c8a97e15f248c630a6e1c16e5e257a5b02959ef749acbc18c41cd150e853a4";
+const SYNTHETIC_SOURCE_HASH = "a544b2abf225396f8c16cd2ea1c182d195a8d9179d3a95be4b1b1e7d43722e11";
+const RECOVERED_COPY_HASH = "704cd69adcd227d6975aca64afea9a63fe0eeb8e17c275b4c79627d85bdd5791";
+const CURRENT_COPY_HASH = "33d337241cd4ad8cf0faa2cdc0107fa4d607b3070f27dab7166c206b05afd882";
+const DEFAULT_RESUME_HASH = "a6930afc82a24637de715bdcac5300318261d3b69969527f43917904478e885b";
 
 const FORMAT_CHARACTERS = [
 	["zero-width space (U+200B)", "\u200B"],


### PR DESCRIPTION
## Summary

- refresh four hand-checked recovery hash fixtures after picture.fit became part of default resume data
- keep production recovery comparison behavior unchanged
- restore mainline tooling and E2E test health after #3460 and #3461 landed together

## Verification

- focused recovery tests: 83 passed
- full tooling suite: 97 passed
- tooling typecheck passed
- Biome and diff checks passed
- independent review: no findings

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Refreshes four recovery-test hash fixtures after `picture.fit` became part of the default resume data, without changing production recovery behavior.

- Updates expected source, recovered-copy, current-copy, and default-resume hashes.
- Preserves the existing recovery comparison assertions and test coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only refreshes expected test hashes and the existing recovery assertions remain intact.

The production comparison implementation is unchanged, the fixture updates correspond to the new default picture-fit field, and the reported focused and full tooling suites pass.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tooling/recovery/compare-resume.test.ts | Updates four expected SHA-256 fixtures consistently with the changed default resume shape; no actionable issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(recovery): refresh hashes for pictu..."](https://github.com/amruthpillai/reactive-resume/commit/43e6de7e4591b87f211f9ace28363204bbbe30f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60867330)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated expected hash values in recovery comparison tests to reflect current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->