### PR TITLE
feat(resume): add skill keyword list presentation

### DIFF
--- a/apps/web/locales/af-ZA.po
+++ b/apps/web/locales/af-ZA.po
@@ -6674,3 +6674,14 @@ msgstr "Zoem uit"
 msgid "Zulu"
 msgstr "Zoeloe"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/am-ET.po
+++ b/apps/web/locales/am-ET.po
@@ -6674,3 +6674,14 @@ msgstr "አጉር"
 msgid "Zulu"
 msgstr "ዙሉ"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ar-SA.po
+++ b/apps/web/locales/ar-SA.po
@@ -6674,3 +6674,14 @@ msgstr "تصغير"
 msgid "Zulu"
 msgstr "الزولو"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/az-AZ.po
+++ b/apps/web/locales/az-AZ.po
@@ -6674,3 +6674,14 @@ msgstr "Uzaqlaşdır"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/bg-BG.po
+++ b/apps/web/locales/bg-BG.po
@@ -6674,3 +6674,14 @@ msgstr "Намаляване"
 msgid "Zulu"
 msgstr "Зулуски"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/bn-BD.po
+++ b/apps/web/locales/bn-BD.po
@@ -6674,3 +6674,14 @@ msgstr "জুম আউট"
 msgid "Zulu"
 msgstr "জুলু"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ca-ES.po
+++ b/apps/web/locales/ca-ES.po
@@ -6674,3 +6674,14 @@ msgstr "Allunya"
 msgid "Zulu"
 msgstr "Zulú"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/cs-CZ.po
+++ b/apps/web/locales/cs-CZ.po
@@ -6674,3 +6674,14 @@ msgstr "Oddálit"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/da-DK.po
+++ b/apps/web/locales/da-DK.po
@@ -6674,3 +6674,14 @@ msgstr "Zoom ud"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/de-DE.po
+++ b/apps/web/locales/de-DE.po
@@ -6674,3 +6674,14 @@ msgstr "Herauszoomen"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/el-GR.po
+++ b/apps/web/locales/el-GR.po
@@ -6674,3 +6674,14 @@ msgstr "Σμίκρυνση"
 msgid "Zulu"
 msgstr "Ζουλού"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/en-GB.po
+++ b/apps/web/locales/en-GB.po
@@ -6674,3 +6674,14 @@ msgstr "Zoom out"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/en-US.po
+++ b/apps/web/locales/en-US.po
@@ -6967,3 +6967,15 @@ msgstr "Zoom out"
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr "Zulu"
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr "Keyword layout"
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr "Bulleted list"
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr "Inline"

--- a/apps/web/locales/es-ES.po
+++ b/apps/web/locales/es-ES.po
@@ -6674,3 +6674,14 @@ msgstr "Alejar"
 msgid "Zulu"
 msgstr "Zulú"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/fa-IR.po
+++ b/apps/web/locales/fa-IR.po
@@ -6674,3 +6674,14 @@ msgstr "کوچک‌نمایی"
 msgid "Zulu"
 msgstr "زولو"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/fi-FI.po
+++ b/apps/web/locales/fi-FI.po
@@ -6674,3 +6674,14 @@ msgstr "Loitonna"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/fr-FR.po
+++ b/apps/web/locales/fr-FR.po
@@ -6674,3 +6674,14 @@ msgstr "Zoom arrière"
 msgid "Zulu"
 msgstr "Zoulou"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/he-IL.po
+++ b/apps/web/locales/he-IL.po
@@ -6674,3 +6674,14 @@ msgstr "התרחקות"
 msgid "Zulu"
 msgstr "זולו"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/hi-IN.po
+++ b/apps/web/locales/hi-IN.po
@@ -6674,3 +6674,14 @@ msgstr "ज़ूम आउट"
 msgid "Zulu"
 msgstr "ज़ुलु"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/hu-HU.po
+++ b/apps/web/locales/hu-HU.po
@@ -6674,3 +6674,14 @@ msgstr "Kicsinyítés"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/id-ID.po
+++ b/apps/web/locales/id-ID.po
@@ -6674,3 +6674,14 @@ msgstr "Perkecil"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/it-IT.po
+++ b/apps/web/locales/it-IT.po
@@ -6674,3 +6674,14 @@ msgstr "Rimpicciolisci"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ja-JP.po
+++ b/apps/web/locales/ja-JP.po
@@ -6674,3 +6674,14 @@ msgstr "ズームアウト"
 msgid "Zulu"
 msgstr "ズールー語"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/km-KH.po
+++ b/apps/web/locales/km-KH.po
@@ -6674,3 +6674,14 @@ msgstr "បង្រួម"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/kn-IN.po
+++ b/apps/web/locales/kn-IN.po
@@ -6674,3 +6674,14 @@ msgstr "ಗಾತ್ರ ಕುಗ್ಗಿಸಿ"
 msgid "Zulu"
 msgstr "ಜೂಲೂ"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ko-KR.po
+++ b/apps/web/locales/ko-KR.po
@@ -6674,3 +6674,14 @@ msgstr "축소"
 msgid "Zulu"
 msgstr "줄루어"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/lt-LT.po
+++ b/apps/web/locales/lt-LT.po
@@ -6674,3 +6674,14 @@ msgstr "Tolinti"
 msgid "Zulu"
 msgstr "Zulų"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/lv-LV.po
+++ b/apps/web/locales/lv-LV.po
@@ -6674,3 +6674,14 @@ msgstr "Tālināt"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ml-IN.po
+++ b/apps/web/locales/ml-IN.po
@@ -6674,3 +6674,14 @@ msgstr "സൂം ഔട്ട് ചെയ്യുക"
 msgid "Zulu"
 msgstr "സൂളു"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/mr-IN.po
+++ b/apps/web/locales/mr-IN.po
@@ -6674,3 +6674,14 @@ msgstr "बाहेर झूम करा"
 msgid "Zulu"
 msgstr "झुलू"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ms-MY.po
+++ b/apps/web/locales/ms-MY.po
@@ -6674,3 +6674,14 @@ msgstr "Zum keluar"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ne-NP.po
+++ b/apps/web/locales/ne-NP.po
@@ -6674,3 +6674,14 @@ msgstr "जूम आउट"
 msgid "Zulu"
 msgstr "जुलु"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/nl-NL.po
+++ b/apps/web/locales/nl-NL.po
@@ -6674,3 +6674,14 @@ msgstr "Uitzoomen"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/no-NO.po
+++ b/apps/web/locales/no-NO.po
@@ -6674,3 +6674,14 @@ msgstr "Zoom ut"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/or-IN.po
+++ b/apps/web/locales/or-IN.po
@@ -6674,3 +6674,14 @@ msgstr "ଜୁମ୍ ଆଉଟ୍ କରନ୍ତୁ"
 msgid "Zulu"
 msgstr "ଜୁଲୁ"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/pl-PL.po
