### PR TITLE
fix(stylesheet): improve unsupported-gradient diagnostics

### DIFF
--- a/apps/web/src/features/resume/stylesheet/editor-extensions.test.ts
+++ b/apps/web/src/features/resume/stylesheet/editor-extensions.test.ts
@@ -208,6 +208,19 @@ describe("Semantic CSS editor extensions", () => {
 		expect(selected).toHaveBeenCalledWith(tokens[0], expect.any(DOMRect));
 	});
 
+	it("keeps unsupported-gradient diagnostics visible in the editor", () => {
+		const source = "@version 1;\nheader { background-image: linear-gradient(red, blue); }\n";
+		const compiled = compileStylesheet({ languageVersion: 1, text: source });
+
+		expect(mapCompilerDiagnostics(source.length, compiled.diagnostics)).toContainEqual(
+			expect.objectContaining({
+				severity: "error",
+				message: "Gradients are not supported by Semantic CSS. Use background-color or another supported property.",
+				source: "UNSUPPORTED_PROPERTY",
+			}),
+		);
+	});
+
 	it("preserves exact clipboard text and emits one change for an IME composition", async () => {
 		const writeText = vi.fn().mockResolvedValue(undefined);
 		Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });

--- a/apps/web/src/features/resume/stylesheet/stylesheet.worker.test.ts
+++ b/apps/web/src/features/resume/stylesheet/stylesheet.worker.test.ts
@@ -59,6 +59,23 @@ describe("stylesheet worker", () => {
 		);
 	});
 
