### PR TITLE
chore: release v5.3.0

### DIFF
--- a/apps/web/locales/af-ZA.po
+++ b/apps/web/locales/af-ZA.po
@@ -1490,10 +1490,6 @@ msgstr "Word apart van die ontledingstelling getel. Dekking voorspel niks."
 msgid "Cover"
 msgstr "Vul"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Vul sny die beeld af sodat dit die raam vul. Pas in wys die hele beeld. Laai die oorspronklike weer op om rande te herstel wat 'n vroeëre afsnyding verwyder het."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Skep tans jou API-sleutel..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Skep tans jou CV..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Bewaar"
 msgid "Save & Test Provider"
 msgstr "Stoor en toetsverskaffer"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Stoor en laai op"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Stoor 'n onbeskermde kopie, sonder wagwoord en sonder toestemmingsbeperkings."
@@ -5226,6 +5222,10 @@ msgstr "Grootte"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Vaardighede"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/af-ZA.po
+++ b/apps/web/locales/af-ZA.po
@@ -1667,7 +1667,7 @@ msgstr "Skep tans jou CV..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Sny en laai op"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Vaardighede"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Slaan oor en laai op"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/am-ET.po
+++ b/apps/web/locales/am-ET.po
@@ -1490,10 +1490,6 @@ msgstr "ከንባብ ነጥቡ ተለይቶ ይቆጠራል። ሽፋን ምን�
 msgid "Cover"
 msgstr "ሽፋን"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "ክፈፉን ለመሙላት ምስሉን ይሸፍኑ. ይዘቱ ሙሉውን ምስል ያሳያል። በቀድሞ ሰብል የተወገዱ ጠርዞችን ወደነበረበት ለመመለስ ዋናውን እንደገና ይስቀሉ።"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "API ቁልፉን በመፍጠር ላይ…"
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "የየታሪክዎን መስራት በመፍጠር ላይ…"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "አስቀምጥ"
 msgid "Save & Test Provider"
 msgstr "አስቀምጥ እና አቅራቢውን ሞክር"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "አስቀምጥ እና ስቀል"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "ያለ የይለፍ ቃል እና ያለ ፈቃድ ገደቦች ያልተጠበቀ ቅጂ ያስቀምጡ።"
@@ -5226,6 +5222,10 @@ msgstr "መጠን"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "ችሎታዎች"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/am-ET.po
+++ b/apps/web/locales/am-ET.po
@@ -1667,7 +1667,7 @@ msgstr "የየታሪክዎን መስራት በመፍጠር ላይ…"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "ስዕልን ይከርክሙ እና ይስቀሉ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "ችሎታዎች"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "ይዝለሉ እና ይስቀሉ"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ar-SA.po
+++ b/apps/web/locales/ar-SA.po
@@ -1667,7 +1667,7 @@ msgstr "جاري إنشاء سيرتك الذاتية..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "اقتصاص وتحميل"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "المهارات"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "تخطي وتحميل"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ar-SA.po
+++ b/apps/web/locales/ar-SA.po
@@ -1490,10 +1490,6 @@ msgstr "تُحتسب بشكل منفصل عن درجة القراءة. التغ�
 msgid "Cover"
 msgstr "الغلاف"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "يقوم الغطاء بقص الصورة لملء الإطار. يحتوي على يظهر الصورة كاملة. أعد تحميل النسخة الأصلية لاستعادة الحواف التي تمت إزالتها بواسطة عملية قص سابقة."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "جاري إنشاء مفتاح واجهة برمجة التطبيقات 
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "جاري إنشاء سيرتك الذاتية..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "الحفظ"
 msgid "Save & Test Provider"
 msgstr "موفر الحفظ والاختبار"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "حفظ وتحميل"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "احفظ نسخة غير محمية، بلا كلمة مرور وبلا قيود صلاحيات."
@@ -5226,6 +5222,10 @@ msgstr "الحجم"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "المهارات"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/az-AZ.po
+++ b/apps/web/locales/az-AZ.po
@@ -1667,7 +1667,7 @@ msgstr "Özgeçmişiniz yaradılır..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Kəs və yüklə"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Bacarıqlar"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Keç və yüklə"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/az-AZ.po
+++ b/apps/web/locales/az-AZ.po
@@ -1490,10 +1490,6 @@ msgstr "Oxunma balından ayrıca hesablanır. Əhatə heç nəyi proqnozlaşdır
 msgid "Cover"
 msgstr "Qapaq"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Qapaq çərçivəni doldurmaq üçün şəkli kəsir. Contain bütün şəkli göstərir. Əvvəlki kəsmə ilə çıxarılan kənarları bərpa etmək üçün orijinalı yenidən yükləyin."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "API açarınız yaradılır..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Özgeçmişiniz yaradılır..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Yadda saxla"
 msgid "Save & Test Provider"
 msgstr "Saxla və Test Təminatçısı"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Yadda saxla və yüklə"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Parolsuz və icazə məhdudiyyəti olmayan qorunmamış nüsxə saxlayın."
@@ -5226,6 +5222,10 @@ msgstr "Ölçü"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Bacarıqlar"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/bg-BG.po
+++ b/apps/web/locales/bg-BG.po
@@ -1667,7 +1667,7 @@ msgstr "Създаване на вашата автобиография..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Изрежете и качете"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Умения"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Пропуснете и качете"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/bg-BG.po
+++ b/apps/web/locales/bg-BG.po
@@ -1490,10 +1490,6 @@ msgstr "Отчита се отделно от оценката за разчит
 msgid "Cover"
 msgstr "Капак"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cover изрязва изображението, за да запълни рамката. Contain показва цялото изображение. Качете отново оригинала, за да възстановите ръбовете, премахнати от по-ранно изрязване."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Създаване на вашия API ключ..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Създаване на вашата автобиография..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Запазете"
 msgid "Save & Test Provider"
 msgstr "Доставчик на „Запазване и тестване“"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Запазване и качване"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Запазете незащитено копие, без парола и без ограничения за права."
@@ -5226,6 +5222,10 @@ msgstr "Размер"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Умения"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/bn-BD.po
+++ b/apps/web/locales/bn-BD.po
@@ -1667,7 +1667,7 @@ msgstr "আপনার জীবনবৃত্তান্ত তৈরি ক
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "ছবি ক্রপ করে আপলোড করুন"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "স্কিলসমূহ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "এড়িয়ে আপলোড করুন"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/bn-BD.po
+++ b/apps/web/locales/bn-BD.po
@@ -1490,10 +1490,6 @@ msgstr "এটি পার্স স্কোর থেকে আলাদা�
 msgid "Cover"
 msgstr "আবরণ"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "ফ্রেম পূরণ করতে কভার ছবি ক্রপ করুন। কন্টেন পুরো ইমেজ দেখায়. আগের ক্রপ দ্বারা সরানো প্রান্তগুলি পুনরুদ্ধার করতে আসলটি পুনরায় আপলোড করুন৷"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "আপনার API কী তৈরি করা হচ্ছে..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "আপনার জীবনবৃত্তান্ত তৈরি করা হচ্ছে..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "সংরক্ষণ করুন"
 msgid "Save & Test Provider"
 msgstr "সংরক্ষণ ও পরীক্ষা প্রদানকারী"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "সংরক্ষণ ও আপলোড করুন"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "কোনো পাসওয়ার্ড বা অনুমতি সীমাবদ্ধতা ছাড়াই একটি অসুরক্ষিত কপি সংরক্ষণ করুন।"
@@ -5226,6 +5222,10 @@ msgstr "আকার"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "স্কিলসমূহ"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ca-ES.po
+++ b/apps/web/locales/ca-ES.po
@@ -1667,7 +1667,7 @@ msgstr "S’està creant el currículum..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Retalla i puja"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Habilitats"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Omet i puja"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ca-ES.po
+++ b/apps/web/locales/ca-ES.po
@@ -1490,10 +1490,6 @@ msgstr "Es compta a part de la puntuació de lectura. La cobertura no prediu res
 msgid "Cover"
 msgstr "Cobrir"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cobrir retalla la imatge per omplir el marc. Contenir mostra la imatge sencera. Torna a pujar l'original per recuperar les vores eliminades per un retall anterior."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "S’està creant la clau API..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "S’està creant el currículum..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Desa"
 msgid "Save & Test Provider"
 msgstr "Desa i prova el proveïdor"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Desa i puja"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Desa una còpia sense protegir, sense contrasenya ni restriccions de permisos."
@@ -5226,6 +5222,10 @@ msgstr "Mida"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Habilitats"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/cs-CZ.po
+++ b/apps/web/locales/cs-CZ.po
@@ -1490,10 +1490,6 @@ msgstr "Počítá se odděleně od skóre parsování. Pokrytí nic nepředpoví
 msgid "Cover"
 msgstr "Kryt"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cover ořízne obrázek tak, aby vyplnil rámeček. Obsah zobrazí celý obrázek. Znovu nahrajte originál a obnovte okraje odstraněné dřívějším oříznutím."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Vytváření API klíče…"
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Vytváření životopisu…"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Uložit"
 msgid "Save & Test Provider"
 msgstr "Poskytovatel uložení a testování"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Uložit a nahrát"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Uložte nechráněnou kopii, bez hesla a bez omezení oprávnění."