+++ b/apps/web/locales/pl-PL.po
@@ -6674,3 +6674,14 @@ msgstr "Pomniejsz"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/pt-BR.po
+++ b/apps/web/locales/pt-BR.po
@@ -6674,3 +6674,14 @@ msgstr "Diminuir zoom"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/pt-PT.po
+++ b/apps/web/locales/pt-PT.po
@@ -6674,3 +6674,14 @@ msgstr "Afastar"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ro-RO.po
+++ b/apps/web/locales/ro-RO.po
@@ -6674,3 +6674,14 @@ msgstr "Micșorează"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ru-RU.po
+++ b/apps/web/locales/ru-RU.po
@@ -6674,3 +6674,14 @@ msgstr "Уменьшить"
 msgid "Zulu"
 msgstr "Зулу"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/sk-SK.po
+++ b/apps/web/locales/sk-SK.po
@@ -6674,3 +6674,14 @@ msgstr "Oddialiť"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/sl-SI.po
+++ b/apps/web/locales/sl-SI.po
@@ -6674,3 +6674,14 @@ msgstr "Oddalji"
 msgid "Zulu"
 msgstr "Zuluščina"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/sq-AL.po
+++ b/apps/web/locales/sq-AL.po
@@ -6674,3 +6674,14 @@ msgstr "Zvogëlo"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/sr-SP.po
+++ b/apps/web/locales/sr-SP.po
@@ -6674,3 +6674,14 @@ msgstr "Умањи"
 msgid "Zulu"
 msgstr "Зулу"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/sv-SE.po
+++ b/apps/web/locales/sv-SE.po
@@ -6674,3 +6674,14 @@ msgstr "Zooma ut"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/ta-IN.po
+++ b/apps/web/locales/ta-IN.po
@@ -6674,3 +6674,14 @@ msgstr "சிறிதாக்கு"
 msgid "Zulu"
 msgstr "ஜூலு"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/te-IN.po
+++ b/apps/web/locales/te-IN.po
@@ -6674,3 +6674,14 @@ msgstr "జూమ్ అవుట్ చేయండి"
 msgid "Zulu"
 msgstr "జులు"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/th-TH.po
+++ b/apps/web/locales/th-TH.po
@@ -6674,3 +6674,14 @@ msgstr "ซูมออก"
 msgid "Zulu"
 msgstr "ซูลู"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/tr-TR.po
+++ b/apps/web/locales/tr-TR.po
@@ -6674,3 +6674,14 @@ msgstr "Uzaklaştır"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/uk-UA.po
+++ b/apps/web/locales/uk-UA.po
@@ -6674,3 +6674,14 @@ msgstr "Зменшити"
 msgid "Zulu"
 msgstr "Зулу"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/uz-UZ.po
+++ b/apps/web/locales/uz-UZ.po
@@ -6674,3 +6674,14 @@ msgstr "Kichraytirish"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/vi-VN.po
+++ b/apps/web/locales/vi-VN.po
@@ -6674,3 +6674,14 @@ msgstr "Thu nhỏ"
 msgid "Zulu"
 msgstr "Zulu"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/zh-CN.po
+++ b/apps/web/locales/zh-CN.po
@@ -6674,3 +6674,14 @@ msgstr "缩小"
 msgid "Zulu"
 msgstr "祖鲁语"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/zh-TW.po
+++ b/apps/web/locales/zh-TW.po
@@ -6674,3 +6674,14 @@ msgstr "縮小"
 msgid "Zulu"
 msgstr "祖魯語"
 
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/locales/zu-ZA.po
+++ b/apps/web/locales/zu-ZA.po
@@ -6636,3 +6636,15 @@ msgstr ""
 #: src/libs/locale.ts
 msgid "Zulu"
 msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Keyword layout"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Bulleted list"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+msgid "Inline"
+msgstr ""

