### PR TITLE
fix(editor): avoid unsafe clipboard parsing pattern

### DIFF
--- a/apps/web/src/components/input/rich-input-whitespace.ts
+++ b/apps/web/src/components/input/rich-input-whitespace.ts
@@ -53,8 +53,7 @@ const isPreservableTextBlock = (node: ProseMirrorNode) =>
 // Mark real text blocks before ProseMirror collapses their whitespace. Containers
 // that its parser turns into paragraphs need the same explicit block boundary.
 const markPastedHtml = (html: string) => {
-	const root = document.createElement("div");
-	root.innerHTML = html;
+	const root = new DOMParser().parseFromString(html, "text/html").body;
 	const blockTags = /^(P|H[1-6]|DIV|BLOCKQUOTE|UL|OL|LI|PRE|HR|TABLE)$/;
 	const normalize = (container: HTMLElement) => {
 		let paragraph: HTMLParagraphElement | undefined;

--- a/packages/pdf/src/templates/shared/rich-text-html.test.ts
+++ b/packages/pdf/src/templates/shared/rich-text-html.test.ts
@@ -28,7 +28,7 @@ describe("normalizeRichTextHtml", () => {
 	it("does not reinterpret marked RTL line breaks as pseudo-bullet lists", () => {
 		const html = '<p data-resume-whitespace="preserve">  - First<br>  - Second</p>';
 		expect(normalizeRichTextHtml(html, { direction: "rtl" })).toBe(
-			'<p data-resume-whitespace="preserve">‏  - First<br>  - Second</p>',
+			'<p data-resume-whitespace="preserve">\u200f  - First<br>  - Second</p>',
 		);
 	});
 

--- a/packages/pdf/src/templates/shared/rich-text-html.ts
+++ b/packages/pdf/src/templates/shared/rich-text-html.ts
@@ -148,7 +148,7 @@ const isInlineNode = (node: Node): boolean => {
 };
 
 // Allow optional leading whitespace + LRM/RLM marks before the bullet character.
-const PSEUDO_BULLET_LEAD = /^[\s‎‏]*[-•*]\s+/;
+const PSEUDO_BULLET_LEAD = /^[\s\u200e\u200f]*[-•*]\s+/;
 
 const stripEmptyInlineWrappers = (html: string): string =>
 	html.replace(/<(strong|b|em|i|u|span)\b[^>]*>\s*<\/\1>/gi, "");


### PR DESCRIPTION
## Summary

- parse pasted HTML through DOMParser instead of assigning untrusted clipboard markup to innerHTML
- express LRM/RLM controls with Unicode escapes so source and tests contain no newly introduced invisible controls
- preserve existing normalization behavior

## Verification

- rich-text editor suites: 102 passed
- PDF rich-text normalization: 44 passed
- web and PDF typechecks
- focused Biome check
- git diff --check

Follow-up to Codacy findings on #3472.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pasted HTML content, including whitespace and block formatting.
  * Improved recognition of pseudo-bullets in right-to-left text.
* **Tests**
  * Updated right-to-left text coverage to use explicit Unicode markers for more reliable test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces untrusted clipboard `innerHTML` assignment with inert document parsing while preserving rich-text whitespace normalization.
- Parses pasted HTML through `DOMParser` before applying block-boundary markers.
- Replaces invisible LRM/RLM source characters with explicit Unicode escapes.
- Updates the RTL normalization expectation to use the escaped representation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete functional, security, or compatibility regressions identified.

The clipboard parsing change remains on a DOM-enabled browser path and preserves the existing normalization traversal, while the Unicode escape changes are semantically equivalent to the replaced literal controls.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/input/rich-input-whitespace.ts | Safely replaces detached-element `innerHTML` parsing with `DOMParser` on the browser-only paste path without changing the normalization traversal. |
| packages/pdf/src/templates/shared/rich-text-html.ts | Replaces literal directional controls in the pseudo-bullet regex with equivalent Unicode escapes. |
| packages/pdf/src/templates/shared/rich-text-html.test.ts | Updates the RTL expectation to represent the same RLM character explicitly. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(editor): avoid unsafe clipboard pars..."](https://github.com/amruthpillai/reactive-resume/commit/ec0a18fd8b5cd0b9b1cc7ee31a12d2d783eb4ffd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60877123)</sub>

<!-- /greptile_comment -->