@@ -5226,6 +5222,10 @@ msgstr "Velikost"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Dovednosti"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/cs-CZ.po
+++ b/apps/web/locales/cs-CZ.po
@@ -1667,7 +1667,7 @@ msgstr "Vytváření životopisu…"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Oříznout a nahrát"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Dovednosti"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Přeskočit a nahrát"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/da-DK.po
+++ b/apps/web/locales/da-DK.po
@@ -1667,7 +1667,7 @@ msgstr "Opretter dit CV..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Beskær og upload"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Færdigheder"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Spring over og upload"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/da-DK.po
+++ b/apps/web/locales/da-DK.po
@@ -1490,10 +1490,6 @@ msgstr "Tælles adskilt fra parse-scoren. Dækning forudsiger ikke noget."
 msgid "Cover"
 msgstr "Udfyld"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Udfyld beskærer billedet, så det fylder rammen. Tilpas viser hele billedet. Upload originalen igen for at gendanne kanter, der blev fjernet ved en tidligere beskæring."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Opretter din API-nøgle..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Opretter dit CV..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Gemme"
 msgid "Save & Test Provider"
 msgstr "Gem og test udbyder"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Gem og upload"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Gem en ubeskyttet kopi uden adgangskode og uden rettighedsbegrænsninger."
@@ -5226,6 +5222,10 @@ msgstr "Størrelse"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Færdigheder"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/de-DE.po
+++ b/apps/web/locales/de-DE.po
@@ -1490,10 +1490,6 @@ msgstr "Wird getrennt vom Parse-Score gezählt. Die Abdeckung sagt nichts voraus
 msgid "Cover"
 msgstr "Ausfüllen"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "„Ausfüllen“ beschneidet das Bild, damit es den Rahmen füllt. „Einpassen“ zeigt das gesamte Bild. Laden Sie das Original erneut hoch, um Ränder wiederherzustellen, die ein früherer Zuschnitt entfernt hat."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Dein API-Schlüssel wird erstellt ..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Ihr Lebenslauf wird erstellt..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Speichern"
 msgid "Save & Test Provider"
 msgstr "Save & Test Provider"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Speichern & Hochladen"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Speichern Sie eine ungeschützte Kopie ohne Passwort und ohne Berechtigungseinschränkungen."
@@ -5226,6 +5222,10 @@ msgstr "Größe"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Fähigkeiten"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/de-DE.po
+++ b/apps/web/locales/de-DE.po
@@ -1667,7 +1667,7 @@ msgstr "Ihr Lebenslauf wird erstellt..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Zuschneiden und hochladen"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Fähigkeiten"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Überspringen und hochladen"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/el-GR.po
+++ b/apps/web/locales/el-GR.po
@@ -1490,10 +1490,6 @@ msgstr "Μετριέται ξεχωριστά από τη βαθμολογία �
 msgid "Cover"
 msgstr "Εξώφυλλο"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Το εξώφυλλο περικόπτει την εικόνα για να γεμίσει το πλαίσιο. Το Contain δείχνει ολόκληρη την εικόνα. Ανεβάστε ξανά το πρωτότυπο για να επαναφέρετε τις άκρες που αφαιρέθηκαν από προηγούμενη περικοπή."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Δημιουργία κλειδιού API..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Δημιουργία του βιογραφικού σας σημειώματος..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Αποθήκευση"
 msgid "Save & Test Provider"
 msgstr "Αποθήκευση & Δοκιμή Παρόχου"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Αποθήκευση & Μεταφόρτωση"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Αποθηκεύστε ένα μη προστατευμένο αντίγραφο, χωρίς κωδικό πρόσβασης και χωρίς περιορισμούς δικαιωμάτων."
@@ -5226,6 +5222,10 @@ msgstr "Μέγεθος"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Δεξιότητες"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/el-GR.po
+++ b/apps/web/locales/el-GR.po
@@ -1667,7 +1667,7 @@ msgstr "Δημιουργία του βιογραφικού σας σημειώμ
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Περικοπή και μεταφόρτωση"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Δεξιότητες"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Παράλειψη και μεταφόρτωση"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/en-GB.po
+++ b/apps/web/locales/en-GB.po
@@ -1667,7 +1667,7 @@ msgstr "Creating your resume..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Crop and Upload"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Skills"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Skip and Upload"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/en-GB.po
+++ b/apps/web/locales/en-GB.po
@@ -1490,10 +1490,6 @@ msgstr "Counted separately from the parse score. Coverage does not predict anyth
 msgid "Cover"
 msgstr "Cover"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Creating your API key..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Creating your resume..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Save"
 msgid "Save & Test Provider"
 msgstr "Save & Test Provider"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Save & Upload"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Save an unprotected copy, with no password and no permissions restrictions."
@@ -5226,6 +5222,10 @@ msgstr "Size"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Skills"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/en-US.po
+++ b/apps/web/locales/en-US.po
@@ -1485,10 +1485,6 @@ msgstr "Counted separately from the parse score. Coverage does not predict anyth
 msgid "Cover"
 msgstr "Cover"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1663,6 +1659,10 @@ msgstr "Creating your API key..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Creating your resume..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr "Crop and Upload"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4754,10 +4754,6 @@ msgstr "Save"
 msgid "Save & Test Provider"
 msgstr "Save & Test Provider"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Save & Upload"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Save an unprotected copy, with no password and no permissions restrictions."
@@ -5221,6 +5217,10 @@ msgstr "Size"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Skills"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr "Skip and Upload"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/es-ES.po
+++ b/apps/web/locales/es-ES.po
@@ -1667,7 +1667,7 @@ msgstr "Creando tu currículum..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Recortar y subir"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Habilidades"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Omitir y subir"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/es-ES.po
+++ b/apps/web/locales/es-ES.po
@@ -1490,10 +1490,6 @@ msgstr "Se cuenta aparte de la puntuación de lectura. La cobertura no predice n
 msgid "Cover"
 msgstr "Cubrir"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cubrir recorta la imagen para llenar el marco. Contener muestra la imagen completa. Vuelve a subir el original para recuperar los bordes eliminados por un recorte anterior."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Creando tu clave API..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Creando tu currículum..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Guarde"
 msgid "Save & Test Provider"
 msgstr "Proveedor de guardar y probar"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Guardar y subir"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Guarde una copia sin protección, sin contraseña ni restricciones de permisos."
@@ -5226,6 +5222,10 @@ msgstr "Tamaño"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Habilidades"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/fa-IR.po
+++ b/apps/web/locales/fa-IR.po
@@ -1667,7 +1667,7 @@ msgstr "در حال ایجاد رزومه شما..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "برش و بارگذاری"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "مهارت‌ها"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "رد کردن و بارگذاری"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/fa-IR.po
+++ b/apps/web/locales/fa-IR.po
@@ -1490,10 +1490,6 @@ msgstr "جدا از امتیاز استخراج شمرده می‌شود. پوش
 msgid "Cover"
 msgstr "پوشش"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "کاور تصویر را برش می دهد تا کادر را پر کند. Contain کل تصویر را نشان می دهد. برای بازیابی لبه های حذف شده توسط یک برش قبلی، نسخه اصلی را دوباره آپلود کنید."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "در حال ایجاد کلید API شما..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "در حال ایجاد رزومه شما..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "ذخیره"
 msgid "Save & Test Provider"
 msgstr "ذخیره و تست ارائه دهنده"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "ذخیره و آپلود"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "یک نسخهٔ بدون محافظت ذخیره کنید، بدون گذرواژه و بدون محدودیت دسترسی."
@@ -5226,6 +5222,10 @@ msgstr "اندازه"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "مهارت‌ها"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/fi-FI.po
+++ b/apps/web/locales/fi-FI.po
@@ -1667,7 +1667,7 @@ msgstr "Luodaan ansioluetteloasi..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Rajaa ja lataa"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Taidot"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Ohita ja lataa"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/fi-FI.po
+++ b/apps/web/locales/fi-FI.po
@@ -1490,10 +1490,6 @@ msgstr "Lasketaan erillään jäsennyspisteistä. Kattavuus ei ennusta mitään.
 msgid "Cover"
 msgstr "Täytä"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Täytä rajaa kuvan niin, että se täyttää kehyksen. Sovita näyttää koko kuvan. Lataa alkuperäinen kuva uudelleen palauttaaksesi reunat, jotka poistettiin aiemmassa rajauksessa."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Luodaan API-avaintasi..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Luodaan ansioluetteloasi..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Tallenna"
 msgid "Save & Test Provider"
 msgstr "Tallenna ja testaa -palveluntarjoaja"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Tallenna ja lataa"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Tallenna suojaamaton kopio ilman salasanaa ja käyttöoikeusrajoituksia."
@@ -5226,6 +5222,10 @@ msgstr "Koko"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Taidot"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/fr-FR.po
+++ b/apps/web/locales/fr-FR.po
@@ -1667,7 +1667,7 @@ msgstr "Création de votre CV..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Recadrer et télécharger"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Compétences"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Ignorer et télécharger"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/fr-FR.po
+++ b/apps/web/locales/fr-FR.po
@@ -1490,10 +1490,6 @@ msgstr "Comptée séparément du score de lecture. La couverture ne prédit rien
 msgid "Cover"
 msgstr "Remplir"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "« Remplir » recadre l'image pour remplir le cadre. « Contenir » affiche l'image entière. Réimportez l'original pour restaurer les bords supprimés par un recadrage précédent."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Création de votre clé API..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Création de votre CV..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Économiser"
 msgid "Save & Test Provider"
 msgstr "Fournisseur de sauvegarde et de test"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Enregistrer et télécharger"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Enregistrez une copie non protégée, sans mot de passe ni restriction de permissions."