+	it("explains that unsupported gradients need a supported background replacement", () => {
+		handleMessage?.(
+			new MessageEvent("message", {
+				data: request("@version 1;\nheader { background-image: linear-gradient(red, blue); }\n"),
+			}),
+		);
+
+		const response = postMessage.mock.calls[0]?.[0] as CompileWorkerResponse | undefined;
+		expect(response?.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "UNSUPPORTED_PROPERTY",
+				severity: "error",
+				message: "Gradients are not supported by Semantic CSS. Use background-color or another supported property.",
+			}),
+		);
+	});
+
 	it("returns overlapping semantic diagnostics once", () => {
 		handleMessage?.(
 			new MessageEvent("message", {

--- a/docs/applying-custom-styles.mdx
+++ b/docs/applying-custom-styles.mdx
@@ -192,6 +192,20 @@ The most useful declarations usually fall into a few groups:
 Use `display: none` only to hide an existing semantic node. Semantic CSS cannot add, remove, duplicate, or re-parent resume
 data.
 
+Semantic CSS keeps background styling PDF-safe. Use a flat color for headers and regions:
+
+```css
+@version 1;
+
+header {
+	background-color: #1e293b;
+}
+```
+
+Gradient declarations such as `background-image: linear-gradient(...)` remain unsupported. The editor reports that limitation
+and suggests `background-color` or another supported property; the unsupported declaration is omitted while neighboring valid
+declarations remain available for preview and export.
+
 ### Style rich-text lists
 
 `list-item` is the outer row that holds a marker and its content. Use it for row layout and spacing. Use `list-marker`

--- a/packages/pdf/src/semantic/issue-fixtures.test.tsx
+++ b/packages/pdf/src/semantic/issue-fixtures.test.tsx
@@ -36,11 +36,24 @@ const findPrimitive = (node: HostNode, type: string, text: string): HostNode | u
 	}
 };
 
+const findPath = (node: HostNode, predicate: (candidate: HostNode) => boolean): HostNode[] | undefined => {
+	if (predicate(node)) return [node];
+	for (const child of node.children ?? []) {
+		const path = findPath(child, predicate);
+		if (path) return [node, ...path];
+	}
+};
+
 const mergedStyle = (node: HostNode | undefined): Record<string, unknown> =>
 	Object.assign({}, ...(Array.isArray(node?.style) ? node.style : node?.style ? [node.style] : []));
 
 const containsStyle = (node: HostNode, property: string, value: unknown): boolean =>
 	mergedStyle(node)[property] === value || (node.children ?? []).some((child) => containsStyle(child, property, value));
+
+const nodesWithStyle = (node: HostNode, property: string, value: unknown): HostNode[] => [
+	...(mergedStyle(node)[property] === value ? [node] : []),
+	...(node.children ?? []).flatMap((child) => nodesWithStyle(child, property, value)),
+];
 
 const textRuns = (node: HostNode): string[] => [
 	...(node.type === "TEXT" ? [nodeText(node)] : []),
@@ -53,7 +66,11 @@ const buildIssueFixture = (): ResumeData => {
 	data.basics = {
 		...data.basics,
 		name: "Ada Lovelace",
+		headline: "Computing pioneer",
 		email: "ada@example.com",
+		phone: "+44 123",
+		location: "London",
+		customFields: [{ id: "custom-1", icon: "globe", text: "Ada Labs", link: "" }],
 	};
 	data.sections.experience.items = [
 		{
@@ -200,8 +217,12 @@ describe("semantic issue fixtures", () => {
 		const data = buildIssueFixture();
 		const stylesheet = source(`
 			@version 1;
-			header { background-color: #1e293b; }
+			header { background-color: #1e293b; padding: 10pt; }
 			name { color: white; }
+			headline { font-size: 14pt; }
+			contact-list { gap: 8pt; }
+			contact-item { padding: 1pt; }
+			icon { font-size: 16pt; }
 			link { text-decoration: none; }
 			section[type="experience"] field[name="company"] { font-weight: 400; }
 			section[type="skills"] field[name="name"] { font-weight: 400; }
@@ -214,12 +235,26 @@ describe("semantic issue fixtures", () => {
 		const document = instance.container.document as HostNode;
 
 		expect(mergedStyle(findText(document, "Ada Lovelace"))).toMatchObject({ color: "white" });
+		expect(mergedStyle(findText(document, "Computing pioneer"))).toMatchObject({ fontSize: 14 });
 		expect(mergedStyle(findText(document, "Analytical Engines"))).toMatchObject({ fontWeight: "400" });
 		expect(mergedStyle(findText(document, "TypeScript"))).toMatchObject({ fontWeight: "400" });
+		expect(
+			findPath(document, (node) => node.type === "LINK" && nodeText(node) === "ada@example.com")?.some(
+				(node) => mergedStyle(node).paddingTop === 1,
+			),
+		).toBe(true);
+		expect(
+			findPath(document, (node) => node.type === "LINK" && nodeText(node) === "+44 123")?.some(
+				(node) => mergedStyle(node).paddingTop === 1,
+			),
+		).toBe(true);
+		expect(nodesWithStyle(document, "fontSize", 16).some(({ type }) => type === "SVG")).toBe(true);
 		expect(mergedStyle(findPrimitive(document, "LINK", "ada@example.com"))).toMatchObject({
 			textDecoration: "none",
 		});
 		expect(containsStyle(document, "backgroundColor", "#1e293b")).toBe(true);
+		expect(containsStyle(document, "paddingTop", 10)).toBe(true);
+		expect(containsStyle(document, "rowGap", 8)).toBe(true);
 		expect(containsStyle(document, "opacity", 0.2)).toBe(true);
 	});
 

--- a/packages/pdf/src/semantic/issue-fixtures.test.tsx
+++ b/packages/pdf/src/semantic/issue-fixtures.test.tsx
@@ -36,14 +36,6 @@ const findPrimitive = (node: HostNode, type: string, text: string): HostNode | u
 	}
 };
 
-const findPath = (node: HostNode, predicate: (candidate: HostNode) => boolean): HostNode[] | undefined => {
-	if (predicate(node)) return [node];
-	for (const child of node.children ?? []) {
-		const path = findPath(child, predicate);
-		if (path) return [node, ...path];
-	}
-};
-
 const mergedStyle = (node: HostNode | undefined): Record<string, unknown> =>
 	Object.assign({}, ...(Array.isArray(node?.style) ? node.style : node?.style ? [node.style] : []));
 
@@ -238,16 +230,8 @@ describe("semantic issue fixtures", () => {
 		expect(mergedStyle(findText(document, "Computing pioneer"))).toMatchObject({ fontSize: 14 });
 		expect(mergedStyle(findText(document, "Analytical Engines"))).toMatchObject({ fontWeight: "400" });
 		expect(mergedStyle(findText(document, "TypeScript"))).toMatchObject({ fontWeight: "400" });
-		expect(
-			findPath(document, (node) => node.type === "LINK" && nodeText(node) === "ada@example.com")?.some(
-				(node) => mergedStyle(node).paddingTop === 1,
-			),
-		).toBe(true);
-		expect(
-			findPath(document, (node) => node.type === "LINK" && nodeText(node) === "+44 123")?.some(
-				(node) => mergedStyle(node).paddingTop === 1,
-			),
-		).toBe(true);
+		expect(mergedStyle(findPrimitive(document, "LINK", "ada@example.com")).paddingTop).toBe(1);
+		expect(mergedStyle(findPrimitive(document, "LINK", "+44 123")).paddingTop).toBe(1);
 		expect(nodesWithStyle(document, "fontSize", 16).some(({ type }) => type === "SVG")).toBe(true);
 		expect(mergedStyle(findPrimitive(document, "LINK", "ada@example.com"))).toMatchObject({
 			textDecoration: "none",

--- a/packages/resume/src/stylesheet/values.test.ts
+++ b/packages/resume/src/stylesheet/values.test.ts
@@ -89,6 +89,45 @@ describe("Semantic CSS value compilation", () => {
 		);
 	});
 
+	it.each([
+		"linear-gradient(red, blue)",
+		"radial-gradient(red, blue)",
+		"conic-gradient(red, blue)",
+		"repeating-linear-gradient(red, blue)",
+		"repeating-radial-gradient(red, blue)",
+		"repeating-conic-gradient(red, blue)",
+	])("recognizes the standard gradient function %s", (value) => {
+		const result = compileStylesheet({
+			languageVersion: 1,
+			text: `@version 1; header { background-image: ${value}; }`,
+		});
+
+		expect(result.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "UNSUPPORTED_PROPERTY",
+				message: "Gradients are not supported by Semantic CSS. Use background-color or another supported property.",
+			}),
+		);
+	});
+
+	it.each([
+		["custom function names", "background-image: not-linear-gradient(red, blue)", "background-image"],
+		["quoted function-like text", 'content: "linear-gradient(red, blue)"', "content"],
+	] as const)("does not treat %s as a standard gradient function", (_case, declaration, property) => {
+		const result = compileStylesheet({
+			languageVersion: 1,
+			text: `@version 1; header { ${declaration}; }`,
+		});
+
+		expect(result.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "UNSUPPORTED_PROPERTY",
+				severity: "error",
+				message: `The ${property} property is not supported by Semantic CSS.`,
+			}),
+		);
+	});
+
 	it("omits an invalid value without dropping valid declarations in the rule", () => {
 		const result = compileStylesheet({
 			languageVersion: 1,

--- a/packages/resume/src/stylesheet/values.test.ts
+++ b/packages/resume/src/stylesheet/values.test.ts
@@ -70,6 +70,25 @@ describe("Semantic CSS value compilation", () => {
 		);
 	});
 
+	it("explains that gradient backgrounds are unsupported and suggests a safe replacement", () => {
+		const result = compileStylesheet({
+			languageVersion: 1,
+			text: "@version 1; header { background-image: linear-gradient(red, blue); color: white; }",
+		});
+
+		expect(result.program).not.toBeNull();
+		expect(result.program?.rules[0]?.declarations).toContainEqual(
+			expect.objectContaining({ property: "color", value: "white" }),
+		);
+		expect(result.diagnostics).toContainEqual(
+			expect.objectContaining({
+				code: "UNSUPPORTED_PROPERTY",
+				severity: "error",
+				message: "Gradients are not supported by Semantic CSS. Use background-color or another supported property.",
+			}),
+		);
+	});
+
 	it("omits an invalid value without dropping valid declarations in the rule", () => {
 		const result = compileStylesheet({
 			languageVersion: 1,

--- a/packages/resume/src/stylesheet/values.ts
+++ b/packages/resume/src/stylesheet/values.ts
@@ -149,10 +149,24 @@ function diagnostic(
 	diagnostics.push(createDiagnostic(code, severity, message, range(node?.loc)));
 }
 
-const gradientFunctionPattern = /\b(?:repeating-)?(?:linear|radial|conic)-gradient\s*\(/i;
+const gradientFunctionNames = new Set([
+	"linear-gradient",
+	"radial-gradient",
+	"conic-gradient",
+	"repeating-linear-gradient",
+	"repeating-radial-gradient",
+	"repeating-conic-gradient",
+]);
 
-function unsupportedPropertyMessage(property: string, value: string): string {
-	if (gradientFunctionPattern.test(value)) {
+function containsGradientFunction(node: AstNode | string | null | undefined): boolean {
+	if (!node || typeof node === "string") return false;
+	if (node.type === "Function" && node.name && gradientFunctionNames.has(identifier(node.name).toLowerCase()))
+		return true;
+	return children(node).some(containsGradientFunction);
+}
+
+function unsupportedPropertyMessage(property: string, value: AstNode | string | null | undefined): string {
+	if (containsGradientFunction(value)) {
 		return "Gradients are not supported by Semantic CSS. Use background-color or another supported property.";
 	}
 	return `The ${property} property is not supported by Semantic CSS.`;
@@ -584,7 +598,7 @@ export function compileProgram(stylesheet: ParsedStylesheet, languageVersion: nu
 				diagnostic(
 					diagnostics,
 					property === "src" ? "FORBIDDEN_CSS_VALUE" : "UNSUPPORTED_PROPERTY",
-					unsupportedPropertyMessage(property, value),
+					unsupportedPropertyMessage(property, declaration.value),
 					declaration,
 				);
 				continue;

--- a/packages/resume/src/stylesheet/values.ts
+++ b/packages/resume/src/stylesheet/values.ts
@@ -149,6 +149,15 @@ function diagnostic(
 	diagnostics.push(createDiagnostic(code, severity, message, range(node?.loc)));
 }
 
+const gradientFunctionPattern = /\b(?:repeating-)?(?:linear|radial|conic)-gradient\s*\(/i;
+
+function unsupportedPropertyMessage(property: string, value: string): string {
+	if (gradientFunctionPattern.test(value)) {
+		return "Gradients are not supported by Semantic CSS. Use background-color or another supported property.";
+	}
+	return `The ${property} property is not supported by Semantic CSS.`;
+}
+
 function splitValue(value: string): string[] {
 	const parts: string[] = [];
 	let start = 0;
@@ -560,6 +569,8 @@ export function compileProgram(stylesheet: ParsedStylesheet, languageVersion: nu
 			const decodedProperty = identifier(declaration.property);
 			const property = decodedProperty.startsWith("--") ? decodedProperty : decodedProperty.toLowerCase();
 			const lowerProperty = property.toLowerCase();
+			const value =
+				typeof declaration.value === "string" ? declaration.value : csstree.generate(declaration.value as CssNode);
 			if (lowerProperty.startsWith("--resume-")) {
 				diagnostic(
 					diagnostics,
@@ -573,7 +584,7 @@ export function compileProgram(stylesheet: ParsedStylesheet, languageVersion: nu
 				diagnostic(
 					diagnostics,
 					property === "src" ? "FORBIDDEN_CSS_VALUE" : "UNSUPPORTED_PROPERTY",
-					`The ${property} property is not supported by Semantic CSS.`,
+					unsupportedPropertyMessage(property, value),
 					declaration,
 				);
 				continue;
@@ -583,8 +594,6 @@ export function compileProgram(stylesheet: ParsedStylesheet, languageVersion: nu
 				continue;
 			}
 
-			const value =
-				typeof declaration.value === "string" ? declaration.value : csstree.generate(declaration.value as CssNode);
 			const trimmedValue = value.trim();
 			const expanded = /var\s*\(/i.test(decodeCssEscapes(trimmedValue))
 				? ([[property, trimmedValue]] as const)


### PR DESCRIPTION
Relates to #3137

Partial update: Semantic CSS now gives actionable diagnostics for unsupported gradient values, with compiler, worker, editor, rendered Onyx host-tree, and documentation coverage.

Gradients remain unsupported. Original issue stays open pending a reporter-derived selected-template/CSS residual fixture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stylesheet validation for standard linear, radial, conic, and repeating gradients.
  * The editor now displays a clear error explaining that gradients are unsupported and recommends using `background-color` or another supported property.
  * Similar-looking custom values and quoted text are no longer incorrectly flagged.
  * Supported declarations in the same rule remain available for preview and export.

* **Documentation**
  * Added guidance for using PDF-safe background colors in custom resume styles.
  * Documented how unsupported gradient declarations are reported and handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR improves Semantic CSS diagnostics for unsupported gradient declarations while preserving neighboring supported declarations.
- Detects standard linear, radial, conic, and repeating gradient functions through the parsed CSS AST.
- Propagates the actionable diagnostic through compiler, worker, and editor coverage.
- Extends rendered host-tree fixture coverage and documents PDF-safe flat-color alternatives.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/resume/src/stylesheet/values.ts | Adds AST-based recognition of standard gradient functions and supplies an actionable unsupported-property diagnostic. |
| packages/resume/src/stylesheet/values.test.ts | Covers supported gradient names, false-positive exclusions, diagnostic content, and preservation of valid neighboring declarations. |
| apps/web/src/features/resume/stylesheet/stylesheet.worker.test.ts | Verifies that worker responses expose the improved gradient diagnostic. |
| apps/web/src/features/resume/stylesheet/editor-extensions.test.ts | Verifies that compiler diagnostics retain their message and severity when mapped into the editor. |
| packages/pdf/src/semantic/issue-fixtures.test.tsx | Expands rendered Onyx host-tree assertions for header, contact, icon, and spacing styles. |
| docs/applying-custom-styles.mdx | Documents flat-color guidance and the handling of unsupported gradient declarations. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Semantic CSS declaration] --> B[Parse declaration value]
  B --> C{Unsupported property?}
  C -- No --> D[Compile supported declaration]
  C -- Yes --> E{Contains standard gradient function?}
  E -- Yes --> F[Emit actionable gradient diagnostic]
  E -- No --> G[Emit generic unsupported-property diagnostic]
  F --> H[Omit unsupported declaration]
  G --> H
  D --> I[Preserve supported neighboring declarations]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(css): tighten gradient diagnostics"](https://github.com/amruthpillai/reactive-resume/commit/28c933b555de7aeed9c18b11745b10f2b108eca9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60868931)</sub>

<!-- /greptile_comment -->