### PR TITLE
test(pdf): characterize safe item pagination boundary

### DIFF
--- a/.orchestration/plan-23-item-pagination-blocker.md
+++ b/.orchestration/plan-23-item-pagination-blocker.md
@@ -1,0 +1,32 @@
+# Plan 23 item-pagination execution evidence
+
+## Scope
+
+Plan 23 steps 1–3 were evaluated from `origin/main` at `368858a56` (Plan 21 / PR #3477 merged). Widow/orphan UI and authored-page continuation guidance remain deferred from this execution, and Semantic CSS was not changed.
+
+## Durable diagnostic matrix
+
+`packages/pdf/src/templates/shared/item-pagination.test.tsx` renders physical PDF pages and checks numbered tokens exactly once for:
+
+- an item that fits remaining space;
+- an item that fits a full page but not the remaining space;
+- an oversized item taller than one page;
+- a two-line paragraph at a boundary;
+- nested bullets; and
+- built-in plus custom items in an Azurill sidebar/main-column overflow fixture.
+
+The fixture also keeps authored `metadata.layout.pages` separate from renderer-generated physical pages.
+
+The current deterministic baseline is: fit remainder = 1 physical page; full-page-but-not-remainder = 3 pages with sampled tokens on pages 2/2/3; oversized = 5 pages with sampled tokens on pages 1/3/5; two-line boundary = 2 pages; nested bullets = 1 page; Azurill built-in/custom/sidebar = 5 pages with sampled tokens on pages 1/4/5/5/1. Page numbers here are 1-based; every token still appears exactly once.
+
+## Concrete blocker
+
+React PDF's only available item-level keep-together primitive is `View wrap={false}`. A durable renderer fixture with 180 paragraph-like child views shows that a non-wrapping item cannot safely fall back when its content exceeds one page: the renderer omits the oversized tail instead of splitting it. Applying the same prop to shared `SectionItem` would therefore violate the lossless token requirement; no item schema flag or menu control was added.
+
+Do not estimate item height from HTML length, persist physical pages, alter existing Semantic CSS, or claim #3350 complete. A future implementation needs renderer-supported conditional keep-together behavior or an actual measured two-pass fallback that preserves every token.
+
+## Verification
+
+- `pnpm --filter @reactive-resume/pdf exec vitest run src/templates/shared/item-pagination.test.tsx`: 7 tests passed.
+- No production source or schema changes made after the unsafe fallback was reproduced.
+- Undo/persistence/lock UI coverage is intentionally absent because no item control was shipped; add it only when safe fallback exists.

--- a/.orchestration/remediation-issue-3350-item-pagination.md
+++ b/.orchestration/remediation-issue-3350-item-pagination.md
@@ -1,0 +1,17 @@
+# Issue 3350 remediation evidence
+
+## Findings addressed
+
+- `item-pagination.test.tsx` now derives complete numbered-token inventories for each generated fixture and asserts every token exactly once. Sampled token-to-physical-page placement checks remain separate.
+- Pagination fixtures snapshot `metadata.layout.pages` before rendering and assert authored layout pages are unchanged afterward. Overflow fixtures also assert physical PDF page count exceeds authored page count.
+- Unsafe `wrap={false}` renderer coverage remains diagnostic-only; no item controls, schema flags, or runtime behavior were added.
+
+## Verification
+
+- `rtk proxy pnpm --filter @reactive-resume/pdf exec vitest run src/semantic/pagination.test.tsx src/templates/shared/item-pagination.test.tsx` — 2 files, 11 tests passed.
+- `rtk proxy pnpm --filter @reactive-resume/pdf typecheck` — passed.
+- `rtk proxy pnpm exec biome check packages/pdf/src/templates/shared/item-pagination.test.tsx` — passed.
+- `rtk proxy pnpm exec turbo boundaries` — passed; 1109 files checked.
+- `rtk git diff --check origin/main...HEAD` — passed.
+
+Only PDF test coverage and this evidence file changed; production behavior remains untouched.

--- a/packages/pdf/src/templates/shared/item-pagination.test.tsx
+++ b/packages/pdf/src/templates/shared/item-pagination.test.tsx
@@ -59,8 +59,13 @@ const makeFixture = (items: ResumeData["sections"]["experience"]["items"]): Resu
 	return data;
 };
 