@@ -5226,6 +5222,10 @@ msgstr "Taille"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Compétences"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/he-IL.po
+++ b/apps/web/locales/he-IL.po
@@ -1667,7 +1667,7 @@ msgstr "יוצר את קורות החיים שלך..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "חיתוך והעלאה"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "מיומנויות"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "דלג והעלה"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/he-IL.po
+++ b/apps/web/locales/he-IL.po
@@ -1490,10 +1490,6 @@ msgstr "נספר בנפרד מציון הפענוח. הכיסוי אינו מנ�
 msgid "Cover"
 msgstr "כיסוי"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "כריכה חותכת את התמונה כדי למלא את המסגרת. מכיל מציג את כל התמונה. העלה מחדש את המקור כדי לשחזר קצוות שהוסרו על ידי חיתוך מוקדם יותר."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "יוצר את מפתח ה־API שלך..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "יוצר את קורות החיים שלך..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "שמור"
 msgid "Save & Test Provider"
 msgstr "שמור ובדוק ספק"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "שמור והעלה"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "שמור עותק לא מוגן, ללא סיסמה וללא הגבלות הרשאה."
@@ -5226,6 +5222,10 @@ msgstr "גודל"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "מיומנויות"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/hi-IN.po
+++ b/apps/web/locales/hi-IN.po
@@ -1490,10 +1490,6 @@ msgstr "इसकी गिनती पार्स स्कोर से अ�
 msgid "Cover"
 msgstr "आवरण"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "फ़्रेम को भरने के लिए कवर छवि को क्रॉप करता है। सम्‍मिलित पूरी छवि दिखाता है। पिछली फ़सल द्वारा हटाए गए किनारों को पुनर्स्थापित करने के लिए मूल को पुनः अपलोड करें।"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "आपकी API कुंजी बनाई जा रही है...
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "आपका रेज़्यूमे बनाया जा रहा है..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "बचाएँ"
 msgid "Save & Test Provider"
 msgstr "प्रदाता को सहेजें और परीक्षण करें"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "सहेजें और अपलोड करें"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "बिना पासवर्ड और बिना अनुमति प्रतिबंधों के एक असुरक्षित प्रति सहेजें।"
@@ -5226,6 +5222,10 @@ msgstr "आकार"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "कौशल"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/hi-IN.po
+++ b/apps/web/locales/hi-IN.po
@@ -1667,7 +1667,7 @@ msgstr "आपका रेज़्यूमे बनाया जा रह�
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "तस्वीर काटें और अपलोड करें"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "कौशल"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "छोड़ें और अपलोड करें"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/hu-HU.po
+++ b/apps/web/locales/hu-HU.po
@@ -1490,10 +1490,6 @@ msgstr "A feldolgozási pontszámtól külön számít. A lefedettség semmit se
 msgid "Cover"
 msgstr "Borító"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "A Cover levágja a képet, hogy kitöltse a keretet. A Contain a teljes képet mutatja. Töltse fel újra az eredetit a korábbi kivágás által eltávolított élek visszaállításához."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "API kulcs létrehozása..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Önéletrajz létrehozása..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Mentés"
 msgid "Save & Test Provider"
 msgstr "Mentés és tesztelés szolgáltatója"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Mentés és feltöltés"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Mentsd el egy nem védett másolatként, jelszó és jogosultsági korlátozás nélkül."
@@ -5226,6 +5222,10 @@ msgstr "Méret"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Készségek"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/hu-HU.po
+++ b/apps/web/locales/hu-HU.po
@@ -1667,7 +1667,7 @@ msgstr "Önéletrajz létrehozása..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Kép kivágása és feltöltése"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Készségek"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Kihagyás és feltöltés"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/id-ID.po
+++ b/apps/web/locales/id-ID.po
@@ -1490,10 +1490,6 @@ msgstr "Dihitung terpisah dari skor pembacaan. Cakupan tidak memprediksi apa pun
 msgid "Cover"
 msgstr "Penutup"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Penutup memotong gambar untuk mengisi bingkai. Berisi menunjukkan keseluruhan gambar. Unggah ulang dokumen asli untuk memulihkan tepian yang terhapus oleh pemotongan sebelumnya."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Membuat API key Anda..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Membuat resume Anda..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Simpan"
 msgid "Save & Test Provider"
 msgstr "Penyedia Simpan & Uji"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Simpan & Unggah"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Simpan salinan yang tidak dilindungi, tanpa kata sandi dan tanpa pembatasan izin."
@@ -5226,6 +5222,10 @@ msgstr "Ukuran"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Keahlian"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/id-ID.po
+++ b/apps/web/locales/id-ID.po
@@ -1667,7 +1667,7 @@ msgstr "Membuat resume Anda..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Pangkas dan unggah"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Keahlian"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Lewati dan unggah"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/it-IT.po
+++ b/apps/web/locales/it-IT.po
@@ -1490,10 +1490,6 @@ msgstr "Conteggiata separatamente dal punteggio di lettura. La copertura non pre
 msgid "Cover"
 msgstr "Riempi"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "«Riempi» ritaglia l'immagine per riempire la cornice. «Adatta» mostra l'immagine intera. Ricarica l'originale per ripristinare i bordi rimossi da un ritaglio precedente."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Creazione della chiave API in corso..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Creazione del tuo curriculum in corso..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Risparmiare"
 msgid "Save & Test Provider"
 msgstr "Provider di salvataggio e test"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Salva e carica"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Salva una copia non protetta, senza password e senza restrizioni sui permessi."
@@ -5226,6 +5222,10 @@ msgstr "Dimensione"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Competenze"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/it-IT.po
+++ b/apps/web/locales/it-IT.po
@@ -1667,7 +1667,7 @@ msgstr "Creazione del tuo curriculum in corso..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Ritaglia e carica"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Competenze"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Salta e carica"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ja-JP.po
+++ b/apps/web/locales/ja-JP.po
@@ -1490,10 +1490,6 @@ msgstr "解析スコアとは別に集計されます。カバレッジは何か
 msgid "Cover"
 msgstr "切り抜き"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "「切り抜き」は画像を切り抜いて枠いっぱいに表示します。「全体表示」は画像全体を表示します。以前の切り抜きで削られた部分を戻すには、元の画像を再アップロードしてください。"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "API キーを作成しています..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "履歴書を作成しています…"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "保存"
 msgid "Save & Test Provider"
 msgstr "プロバイダーを保存してテストする"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "保存してアップロード"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "パスワードや権限制限のない、保護されていないコピーを保存してください。"
@@ -5226,6 +5222,10 @@ msgstr "サイズ"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "スキル"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ja-JP.po
+++ b/apps/web/locales/ja-JP.po
@@ -1667,7 +1667,7 @@ msgstr "履歴書を作成しています…"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "トリミングしてアップロード"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "スキル"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "スキップしてアップロード"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/km-KH.po
+++ b/apps/web/locales/km-KH.po
@@ -1490,10 +1490,6 @@ msgstr "រាប់ដាច់ដោយឡែកពីពិន្ទុវិ
 msgid "Cover"
 msgstr "គម្រប"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "គម្របកាត់រូបភាពដើម្បីបំពេញស៊ុម។ Contain បង្ហាញរូបភាពទាំងមូល។ ផ្ទុក​ដើម​ឡើង​វិញ​ដើម្បី​ស្ដារ​គែម​ដែល​បាន​លុប​ចេញ​ដោយ​ការ​ច្រឹប​មុន។"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "កំពុង​បង្កើត​កូនសោ API របស់�
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "កំពុង​បង្កើត​ប្រវត្តិរូប​របស់​អ្នក..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "រក្សាទុក"
 msgid "Save & Test Provider"
 msgstr "រក្សាទុក និងសាកល្បងអ្នកផ្តល់សេវា"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "រក្សាទុក និងផ្ទុកឡើង"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "រក្សាទុកច្បាប់ចម្លងដែលមិនបានការពារ ដោយគ្មានពាក្យសម្ងាត់ និងគ្មានការដាក់កម្រិតសិទ្ធិ។"
@@ -5226,6 +5222,10 @@ msgstr "ទំហំ"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "ជំនាញ"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/km-KH.po
+++ b/apps/web/locales/km-KH.po
@@ -1667,7 +1667,7 @@ msgstr "កំពុង​បង្កើត​ប្រវត្តិរូប
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "ច្រឹប និងអាប់ឡូដ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "ជំនាញ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "រំលង និងអាប់ឡូដ"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/kn-IN.po
+++ b/apps/web/locales/kn-IN.po
@@ -1667,7 +1667,7 @@ msgstr "ನಿಮ್ಮ ರೆಸ್ಯೂಮ್ ರಚಿಸಲಾಗುತ್�
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "ಚಿತ್ರವನ್ನು ಕ್ರಾಪ್ ಮಾಡಿ ಮತ್ತು ಅಪ್‌ಲೋಡ್ ಮಾಡಿ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "ಕೌಶಲ್ಯಗಳು"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "ಬಿಟ್ಟು ಅಪ್‌ಲೋಡ್ ಮಾಡಿ"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/kn-IN.po
+++ b/apps/web/locales/kn-IN.po
@@ -1490,10 +1490,6 @@ msgstr "ಪಾರ್ಸ್ ಅಂಕದಿಂದ ಪ್ರತ್ಯೇಕವಾ�
 msgid "Cover"
 msgstr "ಕವರ್"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "ಫ್ರೇಮ್ ಅನ್ನು ತುಂಬಲು ಚಿತ್ರವನ್ನು ಕವರ್ ಮಾಡಿ. ಸಂಪೂರ್ಣ ಚಿತ್ರವನ್ನು ತೋರಿಸುತ್ತದೆ. ಹಿಂದಿನ ಕ್ರಾಪ್‌ನಿಂದ ತೆಗೆದುಹಾಕಲಾದ ಅಂಚುಗಳನ್ನು ಮರುಸ್ಥಾಪಿಸಲು ಮೂಲವನ್ನು ಮರುಅಪ್‌ಲೋಡ್ ಮಾಡಿ."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "ನಿಮ್ಮ API ಕೀಲಿ ರಚಿಸಲಾಗುತ್ತಿದ
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "ನಿಮ್ಮ ರೆಸ್ಯೂಮ್ ರಚಿಸಲಾಗುತ್ತಿದೆ..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "ಉಳಿಸಿ"
 msgid "Save & Test Provider"
 msgstr "ಉಳಿಸಿ ಮತ್ತು ಪರೀಕ್ಷಿಸಿ ಪೂರೈಕೆದಾರ"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "ಉಳಿಸಿ ಮತ್ತು ಅಪ್‌ಲೋಡ್ ಮಾಡಿ"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "ಪಾಸ್‌ವರ್ಡ್ ಇಲ್ಲದ ಮತ್ತು ಅನುಮತಿ ನಿರ್ಬಂಧಗಳಿಲ್ಲದ ಅಸಂರಕ್ಷಿತ ಪ್ರತಿಯನ್ನು ಉಳಿಸಿ."
