### PR TITLE
fix(pdf): add marginTop to style of "section" in "Lapras" template

### DIFF
--- a/packages/pdf/src/templates/lapras/LaprasPage.tsx
+++ b/packages/pdf/src/templates/lapras/LaprasPage.tsx
@@ -152,6 +152,7 @@ const useLaprasTemplate = (): LaprasTemplate => {
 				borderRadius: pictureBorderRadius,
 				backgroundColor: background,
 				padding: metrics.gapX(1),
+				marginTop: Math.max(0, headingNegativeMargin - metrics.gapX(1)),
 			},
 			sectionHeading: {
 				alignSelf: "flex-start",


### PR DESCRIPTION
## Bug

Using the default style "Lapras" template, the section heading overlaps with the section above.

## Fix

Add top margin to "section" style to offset the negative margin (headingNegativeMargin) of sectionHeading.

## Info:

**reactive-resume**: v5.3.0
**template**: Lapras
**styles**: default

## Examples

**before**

<img width="495" height="274" alt="before" src="https://github.com/user-attachments/assets/bba3758e-4303-47f5-b579-33cc33cb0873" />

**after**

<img width="500" height="357" alt="after" src="https://github.com/user-attachments/assets/2edb9a9a-2d86-4522-8c06-27aa16995457" />


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects section-heading overlap in the Lapras PDF template by compensating for the heading’s negative top margin.
- Adds a non-negative top margin to each section container.
- Derives the compensation from the heading offset and existing section gap.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness, security, or maintainability issues identified.

The new margin is bounded at zero and directly compensates for the existing negative heading margin, addressing the reported overlap without an established broken layout path.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/lapras/LaprasPage.tsx | Adds a bounded section offset that compensates for the Lapras heading’s negative margin without introducing an established defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pdf): add marginTop to style of &quot;sec..."](https://github.com/amruthpillai/reactive-resume/commit/6512a1345f72cacfbfc7b4af6fc00c24a067d41e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61922952)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spacing between sections in the Lapras PDF template by adjusting the top margin based on heading size and layout gaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->