+const numberedTokens = (prefix: string, count: number) =>
+	Array.from({ length: count }, (_value, index) => `${prefix}_${String(index + 1).padStart(3, "0")}`);
+
 const numberedParagraphs = (prefix: string, count: number) =>
-	Array.from({ length: count }, (_value, index) => `<p>${prefix}_${String(index + 1).padStart(3, "0")}</p>`).join("");
+	numberedTokens(prefix, count)
+		.map((token) => `<p>${token}</p>`)
+		.join("");
 
 const expectTokensExactlyOnce = (pages: string[], tokens: string[]) => {
 	const renderedText = pages.join(" ");
@@ -75,9 +80,11 @@ describe("item pagination token matrix", () => {
 				makeItem("boundary", numberedParagraphs("BOUNDARY", 26)),
 				makeItem("fit", numberedParagraphs("FIT", 4)),
 			]),
-			tokens: ["FIT_001", "FIT_002", "FIT_003", "FIT_004"],
+			allTokens: [...numberedTokens("BOUNDARY", 26), ...numberedTokens("FIT", 4)],
+			sampledTokens: ["FIT_001", "FIT_002", "FIT_003", "FIT_004"],
 			expectedPages: 1,
 			expectedTokenPages: [0, 0, 0, 0],
+			expectsPhysicalOverflow: false,
 		},
 		{
 			name: "item fits a full page but not remaining space",
@@ -85,16 +92,20 @@ describe("item pagination token matrix", () => {
 				makeItem("boundary", numberedParagraphs("BOUNDARY", 48)),
 				makeItem("full-page", numberedParagraphs("FULL_PAGE", 42)),
 			]),
-			tokens: ["FULL_PAGE_001", "FULL_PAGE_021", "FULL_PAGE_042"],
+			allTokens: [...numberedTokens("BOUNDARY", 48), ...numberedTokens("FULL_PAGE", 42)],
+			sampledTokens: ["FULL_PAGE_001", "FULL_PAGE_021", "FULL_PAGE_042"],
 			expectedPages: 3,
 			expectedTokenPages: [1, 1, 2],
+			expectsPhysicalOverflow: true,
 		},
 		{
 			name: "item taller than a page",
 			data: makeFixture([makeItem("oversized", numberedParagraphs("OVERSIZED", 180))]),
-			tokens: ["OVERSIZED_001", "OVERSIZED_090", "OVERSIZED_180"],
+			allTokens: numberedTokens("OVERSIZED", 180),
+			sampledTokens: ["OVERSIZED_001", "OVERSIZED_090", "OVERSIZED_180"],
 			expectedPages: 5,
 			expectedTokenPages: [0, 2, 4],
+			expectsPhysicalOverflow: true,
 		},
 		{
 			name: "two-line paragraph near boundary",
@@ -102,9 +113,11 @@ describe("item pagination token matrix", () => {
 				makeItem("boundary", numberedParagraphs("BOUNDARY", 52)),
 				makeItem("paragraph", "<p>PARAGRAPH_001 first line<br />PARAGRAPH_002 second line</p>"),
 			]),
-			tokens: ["PARAGRAPH_001", "PARAGRAPH_002"],
+			allTokens: [...numberedTokens("BOUNDARY", 52), "PARAGRAPH_001", "PARAGRAPH_002"],
+			sampledTokens: ["PARAGRAPH_001", "PARAGRAPH_002"],
 			expectedPages: 2,
 			expectedTokenPages: [1, 1],
+			expectsPhysicalOverflow: true,
 		},
 		{
 			name: "nested bullets",
@@ -114,16 +127,24 @@ describe("item pagination token matrix", () => {
 					"<ul><li><p>NESTED_001</p><ul><li><p>NESTED_002</p></li><li><p>NESTED_003</p></li></ul></li></ul>",
 				),
 			]),