@@ -5226,6 +5222,10 @@ msgstr "ಗಾತ್ರ"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "ಕೌಶಲ್ಯಗಳು"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ko-KR.po
+++ b/apps/web/locales/ko-KR.po
@@ -1490,10 +1490,6 @@ msgstr "파싱 점수와는 별도로 계산됩니다. 커버리지는 아무것
 msgid "Cover"
 msgstr "채우기"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "채우기는 이미지를 잘라내 프레임을 가득 채웁니다. 전체 표시는 이미지 전체를 보여 줍니다. 이전 자르기로 잘려 나간 가장자리를 되살리려면 원본을 다시 업로드하세요."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "API 키를 생성하는 중입니다..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "이력서를 생성하는 중입니다..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "저장"
 msgid "Save & Test Provider"
 msgstr "저장 및 테스트 제공업체"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "저장 및 업로드"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "비밀번호와 권한 제한이 없는 보호되지 않은 사본으로 저장하세요."
@@ -5226,6 +5222,10 @@ msgstr "크기"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "기술"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ko-KR.po
+++ b/apps/web/locales/ko-KR.po
@@ -1667,7 +1667,7 @@ msgstr "이력서를 생성하는 중입니다..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "사진 자르고 업로드"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "기술"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "건너뛰고 업로드"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/lt-LT.po
+++ b/apps/web/locales/lt-LT.po
@@ -1667,7 +1667,7 @@ msgstr "Kuriamas jūsų gyvenimo aprašymas..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Apkirpti ir įkelti"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Įgūdžiai"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Praleisti ir įkelti"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/lt-LT.po
+++ b/apps/web/locales/lt-LT.po
@@ -1490,10 +1490,6 @@ msgstr "Skaičiuojama atskirai nuo nuskaitymo įvertinimo. Aprėptis nieko nepro
 msgid "Cover"
 msgstr "Viršelis"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Viršelis apkerpa vaizdą, kad užpildytų kadrą. Contain rodo visą vaizdą. Iš naujo įkelkite originalą, kad atkurtumėte ankstesnio apkarpymo pašalintus kraštus."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Kuriamas jūsų API raktas..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Kuriamas jūsų gyvenimo aprašymas..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Išsaugoti"
 msgid "Save & Test Provider"
 msgstr "Išsaugoti ir išbandyti teikėją"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Išsaugoti ir įkelti"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Išsaugokite neapsaugotą kopiją – be slaptažodžio ir be teisių apribojimų."
@@ -5226,6 +5222,10 @@ msgstr "Dydis"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Įgūdžiai"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/lv-LV.po
+++ b/apps/web/locales/lv-LV.po
@@ -1667,7 +1667,7 @@ msgstr "Tiek izveidots jūsu CV..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Apgriezt un augšupielādēt"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Prasmes"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Izlaist un augšupielādēt"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/lv-LV.po
+++ b/apps/web/locales/lv-LV.po
@@ -1490,10 +1490,6 @@ msgstr "Tiek skaitīts atsevišķi no nolasīšanas vērtējuma. Pārklājums ne
 msgid "Cover"
 msgstr "Vāks"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Vāks apgriež attēlu, lai tas aizpildītu rāmi. Saturs parāda visu attēlu. Atkārtoti augšupielādējiet oriģinālu, lai atjaunotu malas, kas noņemtas ar agrāku apgriešanu."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Tiek izveidota jūsu API atslēga..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Tiek izveidots jūsu CV..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Saglabāt"
 msgid "Save & Test Provider"
 msgstr "Saglabāšanas un testēšanas pakalpojumu sniedzējs"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Saglabāt un augšupielādēt"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Saglabājiet neaizsargātu kopiju bez paroles un bez atļauju ierobežojumiem."
@@ -5226,6 +5222,10 @@ msgstr "Izmērs"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Prasmes"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ml-IN.po
+++ b/apps/web/locales/ml-IN.po
@@ -1490,10 +1490,6 @@ msgstr "പാഴ്സ് സ്കോറിൽ നിന്ന് വേറി
 msgid "Cover"
 msgstr "മൂടുക"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "ഫ്രെയിം നിറയ്ക്കാൻ ചിത്രം കവർ ചെയ്യുക. മുഴുവൻ ചിത്രവും കാണിക്കുന്നു. മുമ്പത്തെ ക്രോപ്പ് നീക്കം ചെയ്ത അരികുകൾ പുനഃസ്ഥാപിക്കാൻ യഥാർത്ഥമായത് വീണ്ടും അപ്‌ലോഡ് ചെയ്യുക."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "നിങ്ങളുടെ API കീ സൃഷ്‌ടിക്കു
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "നിങ്ങളുടെ റിസ്യൂം സൃഷ്‌ടിക്കുന്നു..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "സേവ് ചെയ്യുക"
 msgid "Save & Test Provider"
 msgstr "സേവ് & ടെസ്റ്റ് ദാതാവ്"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "സേവ് & അപ്‌ലോഡ് ചെയ്യുക"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "പാസ്‌വേഡോ അനുമതി നിയന്ത്രണങ്ങളോ ഇല്ലാത്ത, സംരക്ഷിക്കപ്പെടാത്ത ഒരു പകർപ്പ് സേവ് ചെയ്യുക."
@@ -5226,6 +5222,10 @@ msgstr "സൈസ്"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "സ്കിൽസ്"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ml-IN.po
+++ b/apps/web/locales/ml-IN.po
@@ -1667,7 +1667,7 @@ msgstr "നിങ്ങളുടെ റിസ്യൂം സൃഷ്‌ടി�
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "ചിത്രം ക്രോപ്പ് ചെയ്ത് അപ്‌ലോഡ് ചെയ്യുക"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "സ്കിൽസ്"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "ഒഴിവാക്കി അപ്‌ലോഡ് ചെയ്യുക"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/mr-IN.po
+++ b/apps/web/locales/mr-IN.po
@@ -1490,10 +1490,6 @@ msgstr "याची मोजणी पार्स स्कोअरपेक
 msgid "Cover"
 msgstr "कव्हर"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "फ्रेम भरण्यासाठी कव्हर इमेज क्रॉप करा. समाविष्ट संपूर्ण प्रतिमा दाखवते. पूर्वीच्या क्रॉपद्वारे काढलेल्या कडा पुनर्संचयित करण्यासाठी मूळ पुन्हा अपलोड करा."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "तुमची API key तयार केली जात आहे...
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "तुमचा रेझ्युमे तयार केला जात आहे..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "सांभाळा"
 msgid "Save & Test Provider"
 msgstr "सेव्ह आणि टेस्ट प्रोव्हायडर"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "जतन करा आणि अपलोड करा"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "पासवर्ड आणि परवानगी निर्बंधांशिवाय असुरक्षित प्रत सेव्ह करा."
@@ -5226,6 +5222,10 @@ msgstr "आकार"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "कौशल्ये"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/mr-IN.po
+++ b/apps/web/locales/mr-IN.po
@@ -1667,7 +1667,7 @@ msgstr "तुमचा रेझ्युमे तयार केला ज�
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "चित्र क्रॉप करून अपलोड करा"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "कौशल्ये"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "वगळा आणि अपलोड करा"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ms-MY.po
+++ b/apps/web/locales/ms-MY.po
@@ -1667,7 +1667,7 @@ msgstr "Mencipta resume anda..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Pangkas dan muat naik"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Kemahiran"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Langkau dan muat naik"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ms-MY.po
+++ b/apps/web/locales/ms-MY.po
@@ -1490,10 +1490,6 @@ msgstr "Dikira berasingan daripada skor pembacaan. Liputan tidak meramalkan apa-
 msgid "Cover"
 msgstr "Penutup"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cover memangkas imej untuk mengisi bingkai. Mengandungi menunjukkan keseluruhan imej. Muat naik semula yang asal untuk memulihkan tepi yang dialih keluar oleh pemangkasan terdahulu."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Mencipta kunci API anda..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Mencipta resume anda..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Simpan"
 msgid "Save & Test Provider"
 msgstr "Pembekal Simpan & Uji"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Simpan & Muat Naik"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Simpan salinan tidak dilindungi, tanpa kata laluan dan tanpa sekatan kebenaran."
