### PR TITLE
test: opt in preview export geometry E2E

### DIFF
--- a/tests/e2e/specs/preview-export-geometry.spec.ts
+++ b/tests/e2e/specs/preview-export-geometry.spec.ts
@@ -78,6 +78,7 @@ const RASTER_MISMATCH_RATIO_LIMIT = 0.02;
 const RASTER_MISMATCH_PIXEL_LIMIT = 200_000;
 const GEOMETRY_E2E_OPT_IN = "PREVIEW_EXPORT_GEOMETRY_E2E";
 const DISPOSABLE_DATABASE_NAME = "reactive_resume_preview_export_geometry_e2e";
+const geometryE2eOptedIn = process.env[GEOMETRY_E2E_OPT_IN] === "1";
 
 const requirePdf = createRequire(`${process.cwd()}/packages/pdf/package.json`);
 const requireWeb = createRequire(`${process.cwd()}/apps/web/package.json`);
@@ -698,6 +699,7 @@ async function runGeometryMatrix(page: Page, testInfo: TestInfo, scenarios: Geom
 }
 
 test.describe("preview/export geometry at DPR1", () => {
+	test.skip(!geometryE2eOptedIn, `Set ${GEOMETRY_E2E_OPT_IN}=1 to run disposable preview/export geometry E2E.`);
 	test.use({ deviceScaleFactor: 1 });
 
 	test("matches active preview and downloaded PDF across synthetic Rhyhorn matrix", async ({ authPage }, testInfo) => {
@@ -707,6 +709,7 @@ test.describe("preview/export geometry at DPR1", () => {
 });
 
 test.describe("preview/export geometry at DPR2", () => {
+	test.skip(!geometryE2eOptedIn, `Set ${GEOMETRY_E2E_OPT_IN}=1 to run disposable preview/export geometry E2E.`);
 	test.use({ deviceScaleFactor: 2 });
 
 	test("matches active preview and downloaded PDF at higher device pixel ratio", async ({ authPage }, testInfo) => {


### PR DESCRIPTION
## Summary

- skip preview/export geometry E2E suites unless `PREVIEW_EXPORT_GEOMETRY_E2E=1`
- preserve existing full DPR matrix and exact disposable loopback PostgreSQL safety guard
- fix baseline E2E regression introduced by #3483, observed in Actions run 34013056139

## Verification

- default-off focused Playwright: 2 skipped
- opt-in collection: 2 tests
- independent focused review: no findings
- web and `@reactive-resume/pdf` `tsgo --noEmit`
- focused Biome check
- `pnpm exec turbo boundaries` (1,117 files)

## Safety

Full opt-in matrix was not rerun for this three-line gating-only change because no disposable PostgreSQL instance was provisioned on required loopback port 55432. Existing exact database name/host/port guard and matrix body are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Preview/export geometry end-to-end tests now run only when explicitly enabled with the `PREVIEW_EXPORT_GEOMETRY_E2E=1` setting.
  * DPR1 and DPR2 geometry test suites are skipped by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the two preview/export geometry suites explicitly opt-in while preserving their existing DPR matrix and disposable-database safeguards.
- Adds an exact-value `PREVIEW_EXPORT_GEOMETRY_E2E=1` gate.
- Applies the gate to both DPR1 and DPR2 Playwright suites.
- Leaves the geometry matrix and database safety checks unchanged.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because both geometry suites are consistently gated and remain runnable through the documented opt-in value.

The new module-level flag uses the repository’s established exact-value opt-in pattern, both tests are covered by describe-level skips, and direct Playwright invocations preserve the environment variable without changing the existing database guard or matrix behavior.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tests/e2e/specs/preview-export-geometry.spec.ts | Adds consistent describe-level skips for both geometry suites using an established test-only environment-variable pattern; no actionable defect found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: opt in preview export geometry E2E"](https://github.com/amruthpillai/reactive-resume/commit/26f2360cf06af3111e68613647f557cf8ff5c478) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60896556)</sub>

<!-- /greptile_comment -->