-			tokens: ["NESTED_001", "NESTED_002", "NESTED_003"],
+			allTokens: ["NESTED_001", "NESTED_002", "NESTED_003"],
+			sampledTokens: ["NESTED_001", "NESTED_002", "NESTED_003"],
 			expectedPages: 1,
 			expectedTokenPages: [0, 0, 0],
+			expectsPhysicalOverflow: false,
 		},
-	])("preserves every token exactly once: $name", async ({ data, tokens, expectedPages, expectedTokenPages }) => {
-		const pages = await readPhysicalPages(await parsePdf(await renderPdf(data)));
-		expect(pages).toHaveLength(expectedPages);
-		expect(tokens.map((token) => pages.findIndex((page) => page.includes(token)))).toEqual(expectedTokenPages);
-		expectTokensExactlyOnce(pages, tokens);
-	});
+	])(
+		"preserves every token exactly once: $name",
+		async ({ data, allTokens, sampledTokens, expectedPages, expectedTokenPages, expectsPhysicalOverflow }) => {
+			const authoredPagesBeforeRender = structuredClone(data.metadata.layout.pages);
+			const pages = await readPhysicalPages(await parsePdf(await renderPdf(data)));
+			expect(pages).toHaveLength(expectedPages);
+			expect(sampledTokens.map((token) => pages.findIndex((page) => page.includes(token)))).toEqual(expectedTokenPages);
+			expectTokensExactlyOnce(pages, allTokens);
+			expect(data.metadata.layout.pages).toEqual(authoredPagesBeforeRender);
+			if (expectsPhysicalOverflow) expect(pages.length).toBeGreaterThan(authoredPagesBeforeRender.length);
+		},
+	);
 
 	it("preserves built-in and custom items across an Azurill sidebar and main-column overflow", async () => {
 		const data = makeFixture([makeItem("builtin", numberedParagraphs("BUILTIN", 150))]);
@@ -156,6 +177,7 @@ describe("item pagination token matrix", () => {
 		];
 		data.metadata.layout.pages[0]?.main.push("custom-experience");
 
+		const authoredPagesBeforeRender = structuredClone(data.metadata.layout.pages);
 		const pages = await readPhysicalPages(await parsePdf(await renderPdf(data, "azurill")));
 		expect(pages).toHaveLength(5);
 		expect(
@@ -163,7 +185,9 @@ describe("item pagination token matrix", () => {
 				pages.findIndex((page) => page.includes(token)),
 			),
 		).toEqual([0, 3, 4, 4, 0]);
-		expectTokensExactlyOnce(pages, ["BUILTIN_001", "BUILTIN_150", "CUSTOM_001", "CUSTOM_030", "SIDEBAR_001"]);
+		expectTokensExactlyOnce(pages, [...numberedTokens("BUILTIN", 150), ...numberedTokens("CUSTOM", 30), "SIDEBAR_001"]);
+		expect(data.metadata.layout.pages).toEqual(authoredPagesBeforeRender);
+		expect(pages.length).toBeGreaterThan(authoredPagesBeforeRender.length);
 	});
 
 	it("records unsafe renderer fallback for an oversized non-wrapping item", async () => {

--- a/packages/pdf/src/templates/shared/item-pagination.test.tsx
+++ b/packages/pdf/src/templates/shared/item-pagination.test.tsx
@@ -1,0 +1,188 @@
+import type { ResumeData } from "@reactive-resume/schema/resume/data";
+import type { Template } from "@reactive-resume/schema/templates";
+import { describe, expect, it, vi } from "vitest";
+import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { createElement } from "react";
+import { defaultResumeData } from "@reactive-resume/schema/resume/default";
+import { ResumeDocument } from "../../document";
+
+vi.mock("@react-pdf/renderer", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@react-pdf/renderer")>()),
+}));
+
+type PdfTextItem = { str: string };
+type ParsedPdfPage = { getTextContent: () => Promise<{ items: PdfTextItem[] }> };
+type ParsedPdf = { numPages: number; getPage: (pageNumber: number) => Promise<ParsedPdfPage> };
+
+const renderPdf = async (data: ResumeData, template: Template = "onyx"): Promise<Uint8Array> => {
+	const renderer = await vi.importActual<typeof import("@react-pdf/renderer")>("@react-pdf/renderer");
+	const element = createElement(ResumeDocument, { data, template }) as unknown as Parameters<
+		typeof renderer.renderToBuffer
+	>[0];
+	return new Uint8Array(await renderer.renderToBuffer(element));
+};
+
+const parsePdf = (data: Uint8Array): Promise<ParsedPdf> => getDocument({ data }).promise as Promise<ParsedPdf>;
+
+const readPhysicalPages = async (document: ParsedPdf): Promise<string[]> => {
+	const pages: string[] = [];
+	for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+		const page = await document.getPage(pageNumber);
+		const content = await page.getTextContent();
+		pages.push(content.items.map(({ str }) => str).join(" "));
+	}
+	return pages;
+};
+
+const makeItem = (id: string, description: string) => ({
+	id,
+	hidden: false,
+	company: id,
+	position: "Synthetic item",
+	location: "",
+	period: "",
+	website: { url: "", label: "", inlineLink: false },
+	description,
+	roles: [],
+});
+
+const makeFixture = (items: ResumeData["sections"]["experience"]["items"]): ResumeData => {
+	const data = structuredClone(defaultResumeData);
+	data.picture.hidden = true;
+	data.basics.name = "ITEM PAGINATION HEADER";
+	data.metadata.template = "onyx";
+	data.metadata.typography.body.fontFamily = "Helvetica";
+	data.metadata.typography.heading.fontFamily = "Helvetica";
+	data.metadata.layout.pages = [{ fullWidth: true, main: ["experience"], sidebar: [] }];
+	data.sections.experience.title = "Experience";
+	data.sections.experience.items = items;
+	return data;
+};
+
+const numberedParagraphs = (prefix: string, count: number) =>
+	Array.from({ length: count }, (_value, index) => `<p>${prefix}_${String(index + 1).padStart(3, "0")}</p>`).join("");
+
+const expectTokensExactlyOnce = (pages: string[], tokens: string[]) => {
+	const renderedText = pages.join(" ");
+	for (const token of tokens) expect(renderedText.split(token)).toHaveLength(2);
+};
+
+describe("item pagination token matrix", () => {
+	it.each([
+		{
+			name: "item fits remaining space",
+			data: makeFixture([
+				makeItem("boundary", numberedParagraphs("BOUNDARY", 26)),
+				makeItem("fit", numberedParagraphs("FIT", 4)),
+			]),
+			tokens: ["FIT_001", "FIT_002", "FIT_003", "FIT_004"],
+			expectedPages: 1,
+			expectedTokenPages: [0, 0, 0, 0],
+		},
+		{
+			name: "item fits a full page but not remaining space",
+			data: makeFixture([
+				makeItem("boundary", numberedParagraphs("BOUNDARY", 48)),
+				makeItem("full-page", numberedParagraphs("FULL_PAGE", 42)),
+			]),
+			tokens: ["FULL_PAGE_001", "FULL_PAGE_021", "FULL_PAGE_042"],
+			expectedPages: 3,
+			expectedTokenPages: [1, 1, 2],
+		},
+		{
+			name: "item taller than a page",
+			data: makeFixture([makeItem("oversized", numberedParagraphs("OVERSIZED", 180))]),
+			tokens: ["OVERSIZED_001", "OVERSIZED_090", "OVERSIZED_180"],
+			expectedPages: 5,
+			expectedTokenPages: [0, 2, 4],
+		},
+		{
+			name: "two-line paragraph near boundary",
+			data: makeFixture([
+				makeItem("boundary", numberedParagraphs("BOUNDARY", 52)),
+				makeItem("paragraph", "<p>PARAGRAPH_001 first line<br />PARAGRAPH_002 second line</p>"),
+			]),
+			tokens: ["PARAGRAPH_001", "PARAGRAPH_002"],
+			expectedPages: 2,
+			expectedTokenPages: [1, 1],
+		},
+		{
+			name: "nested bullets",
+			data: makeFixture([
+				makeItem(
+					"nested",
+					"<ul><li><p>NESTED_001</p><ul><li><p>NESTED_002</p></li><li><p>NESTED_003</p></li></ul></li></ul>",
+				),
+			]),
+			tokens: ["NESTED_001", "NESTED_002", "NESTED_003"],
+			expectedPages: 1,
+			expectedTokenPages: [0, 0, 0],
+		},
+	])("preserves every token exactly once: $name", async ({ data, tokens, expectedPages, expectedTokenPages }) => {
+		const pages = await readPhysicalPages(await parsePdf(await renderPdf(data)));
+		expect(pages).toHaveLength(expectedPages);
+		expect(tokens.map((token) => pages.findIndex((page) => page.includes(token)))).toEqual(expectedTokenPages);
+		expectTokensExactlyOnce(pages, tokens);
+	});
+
+	it("preserves built-in and custom items across an Azurill sidebar and main-column overflow", async () => {
+		const data = makeFixture([makeItem("builtin", numberedParagraphs("BUILTIN", 150))]);
+		data.metadata.template = "azurill";
+		data.metadata.layout.pages = [{ fullWidth: false, main: ["experience"], sidebar: ["profiles"] }];
+		data.sections.profiles.items = [
+			{
+				id: "sidebar",
+				hidden: false,
+				icon: "github-logo",
+				iconColor: "",
+				network: "SIDEBAR_001",
+				username: "sidebar",
+				website: { url: "", label: "", inlineLink: false },
+			},
+		];
+		data.customSections = [
+			{
+				id: "custom-experience",
+				type: "experience",
+				title: "Custom Experience",
+				icon: "",
+				columns: 1,
+				hidden: false,
+				showHeading: true,
+				keepTogether: false,
+				startOnNewPage: false,
+				items: [makeItem("custom", numberedParagraphs("CUSTOM", 30))],
+			},
+		];
+		data.metadata.layout.pages[0]?.main.push("custom-experience");
+
+		const pages = await readPhysicalPages(await parsePdf(await renderPdf(data, "azurill")));
+		expect(pages).toHaveLength(5);
+		expect(
+			["BUILTIN_001", "BUILTIN_150", "CUSTOM_001", "CUSTOM_030", "SIDEBAR_001"].map((token) =>
+				pages.findIndex((page) => page.includes(token)),
+			),
+		).toEqual([0, 3, 4, 4, 0]);
+		expectTokensExactlyOnce(pages, ["BUILTIN_001", "BUILTIN_150", "CUSTOM_001", "CUSTOM_030", "SIDEBAR_001"]);
+	});
+
+	it("records unsafe renderer fallback for an oversized non-wrapping item", async () => {
+		const renderer = await vi.importActual<typeof import("@react-pdf/renderer")>("@react-pdf/renderer");
+		const tokens = Array.from({ length: 180 }, (_value, index) => `UNSAFE_${String(index + 1).padStart(3, "0")}`);
+		const item = createElement(
+			renderer.View,
+			{ wrap: false },
+			...tokens.map((token) => createElement(renderer.View, { key: token }, createElement(renderer.Text, null, token))),
+		);
+		const element = createElement(
+			renderer.Document,
+			null,
+			createElement(renderer.Page, { size: "A4" }, item),
+		) as Parameters<typeof renderer.renderToBuffer>[0];
+		const pages = await readPhysicalPages(await parsePdf(new Uint8Array(await renderer.renderToBuffer(element))));
+
+		// React PDF warns that an oversized View cannot wrap and drops content; this is the blocker for item Keep together.
+		expect(pages.join(" ")).toContain("UNSAFE_001");
+		expect(pages.join(" ")).not.toContain("UNSAFE_180");
+	});
+});


### PR DESCRIPTION
## Summary

- add deterministic physical-page token matrix for built-in/custom items, boundary overflow, long items, and nested bullets
- prove every generated token survives exactly once under normal wrapping
- document installed renderer blocker: forcing an oversized item to stay together truncates content
- keep issue #3350 open; no unsafe pagination control or runtime flag is shipped

## Verification

- PDF pagination suites: 11/11 passed
- PDF typecheck passed
- targeted Biome passed
- package boundaries passed across 1109 files
- Markdown and diff checks passed
- independent review completed; concrete assertion gaps remediated

## Remaining gate

A renderer-safe conditional fallback is required before an item-level keep-together control can ship. Current wrap=false behavior is intentionally not exposed because oversized content is lost.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds deterministic PDF pagination characterization without changing production behavior.
- Covers fitting, boundary-overflow, oversized, multiline, nested-list, built-in, custom, sidebar, and main-column fixtures.
- Verifies complete token preservation, physical-page placement, and preservation of authored layout metadata.
- Documents why oversized `wrap={false}` items cannot safely support a keep-together control yet.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge after the non-blocking import organization issue is cleaned up.

The changes are limited to diagnostic tests and documentation, and no reachable runtime or security failure was identified.

**Files Needing Attention:** packages/pdf/src/templates/shared/item-pagination.test.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/shared/item-pagination.test.tsx | Adds comprehensive physical-page and token-preservation coverage; only import organization needs cleanup. |
| .orchestration/plan-23-item-pagination-blocker.md | Records the tested pagination matrix, renderer truncation blocker, and verification results. |
| .orchestration/remediation-issue-3350-item-pagination.md | Documents the remediated assertion gaps and confirms that no production pagination control was introduced. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20amruthpillai%2Freactive-resume%20PR%20%233478%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=3478&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Ftemplates%2Fshared%2Fitem-pagination.test.tsx%3A1-6%0A**Keep%20package%20imports%20grouped**%0A%0AThe%20%60%40reactive-resume%60%20imports%20are%20separated%20by%20third-party%20imports%2C%20violating%20the%20repository's%20organized-import%20convention%20and%20creating%20avoidable%20formatter%20and%20maintenance%20churn.%0A%0A%60%60%60suggestion%0Aimport%20type%20%7B%20ResumeData%20%7D%20from%20%22%40reactive-resume%2Fschema%2Fresume%2Fdata%22%3B%0Aimport%20%7B%20defaultResumeData%20%7D%20from%20%22%40reactive-resume%2Fschema%2Fresume%2Fdefault%22%3B%0Aimport%20type%20%7B%20Template%20%7D%20from%20%22%40reactive-resume%2Fschema%2Ftemplates%22%3B%0Aimport%20%7B%20describe%2C%20expect%2C%20it%2C%20vi%20%7D%20from%20%22vitest%22%3B%0Aimport%20%7B%20getDocument%20%7D%20from%20%22pdfjs-dist%2Flegacy%2Fbuild%2Fpdf.mjs%22%3B%0Aimport%20%7B%20createElement%20%7D%20from%20%22react%22%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3478&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Ftemplates%2Fshared%2Fitem-pagination.test.tsx%3A1-6%0A**Keep%20package%20imports%20grouped**%0A%0AThe%20%60%40reactive-resume%60%20imports%20are%20separated%20by%20third-party%20imports%2C%20violating%20the%20repository's%20organized-import%20convention%20and%20creating%20avoidable%20formatter%20and%20maintenance%20churn.%0A%0A%60%60%60suggestion%0Aimport%20type%20%7B%20ResumeData%20%7D%20from%20%22%40reactive-resume%2Fschema%2Fresume%2Fdata%22%3B%0Aimport%20%7B%20defaultResumeData%20%7D%20from%20%22%40reactive-resume%2Fschema%2Fresume%2Fdefault%22%3B%0Aimport%20type%20%7B%20Template%20%7D%20from%20%22%40reactive-resume%2Fschema%2Ftemplates%22%3B%0Aimport%20%7B%20describe%2C%20expect%2C%20it%2C%20vi%20%7D%20from%20%22vitest%22%3B%0Aimport%20%7B%20getDocument%20%7D%20from%20%22pdfjs-dist%2Flegacy%2Fbuild%2Fpdf.mjs%22%3B%0Aimport%20%7B%20createElement%20%7D%20from%20%22react%22%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3478&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22amruthpillai%2Freactive-resume%22%20on%20the%20existing%20branch%20%22codex%2Fissue-3350-item-pagination%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fissue-3350-item-pagination%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fpdf%2Fsrc%2Ftemplates%2Fshared%2Fitem-pagination.test.tsx%3A1-6%0A**Keep%20package%20imports%20grouped**%0A%0AThe%20%60%40reactive-resume%60%20imports%20are%20separated%20by%20third-party%20imports%2C%20violating%20the%20repository's%20organized-import%20convention%20and%20creating%20avoidable%20formatter%20and%20maintenance%20churn.%0A%0A%60%60%60suggestion%0Aimport%20type%20%7B%20ResumeData%20%7D%20from%20%22%40reactive-resume%2Fschema%2Fresume%2Fdata%22%3B%0Aimport%20%7B%20defaultResumeData%20%7D%20from%20%22%40reactive-resume%2Fschema%2Fresume%2Fdefault%22%3B%0Aimport%20type%20%7B%20Template%20%7D%20from%20%22%40reactive-resume%2Fschema%2Ftemplates%22%3B%0Aimport%20%7B%20describe%2C%20expect%2C%20it%2C%20vi%20%7D%20from%20%22vitest%22%3B%0Aimport%20%7B%20getDocument%20%7D%20from%20%22pdfjs-dist%2Flegacy%2Fbuild%2Fpdf.mjs%22%3B%0Aimport%20%7B%20createElement%20%7D%20from%20%22react%22%3B%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=amruthpillai%2Freactive-resume&pr=3478&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/pdf/src/templates/shared/item-pagination.test.tsx:1-6
**Keep package imports grouped**

The `@reactive-resume` imports are separated by third-party imports, violating the repository's organized-import convention and creating avoidable formatter and maintenance churn.

```suggestion
import type { ResumeData } from "@reactive-resume/schema/resume/data";
import { defaultResumeData } from "@reactive-resume/schema/resume/default";
import type { Template } from "@reactive-resume/schema/templates";
import { describe, expect, it, vi } from "vitest";
import { getDocument } from "pdfjs-dist/legacy/build/pdf.mjs";
import { createElement } from "react";
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test(pdf): strengthen item pagination co..."](https://github.com/amruthpillai/reactive-resume/commit/f2769dce54ca6c3ee9c344eec195f036ba14645f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60883151)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/amruthpillai/reactive-resume/blob/main/CLAUDE.md))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive PDF pagination coverage across boundary, oversized, multi-line, nested-list, and sidebar content.
  - Verified that rendered content appears exactly once and that authored page metadata remains unchanged.
  - Added checks for physical page counts when content overflows authored layouts.

- **Documentation**
  - Documented current pagination limitations and diagnostic findings.
  - Recorded verification results and scenarios that remain unsupported without risking content loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->