@@ -5226,6 +5222,10 @@ msgstr "Saiz"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Kemahiran"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ne-NP.po
+++ b/apps/web/locales/ne-NP.po
@@ -1490,10 +1490,6 @@ msgstr "यसको गणना पार्स अंकभन्दा छ�
 msgid "Cover"
 msgstr "कभर"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "आवरणले फ्रेम भर्नको लागि छवि क्रप गर्नुहोस्। समावेश सम्पूर्ण छवि देखाउँछ। पहिलेको क्रपद्वारा हटाइएका किनारहरू पुनर्स्थापना गर्न मूल पुन: अपलोड गर्नुहोस्।"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "तपाईंको API key बनाउँदै..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "तपाईंको बायोडाटा बनाउँदै..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "बचाउनुहोस्"
 msgid "Save & Test Provider"
 msgstr "सेभ र टेस्ट प्रदायक"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "बचत गर्नुहोस् र अपलोड गर्नुहोस्"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "पासवर्ड र अनुमति प्रतिबन्ध नभएको असुरक्षित प्रतिलिपि सुरक्षित गर्नुहोस्।"
@@ -5226,6 +5222,10 @@ msgstr "आकार"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "सीपहरू"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ne-NP.po
+++ b/apps/web/locales/ne-NP.po
@@ -1667,7 +1667,7 @@ msgstr "तपाईंको बायोडाटा बनाउँदै..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "तस्बिर क्रप गरेर अपलोड गर्नुहोस्"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "सीपहरू"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "छोडेर अपलोड गर्नुहोस्"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/nl-NL.po
+++ b/apps/web/locales/nl-NL.po
@@ -1667,7 +1667,7 @@ msgstr "Uw cv wordt aangemaakt..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Afbeelding bijsnijden en uploaden"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Vaardigheden"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Overslaan en uploaden"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/nl-NL.po
+++ b/apps/web/locales/nl-NL.po
@@ -1490,10 +1490,6 @@ msgstr "Wordt los van de parseerscore geteld. Dekking voorspelt niets."
 msgid "Cover"
 msgstr "Vullen"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Vullen snijdt de afbeelding bij zodat die het kader vult. Passend toont de hele afbeelding. Upload het origineel opnieuw om randen te herstellen die een eerdere bijsnijding heeft weggehaald."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Uw API-sleutel wordt aangemaakt..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Uw cv wordt aangemaakt..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Sla"
 msgid "Save & Test Provider"
 msgstr "Aanbieder opslaan en testen"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Opslaan en uploaden"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Sla een onbeveiligde kopie op, zonder wachtwoord en zonder rechtenbeperkingen."
@@ -5226,6 +5222,10 @@ msgstr "Grootte"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Vaardigheden"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/no-NO.po
+++ b/apps/web/locales/no-NO.po
@@ -1490,10 +1490,6 @@ msgstr "Telles separat fra parse-poengsummen. Dekning forutsier ingenting."
 msgid "Cover"
 msgstr "Fyll"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Fyll beskjærer bildet slik at det fyller rammen. Tilpass viser hele bildet. Last opp originalen på nytt for å gjenopprette kanter som ble fjernet av en tidligere beskjæring."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Oppretter API-nøkkelen din..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Oppretter CV-en din..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Lagre"
 msgid "Save & Test Provider"
 msgstr "Lagre og testleverandør"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Lagre og last opp"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Lagre en ubeskyttet kopi, uten passord og uten tillatelsesbegrensninger."
@@ -5226,6 +5222,10 @@ msgstr "Størrelse"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Ferdigheter"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/no-NO.po
+++ b/apps/web/locales/no-NO.po
@@ -1667,7 +1667,7 @@ msgstr "Oppretter CV-en din..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Beskjær og last opp"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Ferdigheter"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Hopp over og last opp"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/or-IN.po
+++ b/apps/web/locales/or-IN.po
@@ -1667,7 +1667,7 @@ msgstr "ଆପଣଙ୍କ ରେଜ୍ୟୁମେ ତିଆରି ହେଉଛ
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "ଛବି କ୍ରପ୍ କରନ୍ତୁ ଏବଂ ଅପଲୋଡ୍ କରନ୍ତୁ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "କୌଶଳଗୁଡିକ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "ଛାଡ଼ି ଅପଲୋଡ୍ କରନ୍ତୁ"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/or-IN.po
+++ b/apps/web/locales/or-IN.po
@@ -1490,10 +1490,6 @@ msgstr "ପାର୍ସ ସ୍କୋରଠାରୁ ଅଲଗା ଭାବରେ
 msgid "Cover"
 msgstr "ଆଚ୍ଛାଦନ କରନ୍ତୁ |"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "ଫ୍ରେମ୍ ଭରିବା ପାଇଁ ପ୍ରତିଛବିକୁ ଫସଲ ଘୋଡାନ୍ତୁ | ଧାରଣ ସମଗ୍ର ପ୍ରତିଛବି ଦେଖାଏ | ପୂର୍ବ ଫସଲ ଦ୍ୱାରା ଅପସାରିତ ଧାରଗୁଡିକ ପୁନ restore ସ୍ଥାପନ କରିବାକୁ ମୂଳକୁ ପୁନ up ଲୋଡ୍ କରନ୍ତୁ |"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "ଆପଣଙ୍କ API କି ତିଆରି ହେଉଛି..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "ଆପଣଙ୍କ ରେଜ୍ୟୁମେ ତିଆରି ହେଉଛି..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "ସଞ୍ଚୟ କରନ୍ତୁ"
 msgid "Save & Test Provider"
 msgstr "ସେଭ୍ ଏବଂ ପରୀକ୍ଷଣ ପ୍ରଦାନକାରୀ"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "ସେଭ୍ ଏବଂ ଅପଲୋଡ୍ କରନ୍ତୁ"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "କୌଣସି ପାସୱାର୍ଡ କିମ୍ବା ଅନୁମତି ପ୍ରତିବନ୍ଧକ ବିନା ଏକ ଅସୁରକ୍ଷିତ କପି ସେଭ୍ କରନ୍ତୁ।"
@@ -5226,6 +5222,10 @@ msgstr "ଆକାର"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "କୌଶଳଗୁଡିକ"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/pl-PL.po
+++ b/apps/web/locales/pl-PL.po
@@ -1490,10 +1490,6 @@ msgstr "Liczone osobno od wyniku odczytu pliku. Pokrycie niczego nie przewiduje.
 msgid "Cover"
 msgstr "Okładka"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Okładka przycina obraz tak, aby wypełnił ramkę. Zawiera pokazuje cały obraz. Prześlij oryginał ponownie, aby przywrócić krawędzie usunięte podczas wcześniejszego przycięcia."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Tworzenie klucza API..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Tworzenie CV..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Zapisz"
 msgid "Save & Test Provider"
 msgstr "Zapisz i przetestuj dostawcę"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Zapisz i prześlij"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Zapisz niechronioną kopię, bez hasła i bez ograniczeń uprawnień."
@@ -5226,6 +5222,10 @@ msgstr "Rozmiar"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Umiejętności"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/pl-PL.po
+++ b/apps/web/locales/pl-PL.po
@@ -1667,7 +1667,7 @@ msgstr "Tworzenie CV..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Przytnij i prześlij"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Umiejętności"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Pomiń i prześlij"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/pt-BR.po
+++ b/apps/web/locales/pt-BR.po
@@ -1490,10 +1490,6 @@ msgstr "Contabilizada separadamente da pontuação de leitura. A cobertura não 
 msgid "Cover"
 msgstr "Cobrir"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cobrir corta a imagem para preencher o quadro. Conter mostra a imagem inteira. Envie o original novamente para recuperar as bordas removidas por um corte anterior."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Criando sua chave de API..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Criando seu currículo..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Salvar"
 msgid "Save & Test Provider"
 msgstr "Fornecedor de salvamento e teste"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Salvar e enviar"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Salve uma cópia sem proteção, sem senha e sem restrições de permissão."
@@ -5226,6 +5222,10 @@ msgstr "Tamanho"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Habilidades"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/pt-BR.po
+++ b/apps/web/locales/pt-BR.po
@@ -1667,7 +1667,7 @@ msgstr "Criando seu currículo..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Recortar e carregar"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Habilidades"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Pular e carregar"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/pt-PT.po
+++ b/apps/web/locales/pt-PT.po
@@ -1667,7 +1667,7 @@ msgstr "A criar o seu currículo..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Recortar e carregar"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Competências"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Saltar e carregar"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/pt-PT.po
+++ b/apps/web/locales/pt-PT.po
@@ -1490,10 +1490,6 @@ msgstr "Contabilizada à parte da pontuação de leitura. A cobertura não prev�
 msgid "Cover"
 msgstr "Cobrir"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cobrir corta a imagem para preencher a moldura. Conter mostra a imagem completa. Carregue novamente o original para recuperar as margens removidas por um corte anterior."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "A criar a sua chave API..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "A criar o seu currículo..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Guardar"
 msgid "Save & Test Provider"
 msgstr "Fornecedor de salvamento e teste"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Guardar e enviar"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Guarde uma cópia sem proteção, sem palavra-passe e sem restrições de permissões."
@@ -5226,6 +5222,10 @@ msgstr "Tamanho"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Competências"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ro-RO.po
+++ b/apps/web/locales/ro-RO.po
@@ -1490,10 +1490,6 @@ msgstr "Se numără separat de scorul de analiză. Acoperirea nu prezice nimic."
 msgid "Cover"
 msgstr "Umplere"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "„Umplere” decupează imaginea pentru a umple cadrul. „Încadrare” afișează imaginea întreagă. Încarcă din nou originalul pentru a restaura marginile eliminate de o decupare anterioară."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Se creează cheia API..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Se creează CV-ul..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Salvați"
 msgid "Save & Test Provider"
 msgstr "Salvați și testați furnizorul"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Salvați și încărcați"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Salvați o copie neprotejată, fără parolă și fără restricții de permisiuni."