--- a/apps/web/src/dialogs/resume/sections/custom.tsx
+++ b/apps/web/src/dialogs/resume/sections/custom.tsx
@@ -75,18 +75,9 @@ export function CreateCustomSectionDialog({ data }: DialogProps<"resume.sections
 	const closeDialog = useDialogStore((state) => state.closeDialog);
 	const updateResumeData = useUpdateResumeData();
 
+	const initialValues: FormValues = { ...defaultValues, ...data, id: generateId() };
 	const form = useAppForm({
-		defaultValues: {
-			id: generateId(),
-			title: data?.title ?? "",
-			type: (data?.type ?? "experience") as CustomSectionType,
-			icon: data?.icon ?? "",
-			columns: data?.columns ?? 1,
-			hidden: data?.hidden ?? false,
-			keepTogether: data?.keepTogether ?? false,
-			startOnNewPage: data?.startOnNewPage ?? false,
-			items: data?.items ?? [],
-		},
+		defaultValues: initialValues,
 		validators: { onSubmit: formSchema },
 		onSubmit: ({ value }) => {
 			updateResumeData((draft) => {

--- a/apps/web/src/features/resume/builder/draft.test.ts
+++ b/apps/web/src/features/resume/builder/draft.test.ts
@@ -6,6 +6,7 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "@lingui/core";
 import { sortSectionItemsByPeriod } from "@reactive-resume/resume/section-sort";
+import { parseResumeData } from "@reactive-resume/schema/resume/data";
 import { defaultResumeData } from "@reactive-resume/schema/resume/default";
 import {
 	isEditableElementFocused,
@@ -472,6 +473,44 @@ describe("builder resume undo/redo", () => {
 		vi.useRealTimers();
 		useResumeStore.getState().reset();
 	});
+
+	it.each([false, true])(
+		"persists skill keyword layout through undo, redo, and reload with custom=%s",
+		async (custom) => {
+			const store = useResumeStore.getState;
+			const initial = makeResume("skill-keyword-history");
+			initial.data.customSections = [{ ...initial.data.sections.skills, id: "custom-skills", type: "skills" }];
+			store().initialize(initial);
+			const currentLayout = () =>
+				custom
+					? store().resume?.data.customSections[0]?.keywordLayout
+					: store().resume?.data.sections.skills.keywordLayout;
+			store().updateResumeData((draft) => {
+				if (custom && draft.customSections[0]) draft.customSections[0].keywordLayout = "list";
+				else draft.sections.skills.keywordLayout = "list";
+			});
+			expect(currentLayout()).toBe("list");
+			store().undo();
+			expect(currentLayout()).toBe("inline");
+			store().redo();
+			expect(currentLayout()).toBe("list");
+			await vi.advanceTimersByTimeAsync(550);
+			await flushMicrotasks();
+			const saved = orpcMocks.updateResume.mock.lastCall?.[0];
+			expect(saved).toBeDefined();
+			store().reset();
+			store().initialize({ ...initial, data: parseResumeData(JSON.parse(JSON.stringify(saved.data))) });
+			expect(currentLayout()).toBe("list");
+			store().patchResume((resume) => {
+				resume.isLocked = true;
+			});
+			store().updateResumeData((draft) => {
+				if (custom && draft.customSections[0]) draft.customSections[0].keywordLayout = "inline";
+				else draft.sections.skills.keywordLayout = "inline";
+			});
+			expect(currentLayout()).toBe("list");
+		},
+	);
 
 	it("coalesces rapid edits into a single undo step and restores the pre-burst state", () => {
 		const store = useResumeStore.getState;

--- a/apps/web/src/features/resume/preview/resume-accessible-text.test.tsx
+++ b/apps/web/src/features/resume/preview/resume-accessible-text.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { render, screen, within } from "@testing-library/react";
+import { beforeAll, expect, it, vi } from "vitest";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeAccessibleText } from "./resume-accessible-text";
+
+vi.mock("@/features/resume/builder/draft", () => ({ useResumeData: () => undefined }));
+beforeAll(() => i18n.loadAndActivate({ locale: "en", messages: {} }));
+it.each([false, true])("exposes keyword list semantics for custom=%s", (custom) => {
+	const data = structuredClone(defaultResumeData);
+	Object.assign(data.sections.skills, { keywordLayout: "list" });
+	data.sections.skills.items = [
+		{
+			id: "skill",
+			name: "Engineering",
+			hidden: false,
+			icon: "",
+			iconColor: "",
+			proficiency: "Expert",
+			level: 3,
+			keywords: ["Alpha", "Beta", "Gamma"],
+		},
+	];
+	if (custom) {
+		data.customSections = [{ ...data.sections.skills, id: "custom", type: "skills" }];
+		data.sections.skills.items = [];
+	}
+	render(
+		<I18nProvider i18n={i18n}>
+			<ResumeAccessibleText data={data} />
+		</I18nProvider>,
+	);
+	const keyword = screen.getByText("Alpha");
+	expect(keyword.tagName).toBe("LI");
+	const list = keyword.parentElement;
+	if (!list) throw new Error("Missing keyword list");
+	expect(within(list).getAllByRole("listitem")).toHaveLength(3);
+});

--- a/apps/web/src/features/resume/preview/resume-accessible-text.tsx
+++ b/apps/web/src/features/resume/preview/resume-accessible-text.tsx
@@ -66,7 +66,7 @@ function ItemBody({ primary, details, description, website }: ItemBodyProps) {
 	);
 }
 
-function renderItem(type: CustomSectionType, item: CustomSectionItem): ReactNode {
+function renderItem(type: CustomSectionType, item: CustomSectionItem, keywordLayout?: "inline" | "list"): ReactNode {
 	switch (type) {
 		case "experience": {
 			const it = item as ExperienceItem;
@@ -110,6 +110,20 @@ function renderItem(type: CustomSectionType, item: CustomSectionItem): ReactNode
 		case "skills": {
 			const it = item as SkillItem;
 
+			if (keywordLayout === "list") {
+				return (
+					<>
+						<ItemBody primary={it.name} details={it.proficiency} />
+						{it.keywords.length > 0 && (
+							<ul>
+								{it.keywords.map((keyword, index) => (
+									<li key={index}>{keyword}</li>
+								))}
+							</ul>
+						)}
+					</>
+				);
+			}
 			return <ItemBody primary={it.name} details={joinInline(it.proficiency, (it.keywords ?? []).join(", "))} />;
 		}
 		case "interests": {
@@ -214,9 +228,10 @@ type AccessibleSectionProps = {
 	title: string;
 	hidden: boolean;
 	items: CustomSectionItem[];
+	keywordLayout?: "inline" | "list";
 };
 
-function AccessibleSection({ type, title, hidden, items }: AccessibleSectionProps) {
+function AccessibleSection({ type, title, hidden, items, keywordLayout }: AccessibleSectionProps) {
 	if (hidden) return null;
 
 	const visibleItems = items.filter((item) => !item.hidden);
@@ -227,7 +242,7 @@ function AccessibleSection({ type, title, hidden, items }: AccessibleSectionProp
 			<h2>{title}</h2>
 			<ul>
 				{visibleItems.map((item) => (
-					<li key={item.id}>{renderItem(type, item)}</li>
+					<li key={item.id}>{renderItem(type, item, keywordLayout)}</li>
 				))}
 			</ul>
 		</section>
@@ -297,6 +312,7 @@ export function ResumeAccessibleText({ data }: ResumeAccessibleTextProps) {
 						title={section.title?.trim() || getSectionTitle(type)}
 						hidden={section.hidden}
 						items={section.items}
+						keywordLayout={"keywordLayout" in section ? section.keywordLayout : undefined}
 					/>
 				);
 			})}
@@ -308,6 +324,7 @@ export function ResumeAccessibleText({ data }: ResumeAccessibleTextProps) {
 					title={section.title?.trim() || getSectionTitle(section.type)}
 					hidden={section.hidden}
 					items={section.items}
+					keywordLayout={"keywordLayout" in section ? section.keywordLayout : undefined}
 				/>
 			))}
 		</section>

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/custom.tsx
@@ -37,6 +37,7 @@ import { useConfirm } from "@/hooks/use-confirm";
 import { getSectionTitle } from "@/libs/resume/section";
 import { SectionBase } from "../shared/section-base";
 import { SectionAddItemButton, SectionItem } from "../shared/section-item";
+import { SkillKeywordLayoutMenu } from "../shared/skill-keyword-layout-menu";
 
 // ponytail: data maps replace ts-pattern exhaustive matchers — same coverage, no runtime dependency
 const TITLE_FIELD: Partial<Record<CustomSectionType, string>> = {
@@ -295,6 +296,8 @@ function CustomSectionDropdownMenu({ section }: CustomSectionDropdownMenuProps) 
 						<CopySimpleIcon />
 						<Trans>Duplicate</Trans>
 					</DropdownMenuItem>
+
+					{section.type === "skills" && <SkillKeywordLayoutMenu sectionId={section.id} />}
 
 					<DropdownMenuSub>
 						<DropdownMenuSubTrigger>

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.test.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.test.tsx
@@ -85,6 +85,20 @@ function openSectionOptions() {
 }
 
 describe("SkillsSectionDropdownMenu", () => {
+	it("selects keyword bullets without changing item layout or columns", async () => {
+		render(
+			<I18nProvider i18n={i18n}>
+				<SectionDropdownMenu type="skills" />
+			</I18nProvider>,
+		);
+		screen.getByRole("button", { name: "Section options" }).click();
+		(await screen.findByRole("menuitem", { name: "Keyword layout" })).click();
+		(await screen.findByRole("menuitemradio", { name: "Bulleted list" })).click();
+		const draft = { sections: { skills: { layout: "default", columns: 2, keywordLayout: "inline", items: [] } } };
+		mocks.updateResumeData.mock.calls[0][0](draft);
+		expect(draft.sections.skills).toEqual({ layout: "default", columns: 2, keywordLayout: "list", items: [] });
+	});
+
 	it("updates resume data correctly when selecting 'inline' for skills section", async () => {
 		render(
 			<I18nProvider i18n={i18n}>

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/section-menu.tsx
@@ -31,6 +31,7 @@ import { useDialogStore } from "@/dialogs/store";
 import { useCurrentResume, useUpdateResumeData } from "@/features/resume/builder/draft";
 import { useConfirm } from "@/hooks/use-confirm";
 import { usePrompt } from "@/hooks/use-prompt";
+import { SkillKeywordLayoutMenu } from "./skill-keyword-layout-menu";
 
 type Props = {
 	type: "summary" | SectionType;
@@ -193,6 +194,8 @@ export function SectionDropdownMenu({ type }: Props) {
 						<PencilSimpleLineIcon />
 						<Trans>Rename</Trans>
 					</DropdownMenuItem>
+
+					{type === "skills" && <SkillKeywordLayoutMenu />}
 
 					<DropdownMenuSub>
 						<DropdownMenuSubTrigger>

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.test.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@reactive-resume/ui/components/dropdown-menu";
+import { useResumeStore } from "@/features/resume/builder/draft";
+import { SkillKeywordLayoutMenu } from "./skill-keyword-layout-menu";
+
+const queryClient = { setQueryData: vi.fn() };
+vi.mock("@tanstack/react-query", () => ({ useQueryClient: () => queryClient }));
+vi.mock("@tanstack/react-router", () => ({ useParams: () => ({ resumeId: "keywords" }) }));
+vi.mock("@/libs/orpc/client", () => ({
+	orpc: { resume: { getById: { queryOptions: () => ({ queryKey: ["resume"] }) } } },
+	streamClient: {},
+}));
+
+beforeEach(() => {
+	i18n.loadAndActivate({ locale: "en", messages: {} });
+	const data = structuredClone(defaultResumeData);
+	data.customSections = [{ ...data.sections.skills, id: "custom", type: "skills", columns: 2 }];
+	useResumeStore.getState().initialize({
+		id: "keywords",
+		name: "Keywords",
+		slug: "keywords",
+		tags: [],
+		data,
+		isLocked: false,
+		updatedAt: new Date(),
+	});
+});
+afterEach(() => useResumeStore.getState().reset());
+
+function renderMenu(custom: boolean) {
+	return render(
+		<I18nProvider i18n={i18n}>
+			<DropdownMenu>
+				<DropdownMenuTrigger>Options</DropdownMenuTrigger>
+				<DropdownMenuContent>
+					<SkillKeywordLayoutMenu sectionId={custom ? "custom" : undefined} />
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</I18nProvider>,
+	);
+}
+
+it.each([false, true])("changes keyword presentation through real draft hook with custom=%s", async (custom) => {
+	renderMenu(custom);
+	const selected = () =>
+		custom
+			? useResumeStore.getState().resume?.data.customSections[0]
+			: useResumeStore.getState().resume?.data.sections.skills;
+	screen.getByRole("button", { name: "Options" }).click();
+	(await screen.findByRole("menuitem", { name: "Keyword layout" })).click();
+	(await screen.findByRole("menuitemradio", { name: "Bulleted list" })).click();
+	expect(selected()?.keywordLayout).toBe("list");
+	expect(selected()?.columns).toBe(custom ? 2 : 1);
+	act(() => useResumeStore.getState().undo());
+	expect(selected()?.keywordLayout).toBe("inline");
+	act(() => useResumeStore.getState().redo());
+	expect(selected()?.keywordLayout).toBe("list");
+});
+
+it.each([false, true])("disables keyword controls on locked resumes with custom=%s", async (custom) => {
+	useResumeStore.getState().patchResume((resume) => {
+		resume.isLocked = true;
+	});
+	renderMenu(custom);
+	screen.getByRole("button", { name: "Options" }).click();
+	const control = await screen.findByRole("menuitem", { name: "Keyword layout" });
+	expect(control.getAttribute("aria-disabled")).toBe("true");
+	control.click();
+	expect(screen.queryByRole("menuitemradio", { name: "Bulleted list" })).toBeNull();
+});

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx
@@ -1,0 +1,51 @@
+import { Trans } from "@lingui/react/macro";
+import { ListIcon } from "@phosphor-icons/react";
+import {
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+} from "@reactive-resume/ui/components/dropdown-menu";
+import { useCurrentResume, useUpdateResumeData } from "@/features/resume/builder/draft";
+
+type SkillKeywordLayoutMenuProps = { sectionId?: string };
+
+export function SkillKeywordLayoutMenu({ sectionId }: SkillKeywordLayoutMenuProps) {
+	const resume = useCurrentResume();
+	const updateResumeData = useUpdateResumeData();
+	const section = sectionId
+		? resume.data.customSections.find((section) => section.id === sectionId && section.type === "skills")
+		: resume.data.sections.skills;
+	if (!section) return null;
+
+	return (
+		<DropdownMenuSub>
+			<DropdownMenuSubTrigger disabled={resume.isLocked}>
+				<ListIcon />
+				<Trans>Keyword layout</Trans>
+			</DropdownMenuSubTrigger>
+			<DropdownMenuSubContent>
+				<DropdownMenuRadioGroup
+					value={section.keywordLayout ?? "inline"}
+					onValueChange={(value) => {
+						if (value !== "inline" && value !== "list") return;
+						updateResumeData((draft) => {
+							const target = sectionId
+								? draft.customSections.find((section) => section.id === sectionId && section.type === "skills")
+								: draft.sections.skills;
+							if (target) target.keywordLayout = value;
+						});
+					}}
+				>
+					<DropdownMenuRadioItem value="inline">
+						<Trans>Inline</Trans>
+					</DropdownMenuRadioItem>
+					<DropdownMenuRadioItem value="list">
+						<Trans>Bulleted list</Trans>
+					</DropdownMenuRadioItem>
+				</DropdownMenuRadioGroup>
+			</DropdownMenuSubContent>
+		</DropdownMenuSub>
+	);
+}

--- a/docs/guides/json-resume-schema.mdx
+++ b/docs/guides/json-resume-schema.mdx
@@ -978,6 +978,15 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 							},
 							"description": "The items to display in the skills section."
 						},
+						"keywordLayout": {
+							"default": "inline",
+							"description": "How skill keywords are displayed: inline separated by commas, or one bullet per keyword.",
+							"type": "string",
+							"enum": [
+								"inline",
+								"list"
+							]
+						},
 						"layout": {
 							"default": "default",
 							"description": "The layout style for skill items. 'inline' places item fields next to name",
@@ -1814,6 +1823,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -1901,6 +1911,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -1983,6 +1994,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -2112,6 +2124,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -2278,6 +2291,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -2421,6 +2435,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -2544,6 +2559,15 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {
+								"default": "inline",
+								"description": "How skill keywords are displayed: inline separated by commas, or one bullet per keyword.",
+								"type": "string",
+								"enum": [
+									"inline",
+									"list"
+								]
+							},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -2660,6 +2684,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -2756,6 +2781,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -2859,6 +2885,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -2987,6 +3014,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -3115,6 +3143,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -3243,6 +3272,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."
@@ -3371,6 +3401,7 @@ The full JSON Schema for Reactive Resume follows. You can also fetch the latest 
 								"description": "If true, the section always begins on a new page.",
 								"type": "boolean"
 							},
+							"keywordLayout": {},
 							"id": {
 								"type": "string",
 								"description": "The unique identifier for the custom section. Usually generated as a UUID."

--- a/packages/docx/src/section-renderers.test.ts
+++ b/packages/docx/src/section-renderers.test.ts
@@ -84,7 +84,7 @@ const emptySection = <T extends SectionType>(type: T): ResumeData["sections"][T]
 		keepTogether: false,
 		startOnNewPage: false,
 		items: [],
-		...(type === "skills" ? { layout: "default" as const } : {}),
+		...(type === "skills" ? { layout: "default" as const, keywordLayout: "inline" as const } : {}),
 	}) as ResumeData["sections"][T];
 
 describe("renderBuiltInSection", () => {

--- a/packages/docx/src/section-renderers.ts
+++ b/packages/docx/src/section-renderers.ts
@@ -264,11 +264,18 @@ function renderSkills(section: Sections["skills"], colorHex: string): Paragraph[
 			children.push(new TextRun({ text: ` — ${item.proficiency}`, ...baseRun }));
 		}
 
-		if (item.keywords.length > 0) {
+		if (section.keywordLayout !== "list" && item.keywords.length > 0) {
 			children.push(new TextRun({ text: `: ${item.keywords.join(", ")}`, ...baseRun }));
 		}
 
 		paragraphs.push(new Paragraph({ spacing: { before: 60 }, children }));
+		if (section.keywordLayout === "list") {
+			for (const keyword of item.keywords) {
+				paragraphs.push(
+					new Paragraph({ bullet: { level: 0 }, children: [new TextRun({ text: keyword, ...baseRun })] }),
+				);
+			}
+		}
 	}
 
 	return paragraphs;
@@ -522,6 +529,7 @@ export function renderCustomSection(section: CustomSection, colorHex: string): P
 	const sectionKey = sectionType as SectionType;
 	if (sectionKey in sectionRenderers) {
 		const syntheticSection = {
+			...(section.type === "skills" ? { keywordLayout: section.keywordLayout } : {}),
 			title: section.title,
 			columns: section.columns,
 			hidden: false,

--- a/packages/docx/src/skill-keywords.test.ts
+++ b/packages/docx/src/skill-keywords.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { renderBuiltInSection, renderCustomSection } from "./section-renderers";
+
+function fixture() {
+	const section = structuredClone(defaultResumeData.sections.skills);
+	Object.assign(section, { keywordLayout: "list" });
+	section.items = [
+		{
+			id: "one",
+			hidden: false,
+			name: "Engineering",
+			proficiency: "Expert",
+			level: 3,
+			icon: "",
+			iconColor: "",
+			keywords: ["Alpha", "Beta", "Gamma"],
+		},
+	];
+	return section;
+}
+
+describe("skill keyword lists", () => {
+	it.each([false, true])("emits real bullet paragraphs for custom=%s", (custom) => {
+		const section = fixture();
+		const paragraphs = custom
+			? renderCustomSection({ ...section, id: "custom", type: "skills" }, "000000")
+			: renderBuiltInSection("skills", section, "000000");
+		const xml = JSON.stringify(paragraphs.map((paragraph) => paragraph.prepForXml({ stack: [] } as never)));
+		expect(xml.match(/w:numPr/g)).toHaveLength(3);
+		for (const keyword of ["Alpha", "Beta", "Gamma"]) expect(xml.split(keyword)).toHaveLength(2);
+		expect(xml).not.toContain("Alpha, Beta");
+	});
+});

--- a/packages/import/src/reactive-resume-v4-json.tsx
+++ b/packages/import/src/reactive-resume-v4-json.tsx
@@ -387,6 +387,7 @@ export function parseReactiveResumeV4JSON(json: string): ResumeData {
 					icon: "",
 					columns: v4Data.sections.skills?.columns ?? 1,
 					layout: "default",
+					keywordLayout: "inline",
 					hidden: !(v4Data.sections.skills?.visible ?? true),
 					keepTogether: false,
 					startOnNewPage: false,

--- a/packages/pdf/src/templates/shared/sections.tsx
+++ b/packages/pdf/src/templates/shared/sections.tsx
@@ -1213,7 +1213,13 @@ const SkillsSection = ({ sectionId = "skills", sectionData }: ItemSectionProps<S
 
 						<View style={{ flexGrow: skills.columns > 1 ? 1 : 0 }}>
 							{hasSplitRowText(item.proficiency) && <Text semanticField="proficiency">{item.proficiency}</Text>}
-							<Small semanticField="keywords">{item.keywords.join(", ")}</Small>
+							{"keywordLayout" in skills && skills.keywordLayout === "list" ? (
+								item.keywords.map((keyword, index) => (
+									<Small key={index} semanticField="keywords">{`• ${keyword}`}</Small>
+								))
+							) : (
+								<Small semanticField="keywords">{item.keywords.join(", ")}</Small>
+							)}
 							{isInlineSkillsItem && <LevelDisplay level={item.level} />}
 						</View>
 						{!isInlineSkillsItem && <LevelDisplay level={item.level} />}

--- a/packages/pdf/src/templates/shared/skill-keyword-fixture.ts
+++ b/packages/pdf/src/templates/shared/skill-keyword-fixture.ts
@@ -1,0 +1,39 @@
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+
+type SkillKeywordFixtureOptions = {
+	keywordLayout?: "inline" | "list";
+	layout?: "default" | "inline";
+	columns?: number;
+	custom?: boolean;
+	keywords?: string[];
+};
+
+export function createSkillKeywordFixture({
+	keywordLayout = "inline",
+	layout = "default",
+	columns = 1,
+	custom = false,
+	keywords = ["Alpha", "Beta", "Gamma"],
+}: SkillKeywordFixtureOptions = {}) {
+	const data = structuredClone(defaultResumeData);
+	data.metadata.template = "leafish";
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.page.hideIcons = true;
+	data.metadata.layout.pages = [{ fullWidth: true, main: [custom ? "custom-skills" : "skills"], sidebar: [] }];
+	Object.assign(data.sections.skills, { keywordLayout, layout, columns });
+	data.sections.skills.items = [
+		{
+			id: "skill",
+			hidden: false,
+			icon: "",
+			iconColor: "",
+			name: "Engineering",
+			proficiency: "Experienced",
+			level: 3,
+			keywords,
+		},
+	];
+	if (custom) data.customSections = [{ ...data.sections.skills, id: "custom-skills", type: "skills" }];
+	return data;
+}

--- a/packages/pdf/src/templates/shared/skill-keyword-presentation.test.tsx
+++ b/packages/pdf/src/templates/shared/skill-keyword-presentation.test.tsx
@@ -1,0 +1,169 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { renderToBuffer } from "@react-pdf/renderer";
+import { encode } from "fast-png";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { act } from "react";
+import { ResumeDocument } from "../../document";
+import { resolveResumeRuntime } from "../../semantic/resolve";
+import { rasterizePdf } from "../../semantic/test/rasterize-pdf";
+import { createSkillKeywordFixture } from "./skill-keyword-fixture";
+
+function required<T>(value: T | null | undefined): T {
+	if (value === undefined || value === null) throw new Error("Missing fixture output");
+	return value;
+}
+
+async function renderKeywords(data: ReturnType<typeof createSkillKeywordFixture>) {
+	const bytes = await act(() => renderToBuffer(<ResumeDocument data={data} template="leafish" />));
+	const loading = getDocument({ data: new Uint8Array(bytes), useSystemFonts: true });
+	try {
+		const pdf = await loading.promise;
+		const pages = [];
+		for (let n = 1; n <= pdf.numPages; n++) {
+			const content = await (await pdf.getPage(n)).getTextContent();
+			pages.push(content.items.flatMap((item) => ("str" in item ? [item] : [])));
+		}
+		return {
+			bytes,
+			pages,
+			text: pages
+				.flat()
+				.map((item) => item.str)
+				.join(" "),
+		};
+	} finally {
+		await loading.destroy();
+	}
+}
+
+describe("skill keyword presentation", () => {
+	it.each([1, 2])("preserves comma output for stacked and inline item layouts with %s columns", async (columns) => {
+		for (const layout of ["default", "inline"] as const) {
+			const result = await renderKeywords(createSkillKeywordFixture({ layout, columns }));
+			expect(result.text).toContain("Alpha, Beta, Gamma");
+			expect(await rasterizePdf(new Uint8Array(result.bytes))).toHaveLength(1);
+		}
+	});
+	it.each([false, true])("renders three separate bullet entries with custom=%s", async (custom) => {
+		const { text, pages } = await renderKeywords(
+			createSkillKeywordFixture({ keywordLayout: "list", custom, columns: 2 }),
+		);
+		for (const word of ["Alpha", "Beta", "Gamma"]) expect(text.split(word)).toHaveLength(2);
+		expect(text.match(/•/g)).toHaveLength(3);
+		expect(text).not.toContain(",");
+		const ys = required(pages[0])
+			.filter((item) => ["Alpha", "Beta", "Gamma"].some((word) => item.str.includes(word)))
+			.map((item) => item.transform[5]);
+		expect(new Set(ys).size).toBe(3);
+	});
+	it.each([[], ["Café"], ["naïve", "München", "résumé"]].map((keywords) => ({ keywords })))(
+		"retains Unicode and empty keyword arrays: $keywords",
+		async ({ keywords }) => {
+			const { text } = await renderKeywords(
+				createSkillKeywordFixture({ keywordLayout: "list", keywords, layout: "inline" }),
+			);
+			expect(text.match(/•/g) ?? []).toHaveLength(keywords.length);
+			for (const word of keywords) expect(text.split(word)).toHaveLength(2);
+		},
+	);
+	it("wraps long keywords and emits each marker once across physical pages", async () => {
+		const keywords = Array.from(
+			{ length: 18 },
+			(_, i) => `Entry${i.toString().padStart(2, "0")} ${"wrapping keyword text ".repeat(9)}`,
+		);
+		const data = createSkillKeywordFixture({ keywordLayout: "list", keywords });
+		data.metadata.stylesheet = {
+			mode: "semantic",
+			source: { languageVersion: 1, text: "@version 1; page { size: 300pt 220pt; }" },
+		};
+		const { text, pages } = await renderKeywords(data);
+		expect(pages.length).toBeGreaterThan(1);
+		expect(text.match(/•/g)).toHaveLength(18);
+		for (let i = 0; i < 18; i++) expect(text.split(`Entry${i.toString().padStart(2, "0")}`)).toHaveLength(2);
+		for (const page of pages)
+			for (const item of page) {
+				expect(item.transform[4]).toBeGreaterThanOrEqual(0);
+				expect(item.transform[4] + item.width).toBeLessThanOrEqual(301);
+			}
+	});
+	it("honors hidden items and semantic keyword typography", async () => {
+		const data = createSkillKeywordFixture({ keywordLayout: "list" });
+		data.sections.skills.items.push({
+			...required(data.sections.skills.items[0]),
+			id: "hidden",
+			hidden: true,
+			keywords: ["Secret"],
+		});
+		data.sections.skills.items.push({
+			...required(data.sections.skills.items[0]),
+			id: "css-hidden",
+			hidden: false,
+			keywords: ["Suppressed"],
+		});
+		data.metadata.stylesheet = {
+			mode: "semantic",
+			source: {
+				languageVersion: 1,
+				text: '@version 1; section[type="skills"] field[name="keywords"] { font-size: 18pt; } section[type="skills"] item[id="css-hidden"] { display: none; }',
+			},
+		};
+		const runtime = resolveResumeRuntime({ data, template: "leafish", mode: "semantic" });
+		expect(runtime.diagnostics).toEqual([]);
+		const { text, pages } = await renderKeywords(data);
+		expect(text).toContain("Engineering");
+		expect(text).not.toContain("Secret");
+		expect(text).not.toContain("Suppressed");
+		const keywords = pages.flat().filter((item) => /Alpha|Beta|Gamma/.test(item.str));
+		expect(keywords).toHaveLength(3);
+		for (const keyword of keywords) expect(keyword.height).toBeCloseTo(18);
+	});
+	it("renders reviewable default and list artifacts without changing comma pixels", async () => {
+		const inline = createSkillKeywordFixture();
+		const legacy = createSkillKeywordFixture();
+		Reflect.deleteProperty(legacy.sections.skills, "keywordLayout");
+		const before = await renderKeywords(legacy);
+		const after = await renderKeywords(inline);
+		const oldRaster = await rasterizePdf(new Uint8Array(before.bytes));
+		const newRaster = await rasterizePdf(new Uint8Array(after.bytes));
+		expect(createHash("sha256").update(required(newRaster[0]).data).digest("hex")).toBe(
+			createHash("sha256").update(required(oldRaster[0]).data).digest("hex"),
+		);
+		const list = await renderKeywords(createSkillKeywordFixture({ keywordLayout: "list" }));
+		const listRaster = await rasterizePdf(new Uint8Array(list.bytes));
+		expect(createHash("sha256").update(required(listRaster[0]).data).digest("hex")).not.toBe(
+			createHash("sha256").update(required(newRaster[0]).data).digest("hex"),
+		);
+		const output = process.env.SKILL_KEYWORD_ARTIFACT_DIR;
+		if (output) {
+			mkdirSync(output, { recursive: true });
+			for (const [name, result, raster] of [
+				["inline", after, newRaster],
+				["list", list, listRaster],
+			] as const) {
+				writeFileSync(join(output, `${name}.pdf`), result.bytes);
+				writeFileSync(join(output, `${name}.txt`), result.text);
+				writeFileSync(join(output, `${name}.png`), encode(required(raster[0])));
+			}
+		}
+	});
+
+	it("retains keyword lists in separate columns with mixed item heights", async () => {
+		const data = createSkillKeywordFixture({ keywordLayout: "list", columns: 2 });
+		data.sections.skills.items.push({
+			...required(data.sections.skills.items[0]),
+			id: "second",
+			name: "Design",
+			keywords: ["Delta", `Epsilon ${"long wrapping keyword ".repeat(8)}`, "Zeta"],
+		});
+		const { text, pages } = await renderKeywords(data);
+		expect(text.match(/•/g)).toHaveLength(6);
+		for (const word of ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"]) expect(text.split(word)).toHaveLength(2);
+		const first = required(required(pages[0]).find((item) => item.str.includes("Alpha")));
+		const second = required(required(pages[0]).find((item) => item.str.includes("Delta")));
+		expect(second.transform[4] - first.transform[4]).toBeGreaterThan(150);
+		expect(first.transform[5]).toBeCloseTo(second.transform[5]);
+	});
+});

--- a/packages/schema/src/resume/data.ts
+++ b/packages/schema/src/resume/data.ts
@@ -322,8 +322,15 @@ const publicationsSectionSchema = itemSection(
 	"The items to display in the publications section.",
 );
 const referencesSectionSchema = itemSection(referenceItemSchema, "The items to display in the references section.");
+const skillKeywordLayoutSchema = z
+	.enum(["inline", "list"])
+	.default("inline")
+	.catch("inline")
+	.describe("How skill keywords are displayed: inline separated by commas, or one bullet per keyword.");
+
 export const skillsSectionSchema = itemSection(skillItemSchema, "The items to display in the skills section.")
 	.extend({
+		keywordLayout: skillKeywordLayoutSchema,
 		layout: z
 			.enum(["default", "inline"])
 			.default("default")
@@ -394,6 +401,7 @@ export type CustomSectionItem = z.infer<(typeof customSectionItemDefinitionByTyp
 
 const customSectionSchemaOptions = Object.entries(customSectionItemDefinitionByType).map(([type, { schema }]) =>
 	baseSectionSchema.extend({
+		keywordLayout: (type === "skills" ? skillKeywordLayoutSchema : z.undefined().catch(undefined)).optional(),
 		id: z.string().describe("The unique identifier for the custom section. Usually generated as a UUID."),
 		type: z
 			.literal(type as CustomSectionType)

--- a/packages/schema/src/resume/default.ts
+++ b/packages/schema/src/resume/default.ts
@@ -48,7 +48,7 @@ export const defaultResumeData: ResumeData = {
 		experience: section("briefcase"),
 		education: section("graduation-cap"),
 		projects: section("code-simple"),
-		skills: { ...section("compass-tool"), layout: "default" },
+		skills: { ...section("compass-tool"), layout: "default", keywordLayout: "inline" },
 		languages: section("translate"),
 		interests: section("football"),
 		awards: section("trophy"),

--- a/packages/schema/src/resume/sample.ts
+++ b/packages/schema/src/resume/sample.ts
@@ -193,6 +193,7 @@ export const sampleResumeData: ResumeData = {
 			icon: "compass-tool",
 			columns: 1,
 			layout: "default",
+			keywordLayout: "inline",
 			hidden: false,
 			keepTogether: false,
 			startOnNewPage: false,

--- a/packages/schema/src/resume/skill-keyword-layout.test.ts
+++ b/packages/schema/src/resume/skill-keyword-layout.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import z from "zod";
+import { parseResumeData } from "./data";
+import { defaultResumeData } from "./default";
+import { createResumeDataJsonSchema } from "./json-schema";
+
+describe("skill keyword presentation", () => {
+	it.each([undefined, "invalid", "inline", "list"])(
+		"normalizes and round-trips %s for built-in and custom Skills",
+		(keywordLayout) => {
+			const input = structuredClone(defaultResumeData);
+			Object.assign(input.sections.skills, { keywordLayout });
+			input.customSections = [{ ...input.sections.skills, id: "custom-skills", type: "skills" }];
+			const parsed = parseResumeData(input);
+			const expected = keywordLayout === "list" ? "list" : "inline";
+			expect(parsed.sections.skills).toHaveProperty("keywordLayout", expected);
+			expect(parsed.customSections[0]).toHaveProperty("keywordLayout", expected);
+			expect(parseResumeData(JSON.parse(JSON.stringify(parsed)))).toEqual(parsed);
+		},
+	);
+
+	it("publishes an optional enum so old JSON and selected modes remain importable", () => {
+		const schema = z.fromJSONSchema(createResumeDataJsonSchema());
+		const input = JSON.parse(JSON.stringify(defaultResumeData));
+		delete input.sections.skills.keywordLayout;
+		expect(schema.safeParse(input).success).toBe(true);
+		input.sections.skills.keywordLayout = "list";
+		expect(schema.safeParse(input).success).toBe(true);
+		input.sections.skills.keywordLayout = "invalid";
+		expect(schema.safeParse(input).success).toBe(false);
+	});
+	it("does not retain skill presentation when a custom section changes type", () => {
+		const input = structuredClone(defaultResumeData);
+		input.customSections = [{ ...input.sections.skills, id: "custom", type: "interests", keywordLayout: "list" }];
+		const parsed = parseResumeData(input);
+		expect(JSON.stringify(parsed.customSections[0])).not.toContain("keywordLayout");
+	});
+});

--- a/skills/resume-builder/references/schema.md
+++ b/skills/resume-builder/references/schema.md
@@ -172,6 +172,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `sections.skills.items[].level` | `number` | yes | minimum: 0; maximum: 5; default: 0 | The proficiency level of the skill, defined as a number between 0 and 5. If set to 0, the icons displaying the level will be hidden. |
 | `sections.skills.items[].keywords` | `array` | yes | default: [] | The keywords associated with the skill, if any. These are displayed as tags below the name. |
 | `sections.skills.items[].keywords[]` | `string` | — | — | — |
+| `sections.skills.keywordLayout` | `string` | no | enum: ["inline","list"]; default: "inline" | How skill keywords are displayed: inline separated by commas, or one bullet per keyword. |
 | `sections.skills.layout` | `string` | no | enum: ["default","inline"]; default: "default" | The layout style for skill items. 'inline' places item fields next to name |
 | `sections.languages` | `object` | yes | — | The section to display the languages of the author. |
 | `sections.languages.title` | `string` | yes | — | The title of the section. |
@@ -307,6 +308,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type summary, schema summaryItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type summary, schema summaryItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type summary, schema summaryItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type summary, schema summaryItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type summary, schema summaryItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type summary, schema summaryItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type summary, schema summaryItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -321,6 +323,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type profiles, schema profileItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type profiles, schema profileItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type profiles, schema profileItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type profiles, schema profileItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type profiles, schema profileItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type profiles, schema profileItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type profiles, schema profileItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -342,6 +345,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type experience, schema experienceItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type experience, schema experienceItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type experience, schema experienceItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type experience, schema experienceItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type experience, schema experienceItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type experience, schema experienceItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type experience, schema experienceItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -370,6 +374,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type education, schema educationItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type education, schema educationItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type education, schema educationItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type education, schema educationItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type education, schema educationItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type education, schema educationItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type education, schema educationItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -394,6 +399,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type projects, schema projectItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type projects, schema projectItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type projects, schema projectItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type projects, schema projectItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type projects, schema projectItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type projects, schema projectItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type projects, schema projectItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -414,6 +420,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type skills, schema skillItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type skills, schema skillItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type skills, schema skillItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `string` | no (type skills, schema skillItemSchema at customSections[]) | enum: ["inline","list"]; default: "inline" | How skill keywords are displayed: inline separated by commas, or one bullet per keyword. |
 | `customSections[].id` | `string` | yes (type skills, schema skillItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type skills, schema skillItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type skills, schema skillItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -434,6 +441,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type languages, schema languageItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type languages, schema languageItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type languages, schema languageItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type languages, schema languageItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type languages, schema languageItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type languages, schema languageItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type languages, schema languageItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -450,6 +458,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type interests, schema interestItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type interests, schema interestItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type interests, schema interestItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type interests, schema interestItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type interests, schema interestItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type interests, schema interestItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type interests, schema interestItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -468,6 +477,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type awards, schema awardItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type awards, schema awardItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type awards, schema awardItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type awards, schema awardItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type awards, schema awardItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type awards, schema awardItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type awards, schema awardItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -489,6 +499,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type certifications, schema certificationItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type certifications, schema certificationItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type certifications, schema certificationItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type certifications, schema certificationItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type certifications, schema certificationItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type certifications, schema certificationItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type certifications, schema certificationItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -510,6 +521,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type publications, schema publicationItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type publications, schema publicationItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type publications, schema publicationItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type publications, schema publicationItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type publications, schema publicationItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type publications, schema publicationItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type publications, schema publicationItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -531,6 +543,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type volunteer, schema volunteerItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type volunteer, schema volunteerItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type volunteer, schema volunteerItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type volunteer, schema volunteerItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type volunteer, schema volunteerItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type volunteer, schema volunteerItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type volunteer, schema volunteerItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -552,6 +565,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type references, schema referenceItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type references, schema referenceItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type references, schema referenceItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type references, schema referenceItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type references, schema referenceItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type references, schema referenceItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type references, schema referenceItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |
@@ -573,6 +587,7 @@ Choose one coherent shape for each union value. Required fields are local to tha
 | `customSections[].hidden` | `boolean` | yes (type cover-letter, schema coverLetterItemSchema at customSections[]) | — | Whether to hide the section from the resume. |
 | `customSections[].keepTogether` | `boolean` | yes (type cover-letter, schema coverLetterItemSchema at customSections[]) | default: false | If true, the section is kept on a single page instead of splitting across a page break. |
 | `customSections[].startOnNewPage` | `boolean` | yes (type cover-letter, schema coverLetterItemSchema at customSections[]) | default: false | If true, the section always begins on a new page. |
+| `customSections[].keywordLayout` | `any` | no (type cover-letter, schema coverLetterItemSchema at customSections[]) | — | — |
 | `customSections[].id` | `string` | yes (type cover-letter, schema coverLetterItemSchema at customSections[]) | — | The unique identifier for the custom section. Usually generated as a UUID. |
 | `customSections[].type` | `string` | yes (type cover-letter, schema coverLetterItemSchema at customSections[]) | — | The type of items this custom section contains. Determines which item schema and form fields to use. |
 | `customSections[].items` | `array` | yes (type cover-letter, schema coverLetterItemSchema at customSections[]) | — | The items to display in the custom section. Items follow the schema of the section type. |

--- a/tooling/recovery/compare-resume.test.ts
+++ b/tooling/recovery/compare-resume.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import { defaultResumeData } from "@reactive-resume/schema/resume/default";
 import { compareResumeRecovery } from "./compare-resume";
 
-const SYNTHETIC_SOURCE_HASH = "a544b2abf225396f8c16cd2ea1c182d195a8d9179d3a95be4b1b1e7d43722e11";
-const RECOVERED_COPY_HASH = "704cd69adcd227d6975aca64afea9a63fe0eeb8e17c275b4c79627d85bdd5791";
-const CURRENT_COPY_HASH = "33d337241cd4ad8cf0faa2cdc0107fa4d607b3070f27dab7166c206b05afd882";
-const DEFAULT_RESUME_HASH = "a6930afc82a24637de715bdcac5300318261d3b69969527f43917904478e885b";
+const SYNTHETIC_SOURCE_HASH = "2fc24960657492304068db58c4f4f8b0861ef4937bf12aadeced12ed03856d41";
+const RECOVERED_COPY_HASH = "87b3c6293158e14591387969b804dda0233ae83df79e59043b340c9f0180bf6d";
+const CURRENT_COPY_HASH = "701ee9fde9161c974ee6325e169132249ccb77adb31d875541ab70dd20835017";
+const DEFAULT_RESUME_HASH = "bb0b5937876766c5a0d5014538257870396f30902d86a2d32d2c901f644ffb1f";
 
 const FORMAT_CHARACTERS = [
 	["zero-width space (U+200B)", "\u200B"],


### PR DESCRIPTION
## Summary

- add inline or bulleted keyword layout for built-in and custom Skills sections
- preserve legacy inline rendering while carrying choice through schema, builder, imports, PDF, DOCX, and accessible text
- add translated controls and focused layout, persistence, export, pagination, and raster coverage

## Verification

- 80 focused tests passed after integrating current main
- schema, PDF, DOCX, import, and web typechecks passed
- Biome check on 20 changed TypeScript files passed
- git diff --check passed
- independent prepublication review: no findings

Closes #2785



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added skills keyword layout options: inline or bulleted list.
  - Keyword layout settings now apply consistently in the resume builder, accessible preview, PDF, and DOCX exports.
  - Custom skills sections support the same layout controls.
  - Layout choices persist through undo/redo, autosave, reload, and resume import.

- **Localization**
  - Added labels for the new layout controls across supported locales. Most translations remain pending and currently fall back to English.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds configurable inline or bulleted skill-keyword presentation while preserving legacy inline behavior.
- Extends resume schema, defaults, imports, and documentation with `keywordLayout`.
- Adds builder controls for built-in and custom Skills sections.
- Carries selected presentation through PDF, DOCX, and accessible-text rendering.
- Adds focused persistence, rendering, pagination, Unicode, and export tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/schema/src/resume/data.ts | Adds normalized inline/list keyword presentation for built-in and custom Skills sections. |
| apps/web/src/routes/builder/$resumeId/-sidebar/left/shared/skill-keyword-layout-menu.tsx | Adds guarded builder control targeting either built-in Skills or a matching custom Skills section. |
| packages/pdf/src/templates/shared/sections.tsx | Renders selected keyword presentation while retaining existing inline comma output by default. |
| packages/docx/src/section-renderers.ts | Emits separate DOCX bullet paragraphs for list-mode skill keywords. |
| apps/web/src/features/resume/preview/resume-accessible-text.tsx | Mirrors list-mode skill keywords using nested semantic HTML lists. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  B[Builder layout control] --> S[Resume schema keywordLayout]
  I[Legacy and v4 imports] --> S
  S --> P[PDF rendering]
  S --> D[DOCX rendering]
  S --> A[Accessible text]
  S --> U[Autosave and undo/redo]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(schema): refresh generated referenc..."](https://github.com/amruthpillai/reactive-resume/commit/3c06c3b0bbe85ff346e38bdecbc24ee2630f8642) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60872627)</sub>

<!-- /greptile_comment -->