@@ -5226,6 +5222,10 @@ msgstr "Dimensiune"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Abilități"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ro-RO.po
+++ b/apps/web/locales/ro-RO.po
@@ -1667,7 +1667,7 @@ msgstr "Se creează CV-ul..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Decupează și încarcă"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Abilități"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Omite și încarcă"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ru-RU.po
+++ b/apps/web/locales/ru-RU.po
@@ -1490,10 +1490,6 @@ msgstr "Считается отдельно от оценки распознав
 msgid "Cover"
 msgstr "Обложка"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Обложка обрезает изображение, чтобы заполнить рамку. Содержать показывает все изображение. Перезагрузите оригинал, чтобы восстановить края, удаленные при предыдущей обрезке."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Создание вашего API-ключа..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Создание вашего резюме..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Сохранить"
 msgid "Save & Test Provider"
 msgstr "Сохранение и тестирование поставщика"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Сохранить и загрузить"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Сохраните незащищённую копию — без пароля и ограничений доступа."
@@ -5226,6 +5222,10 @@ msgstr "Размер"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Навыки"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ru-RU.po
+++ b/apps/web/locales/ru-RU.po
@@ -1667,7 +1667,7 @@ msgstr "Создание вашего резюме..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Обрезать и загрузить"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Навыки"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Пропустить и загрузить"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sk-SK.po
+++ b/apps/web/locales/sk-SK.po
@@ -1667,7 +1667,7 @@ msgstr "Vytváram tvoj životopis..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Orezať a nahrať"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Zručnosti"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Preskočiť a nahrať"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sk-SK.po
+++ b/apps/web/locales/sk-SK.po
@@ -1490,10 +1490,6 @@ msgstr "Počíta sa oddelene od skóre čitateľnosti. Pokrytie nič nepredpoved
 msgid "Cover"
 msgstr "Kryt"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cover oreže obrázok tak, aby vyplnil rám. Obsah zobrazí celý obrázok. Znova nahrajte originál, aby ste obnovili okraje odstránené skorším orezaním."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Vytváram tvoj API kľúč..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Vytváram tvoj životopis..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Uložiť"
 msgid "Save & Test Provider"
 msgstr "Poskytovateľ uloženia a testovania"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Uložiť a nahrať"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Uložte nechránenú kópiu bez hesla a bez obmedzení oprávnení."
@@ -5226,6 +5222,10 @@ msgstr "Veľkosť"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Zručnosti"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sl-SI.po
+++ b/apps/web/locales/sl-SI.po
@@ -1490,10 +1490,6 @@ msgstr "Šteje se ločeno od ocene razčlenjevanja. Pokritost ne napoveduje nič
 msgid "Cover"
 msgstr "Pokrov"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Naslovnica obreže sliko, da zapolni okvir. Contain prikazuje celotno sliko. Znova naložite izvirnik, da obnovite robove, odstranjene s prejšnjim obrezovanjem."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Ustvarjanje vašega API ključa..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Ustvarjanje vašega življenjepisa..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Shrani"
 msgid "Save & Test Provider"
 msgstr "Ponudnik shranjevanja in testiranja"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Shrani in naloži"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Shranite nezaščiteno kopijo, brez gesla in brez omejitev dovoljenj."
@@ -5226,6 +5222,10 @@ msgstr "Velikost"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Spretnosti"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sl-SI.po
+++ b/apps/web/locales/sl-SI.po
@@ -1667,7 +1667,7 @@ msgstr "Ustvarjanje vašega življenjepisa..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Obreži in naloži"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Spretnosti"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Preskoči in naloži"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sq-AL.po
+++ b/apps/web/locales/sq-AL.po
@@ -1667,7 +1667,7 @@ msgstr "Po krijohet CV-ja juaj..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Prit dhe ngarko"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Aftësi"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Kalo dhe ngarko"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sq-AL.po
+++ b/apps/web/locales/sq-AL.po
@@ -1490,10 +1490,6 @@ msgstr "Numërohet veçmas nga rezultati i analizimit. Mbulimi nuk parashikon as
 msgid "Cover"
 msgstr "Mbulesë"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cover pret imazhin për të mbushur kornizën. Contain tregon të gjithë imazhin. Ringarkoni origjinalin për të rivendosur skajet e hequra nga një prerje e mëparshme."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Po krijohet API key-ja juaj..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Po krijohet CV-ja juaj..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Ruaj"
 msgid "Save & Test Provider"
 msgstr "Ruaj dhe Testo Ofruesin"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Ruaj dhe Ngarko"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Ruani një kopje të pambrojtur, pa fjalëkalim dhe pa kufizime lejesh."
@@ -5226,6 +5222,10 @@ msgstr "Madhësia"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Aftësi"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sr-SP.po
+++ b/apps/web/locales/sr-SP.po
@@ -1667,7 +1667,7 @@ msgstr "Креирање вашег резимеа..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Обрежи и отпреми"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Вештине"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Прескочи и отпреми"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sr-SP.po
+++ b/apps/web/locales/sr-SP.po
@@ -1490,10 +1490,6 @@ msgstr "Рачуна се одвојено од оцене читљивости.
 msgid "Cover"
 msgstr "Цовер"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Поклопац изрезује слику да попуни оквир. Цонтаин приказује целу слику. Поново отпремите оригинал да бисте вратили ивице које су уклоњене ранијим изрезивањем."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Креирање вашег API кључа..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Креирање вашег резимеа..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Сачувај"
 msgid "Save & Test Provider"
 msgstr "Провајдер за чување и тестирање"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Сачувај и отпреми"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Сачувајте незаштићену копију, без лозинке и без ограничења дозвола."
@@ -5226,6 +5222,10 @@ msgstr "Величина"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Вештине"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sv-SE.po
+++ b/apps/web/locales/sv-SE.po
@@ -1667,7 +1667,7 @@ msgstr "Skapar ditt CV..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Beskär och ladda upp"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Färdigheter"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Hoppa över och ladda upp"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/sv-SE.po
+++ b/apps/web/locales/sv-SE.po
@@ -1490,10 +1490,6 @@ msgstr "Räknas separat från tolkningspoängen. Täckningen förutsäger ingent
 msgid "Cover"
 msgstr "Fyll"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Fyll beskär bilden så att den fyller ramen. Anpassa visar hela bilden. Ladda upp originalet igen för att återställa kanter som togs bort vid en tidigare beskärning."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Skapar din API-nyckel..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Skapar ditt CV..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Spara"
 msgid "Save & Test Provider"
 msgstr "Spara och testa leverantören"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Spara och ladda upp"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Spara en oskyddad kopia, utan lösenord och utan behörighetsbegränsningar."
@@ -5226,6 +5222,10 @@ msgstr "Storlek"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Färdigheter"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ta-IN.po
+++ b/apps/web/locales/ta-IN.po
@@ -1667,7 +1667,7 @@ msgstr "உங்கள் ரெஸ்யூமியை உருவாக்�
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "படத்தை செதுக்கி பதிவேற்றவும்"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "திறன்கள்"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "தவிர்த்து பதிவேற்றவும்"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/ta-IN.po
+++ b/apps/web/locales/ta-IN.po
@@ -1490,10 +1490,6 @@ msgstr "பாகுபடுத்தல் மதிப்பெண்ணி�
 msgid "Cover"
 msgstr "கவர்"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "சட்டத்தை நிரப்ப படத்தை மூடி வைக்கவும். முழு படத்தையும் காட்டுகிறது. முந்தைய செதுக்கினால் அகற்றப்பட்ட விளிம்புகளை மீட்டெடுக்க அசலை மீண்டும் பதிவேற்றவும்."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "உங்கள் API விசையை உருவாக்குக
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "உங்கள் ரெஸ்யூமியை உருவாக்குகிறது..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "சேமி"
 msgid "Save & Test Provider"
 msgstr "வழங்குநரைச் சேமித்துச் சோதிக்கவும்"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "சேமித்து பதிவேற்றவும்"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "கடவுச்சொல் இல்லாமல், அனுமதிக் கட்டுப்பாடுகள் இல்லாமல், பாதுகாக்கப்படாத நகலைச் சேமிக்கவும்."
@@ -5226,6 +5222,10 @@ msgstr "அளவு"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "திறன்கள்"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/te-IN.po
+++ b/apps/web/locales/te-IN.po
@@ -1490,10 +1490,6 @@ msgstr "పార్స్ స్కోర్ నుంచి విడిగా
 msgid "Cover"
 msgstr "కవర్"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "ఫ్రేమ్‌ను పూరించడానికి చిత్రాన్ని కవర్ చేయండి. కలిగి మొత్తం చిత్రాన్ని చూపుతుంది. మునుపటి క్రాప్ ద్వారా తీసివేయబడిన అంచులను పునరుద్ధరించడానికి అసలైనదాన్ని మళ్లీ అప్‌లోడ్ చేయండి."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "మీ API కీ సృష్టించబడుతోంది..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "మీ రిజ్యూమ్ సృష్టించబడుతోంది..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "పొదుపు చేయండి"
 msgid "Save & Test Provider"
 msgstr "సేవ్ & టెస్ట్ ప్రొవైడర్"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "సేవ్ చేసి అప్‌లోడ్ చేయండి"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "పాస్‌వర్డ్ లేకుండా, అనుమతుల పరిమితులు లేకుండా రక్షణ లేని కాపీని సేవ్ చేయండి."
@@ -5226,6 +5222,10 @@ msgstr "సైజు"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "స్కిల్స్"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/te-IN.po
+++ b/apps/web/locales/te-IN.po
@@ -1667,7 +1667,7 @@ msgstr "మీ రిజ్యూమ్ సృష్టించబడుతో�
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "చిత్రాన్ని కత్తిరించి అప్‌లోడ్ చేయండి"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "స్కిల్స్"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "దాటవేసి అప్‌లోడ్ చేయండి"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/th-TH.po
+++ b/apps/web/locales/th-TH.po
@@ -1490,10 +1490,6 @@ msgstr "นับแยกจากคะแนนการอ่านข้อ
 msgid "Cover"
 msgstr "ปก"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Cover ครอบตัดรูปภาพให้เต็มกรอบ Contain แสดงรูปภาพทั้งหมด อัปโหลดต้นฉบับอีกครั้งเพื่อคืนค่าขอบที่ถูกลบออกโดยการครอบตัดก่อนหน้านี้"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "กำลังสร้างคีย์ API ของคุณ..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "กำลังสร้างเรซูเม่ของคุณ..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "บันทึก"
 msgid "Save & Test Provider"
 msgstr "ผู้ให้บริการบันทึกและทดสอบ"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "บันทึกและอัปโหลด"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "บันทึกสำเนาที่ไม่มีการป้องกัน ไม่มีรหัสผ่านและไม่มีข้อจำกัดสิทธิ์"
@@ -5226,6 +5222,10 @@ msgstr "ขนาด"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "ทักษะ"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/th-TH.po
+++ b/apps/web/locales/th-TH.po
@@ -1667,7 +1667,7 @@ msgstr "กำลังสร้างเรซูเม่ของคุณ...
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "ครอบตัดและอัปโหลด"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "ทักษะ"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "ข้ามและอัปโหลด"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/tr-TR.po
+++ b/apps/web/locales/tr-TR.po
@@ -1667,7 +1667,7 @@ msgstr "Özgeçmişiniz oluşturuluyor..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Kırp ve yükle"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Yetenekler"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Atla ve yükle"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/tr-TR.po
+++ b/apps/web/locales/tr-TR.po
@@ -1490,10 +1490,6 @@ msgstr "Ayrıştırma puanından ayrı sayılır. Kapsam hiçbir şeyi öngörme
 msgid "Cover"
 msgstr "Kapak"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Kapak, çerçeveyi dolduracak şekilde görüntüyü kırpar. İçer, görüntünün tamamını gösterir. Daha önceki bir kırpma nedeniyle kaldırılan kenarları geri yüklemek için orijinali yeniden yükleyin."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "API anahtarınız oluşturuluyor..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Özgeçmişiniz oluşturuluyor..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Kaydet"
 msgid "Save & Test Provider"
 msgstr "Kaydet ve Test Et Sağlayıcı"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Kaydet ve Yükle"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Parolasız ve izin kısıtlaması olmayan korumasız bir kopya kaydedin."
@@ -5226,6 +5222,10 @@ msgstr "Boyut"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Yetenekler"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/uk-UA.po
+++ b/apps/web/locales/uk-UA.po
@@ -1667,7 +1667,7 @@ msgstr "Створення вашого резюме..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Обрізати та завантажити"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Навички"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Пропустити та завантажити"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/uk-UA.po
+++ b/apps/web/locales/uk-UA.po
@@ -1490,10 +1490,6 @@ msgstr "Рахується окремо від оцінки розпізнава
 msgid "Cover"
 msgstr "Обкладинка"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Обкладинка обрізає зображення, щоб заповнити рамку. Contain показує все зображення. Повторно завантажте оригінал, щоб відновити краї, видалені попереднім кадруванням."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Створення вашого API ключа..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Створення вашого резюме..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Зберегти"
 msgid "Save & Test Provider"
 msgstr "Постачальник послуг збереження та тестування"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Зберегти та завантажити"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Збережіть незахищену копію без пароля та обмежень дозволів."
@@ -5226,6 +5222,10 @@ msgstr "Розмір"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Навички"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/uz-UZ.po
+++ b/apps/web/locales/uz-UZ.po
@@ -1490,10 +1490,6 @@ msgstr "O'qish balidan alohida hisoblanadi. Qamrov hech narsani bashorat qilmayd
 msgid "Cover"
 msgstr "Qopqoq"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Qopqoq ramkani toʻldirish uchun tasvirni kesadi. Contain butun tasvirni ko'rsatadi. Oldingi kesish natijasida olib tashlangan qirralarni tiklash uchun asl nusxani qayta yuklang."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "API kalitingiz yaratilmoqda..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Rezyumingiz yaratilmoqda..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Saqlash"
 msgid "Save & Test Provider"
 msgstr "Saqlash va sinovdan o'tkazish provayderi"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Saqlash va yuklash"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Parolsiz va ruxsat cheklovlarisiz himoyalanmagan nusxa saqlang."
@@ -5226,6 +5222,10 @@ msgstr "Hajmi"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Koʻnikmalar"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/uz-UZ.po
+++ b/apps/web/locales/uz-UZ.po
@@ -1667,7 +1667,7 @@ msgstr "Rezyumingiz yaratilmoqda..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Rasmni qirqish va yuklash"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Koʻnikmalar"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "O‘tkazib yuborish va yuklash"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/vi-VN.po
+++ b/apps/web/locales/vi-VN.po
@@ -1667,7 +1667,7 @@ msgstr "Đang tạo sơ yếu lý lịch của bạn..."
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "Cắt và tải ảnh lên"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "Kỹ năng"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "Bỏ qua và tải ảnh lên"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/vi-VN.po
+++ b/apps/web/locales/vi-VN.po
@@ -1490,10 +1490,6 @@ msgstr "Được tính riêng với điểm phân tích. Độ bao phủ không 
 msgid "Cover"
 msgstr "Bìa"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "Che cắt hình ảnh để lấp đầy khung. Chứa hiển thị toàn bộ hình ảnh. Tải lại bản gốc lên để khôi phục các cạnh bị xóa bởi lần cắt trước đó."
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "Đang tạo khóa API của bạn..."
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "Đang tạo sơ yếu lý lịch của bạn..."
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "Lưu"
 msgid "Save & Test Provider"
 msgstr "Lưu & Kiểm tra Nhà cung cấp"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "Lưu & Tải lên"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "Lưu một bản không bảo vệ, không mật khẩu và không hạn chế quyền."
@@ -5226,6 +5222,10 @@ msgstr "Kích thước"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "Kỹ năng"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/zh-CN.po
+++ b/apps/web/locales/zh-CN.po
@@ -1490,10 +1490,6 @@ msgstr "与解析得分分开计算。覆盖率并不能预测任何事情。"
 msgid "Cover"
 msgstr "裁剪填满"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "“裁剪填满”会裁剪图片以填满画框，“完整显示”会显示整张图片。重新上传原图，可恢复此前裁剪掉的边缘。"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "正在创建你的 API key…"
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "正在创建你的简历…"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "节省"
 msgid "Save & Test Provider"
 msgstr "保存和测试提供商"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "保存并上传"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "保存一份不受保护的副本，不设密码，也不设权限限制。"
@@ -5226,6 +5222,10 @@ msgstr "大小"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "技能"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/zh-CN.po
+++ b/apps/web/locales/zh-CN.po
@@ -1667,7 +1667,7 @@ msgstr "正在创建你的简历…"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "裁剪并上传"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "技能"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "跳过并上传"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/zh-TW.po
+++ b/apps/web/locales/zh-TW.po
@@ -1667,7 +1667,7 @@ msgstr "正在建立您的履歷…"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop and Upload"
-msgstr ""
+msgstr "裁切並上傳"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -5225,7 +5225,7 @@ msgstr "技能"
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Skip and Upload"
-msgstr ""
+msgstr "跳過並上傳"
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/zh-TW.po
+++ b/apps/web/locales/zh-TW.po
@@ -1490,10 +1490,6 @@ msgstr "與解析分數分開計算。涵蓋率並不預測任何事情。"
 msgid "Cover"
 msgstr "裁切填滿"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr "「裁切填滿」會裁切圖片以填滿框架，「完整顯示」會顯示整張圖片。重新上傳原圖，可還原先前裁切掉的邊緣。"
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1668,6 +1664,10 @@ msgstr "正在建立您的 API Key…"
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
 msgstr "正在建立您的履歷…"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
+msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
 msgid "Crop picture"
@@ -4759,10 +4759,6 @@ msgstr "節省"
 msgid "Save & Test Provider"
 msgstr "保存和測試提供者"
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr "儲存並上傳"
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr "儲存一份不受保護的副本，不設密碼，也不設權限限制。"
@@ -5226,6 +5222,10 @@ msgstr "尺寸"
 #: src/libs/resume/section.tsx
 msgid "Skills"
 msgstr "技能"
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
+msgstr ""
 
 #: src/routes/_home/route.tsx
 #: src/routes/builder/$resumeId/-components/desktop-builder-shell.tsx

--- a/apps/web/locales/zu-ZA.po
+++ b/apps/web/locales/zu-ZA.po
@@ -1485,10 +1485,6 @@ msgstr ""
 msgid "Cover"
 msgstr ""
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore edges removed by an earlier crop."
-msgstr ""
-
 #: src/features/applications/components/application-detail-sheet.tsx
 #: src/features/applications/components/application-form-sheet.tsx
 #: src/features/cover-letters/library.tsx
@@ -1662,6 +1658,10 @@ msgstr ""
 
 #: src/dialogs/resume/index.tsx
 msgid "Creating your resume..."
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Crop and Upload"
 msgstr ""
 
 #: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -4754,10 +4754,6 @@ msgstr ""
 msgid "Save & Test Provider"
 msgstr ""
 
-#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
-msgid "Save & Upload"
-msgstr ""
-
 #: src/features/ats-checker/messages.ts
 msgid "Save an unprotected copy, with no password and no permissions restrictions."
 msgstr ""
@@ -5220,6 +5216,10 @@ msgstr ""
 #: src/libs/resume/section-title.ts
 #: src/libs/resume/section.tsx
 msgid "Skills"
+msgstr ""
+
+#: src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+msgid "Skip and Upload"
 msgstr ""
 
 #: src/routes/_home/route.tsx

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/field-labels.test.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/field-labels.test.tsx
@@ -2,7 +2,7 @@
 
 import type { ResumeData } from "@reactive-resume/schema/resume/data";
 import type { ReactNode } from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "@lingui/core";
@@ -117,6 +117,21 @@ describe("builder field labels", () => {
 		await user.click(screen.getByRole("button", { name: "Cancel" }));
 		expect(dialog).not.toBeInTheDocument();
 		expect(state.uploadFile).not.toHaveBeenCalled();
+	});
+
+	it("uploads the original file when cropping is skipped", async () => {
+		const user = userEvent.setup();
+		renderSection(<PictureSectionBuilder />);
+
+		const file = new File(["original-image"], "original.png", { type: "image/png" });
+		await user.upload(screen.getAllByLabelText("Upload picture")[0] as HTMLInputElement, file);
+
+		const dialog = screen.getByRole("dialog", { name: "Crop picture" });
+		await user.click(within(dialog).getByRole("button", { name: "Skip and Upload" }));
+
+		await waitFor(() => expect(state.uploadFile).toHaveBeenCalledOnce());
+		expect(state.uploadFile.mock.calls[0]?.[0]).toBe(file);
+		expect(screen.queryByRole("dialog", { name: "Crop picture" })).not.toBeInTheDocument();
 	});
 
 	it("retries the same full contain file after an upload error", async () => {

--- a/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
+++ b/apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx
@@ -183,12 +183,6 @@ function PictureFitField({ form, onAutoSave }: PictureFieldProps) {
 							<Trans>Contain</Trans>
 						</Button>
 					</ButtonGroup>
-					<p className="text-muted-foreground text-xs">
-						<Trans>
-							Cover crops the image to fill the frame. Contain shows the whole image. Reupload the original to restore
-							edges removed by an earlier crop.
-						</Trans>
-					</p>
 				</div>
 			)}
 		</form.Field>
@@ -685,17 +679,29 @@ function PictureSectionForm() {
 						</div>
 					</div>
 
-					<DialogFooter>
+					<DialogFooter className="flex-row flex-wrap justify-between">
 						<Button variant="outline" onClick={closeCropDialog}>
 							<Trans>Cancel</Trans>
 						</Button>
-						<Button
-							onClick={() => {
-								void onConfirmCrop();
-							}}
-						>
-							<Trans>Save & Upload</Trans>
-						</Button>
+						<div className="flex flex-wrap gap-2">
+							<Button
+								variant="outline"
+								onClick={() => {
+									if (!cropState) return;
+									uploadPictureFile(cropState.file);
+									closeCropDialog();
+								}}
+							>
+								<Trans>Skip and Upload</Trans>
+							</Button>
+							<Button
+								onClick={() => {
+									void onConfirmCrop();
+								}}
+							>
+								<Trans>Crop and Upload</Trans>
+							</Button>
+						</div>
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -4,6 +4,32 @@ description: "Release notes for Reactive Resume covering new features, resume bu
 rss: true
 ---
 
+<Update label="v5.3.0" description="6th September 2026">
+## Highlights
+
+- **Create cover letters from the resume builder.** When a resume has a cover-letter section, the builder rail now links directly to it. [a3784558b](https://github.com/amruthpillai/reactive-resume/commit/a3784558b)
+- **Choose cover-letter templates separately from sender details.** New and existing letters can use any template, while sender details can still be copied from a resume. You can also import a saved letter when adding a cover-letter section. [df2e21ef9](https://github.com/amruthpillai/reactive-resume/commit/df2e21ef9)
+- **Resume previews now expose a proper outline to screen readers.** Section and entry headings, nested roles, rich-text lists, and emphasis are preserved in the accessible text view. Hidden content stays hidden, and unsafe links are left out. [9f0202eac](https://github.com/amruthpillai/reactive-resume/commit/9f0202eac), [acd2a9cfe](https://github.com/amruthpillai/reactive-resume/commit/acd2a9cfe)
+- **Keep original photo framing when uploading.** The crop dialog now lets you skip cropping and upload the original image, so the Cover and Contain choices remain useful after upload. [40c997a](https://github.com/amruthpillai/reactive-resume/commit/40c997a)
+
+## Cover Letters
+
+- The cover-letter library now uses a template picker for letter styling, while the resume picker is reserved for sender details and copying content from an existing resume. Refreshing sender details no longer changes the selected template. [df2e21ef9](https://github.com/amruthpillai/reactive-resume/commit/df2e21ef9)
+- Standardized the **Cover Letters** label across the dashboard, library, documentation, and dialogs. [52949fcb4](https://github.com/amruthpillai/reactive-resume/commit/52949fcb4)
+
+## Accessibility
+
+- The accessible resume view now keeps heading levels consistent for entries and nested roles, renders supported rich-text structure, and ignores markup that should not reach assistive technologies. [9f0202eac](https://github.com/amruthpillai/reactive-resume/commit/9f0202eac), [acd2a9cfe](https://github.com/amruthpillai/reactive-resume/commit/acd2a9cfe)
+
+## Self-Hosting & Maintenance
+
+- Added a database migration to match Better Auth 1.7.3. Existing issuer values remain available, while new accounts no longer require that field or its retired uniqueness index. [cea27a97b](https://github.com/amruthpillai/reactive-resume/commit/cea27a97b)
+- Synced the latest translation catalogs from Crowdin. [d277518d2](https://github.com/amruthpillai/reactive-resume/commit/d277518d2)
+- Updated workspace dependencies and development tooling. [e272037be](https://github.com/amruthpillai/reactive-resume/commit/e272037be)
+
+**Full Changelog**: [v5.2.9...v5.3.0](https://github.com/amruthpillai/reactive-resume/compare/v5.2.9...v5.3.0)
+</Update>
+
 <Update label="v5.2.9" description="27th August 2026">
 ## Highlights
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "reactive-resume",
 	"description": "Reactive Resume is a free and open-source resume builder that makes it easy to create, update, and share your resume.",
-	"version": "5.2.9",
+	"version": "5.3.0",
 	"private": true,
 	"license": "MIT",
 	"author": {

--- a/tests/e2e/specs/picture-upload.spec.ts
+++ b/tests/e2e/specs/picture-upload.spec.ts
@@ -32,7 +32,7 @@ test("uploads a large JPEG after cropping without exceeding the upload limit", a
 	});
 	const cropDialog = page.getByRole("dialog", { name: "Crop picture" });
 	await expect(cropDialog.locator("img")).toBeVisible();
-	await cropDialog.getByRole("button", { name: "Save & Upload" }).click();
+	await cropDialog.getByRole("button", { name: "Crop and Upload" }).click();
 	await expect(page.locator("#sidebar-picture input[name=url]")).toHaveValue(/\/uploads\//);
 	await expect
 		.poll(() => page.locator("#sidebar-picture img").evaluate((image: HTMLImageElement) => image.naturalWidth))


### PR DESCRIPTION
## Summary

- Bump release version to v5.3.0.
- Add humanized changelog entries for cover letters, accessibility, photo uploads, and maintenance.
- Allow users to skip photo cropping and upload the original file.
- Label actions `Skip and Upload` and `Crop and Upload`; keep `Cancel` on the left.

## Validation

- `pnpm check` passes.
- Focused picture upload unit test passes: 7/7.
- Picture upload Playwright test passes: 1/1.
- Full `pnpm typecheck` is blocked by existing TypeScript TS5096 configuration error.
- Full `pnpm test` is blocked by generated JavaScript artifacts being parsed as JSX by Vite.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **Skip and Upload** to upload original photos without cropping.
  - Renamed the cropping action to **Crop and Upload**.
  - Improved the crop dialog layout for clearer action selection.

- **Localization**
  - Updated picture-upload labels and translations across supported languages.

- **Documentation**
  - Added the v5.3.0 changelog entry covering photo-upload improvements and other release updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prepares the v5.3.0 release and adds an option to upload a photo without cropping.
- Adds separate skip-and-upload and crop-and-upload actions.
- Updates upload tests, locale catalogs, release metadata, and the changelog.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no blocking failure remaining.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/routes/builder/$resumeId/-sidebar/left/sections/picture.tsx | Adds distinct actions for uploading the original image or applying the configured crop. |
| tests/e2e/specs/picture-upload.spec.ts | Extends picture-upload coverage for the new original-file upload path. |
| package.json | Advances the package release version to 5.3.0. |
| docs/changelog/index.mdx | Documents the v5.3.0 release changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: update translations"](https://github.com/amruthpillai/reactive-resume/commit/e8f20b2e113735d3a298c587a411bd692214e6bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60970140)</sub>

<!-- /greptile_comment -->