### PR TITLE
fix(pdf/onyx): restore profiles section to header right column

### DIFF
--- a/packages/pdf/src/templates/onyx/OnyxPage.test.tsx
+++ b/packages/pdf/src/templates/onyx/OnyxPage.test.tsx
@@ -95,6 +95,59 @@ const renderOnyxWithProfiles = async () => {
 	}
 };
 
+const renderOnyxWithProfilesOnSecondPage = async () => {
+	const data = structuredClone(defaultResumeData);
+	data.basics.name = "Name";
+	data.basics.headline = "Headline";
+	data.basics.email = "email@example.com";
+	data.picture.hidden = true;
+	data.summary = {
+		...data.summary,
+		hidden: false,
+		showHeading: false,
+		content: "<p>Summary body text</p>",
+	};
+	data.sections.profiles = {
+		...data.sections.profiles,
+		hidden: false,
+		showHeading: false,
+		items: [
+			{
+				id: "profile-1",
+				hidden: false,
+				icon: "github-logo",
+				iconColor: "",
+				network: "GitHub",
+				username: "dkowalski-dev",
+				website: { url: "https://github.com/dkowalski-dev", label: "", inlineLink: false },
+			},
+		],
+	};
+	data.metadata.page.locale = "en-US";
+	data.metadata.page.marginX = 14;
+	data.metadata.stylesheet = { mode: "semantic", source: { languageVersion: 1, text: "@version 1;" } };
+	data.metadata.layout.pages = [
+		{ fullWidth: false, main: ["summary"], sidebar: [] },
+		{ fullWidth: false, main: ["profiles"], sidebar: [] },
+	];
+	const element = createElement(ResumeDocument, { data, template: "onyx" }) as unknown as Parameters<
+		typeof renderToBuffer
+	>[0];
+	let bytes: Uint8Array = new Uint8Array();
+	await act(async () => {
+		bytes = new Uint8Array(await renderToBuffer(element));
+	});
+	const loadingTask = getDocument({ data: bytes, useSystemFonts: true });
+	try {
+		const document = await loadingTask.promise;
+		const page = await document.getPage(2);
+		const content = await page.getTextContent();
+		return content.items.filter((item): item is TextItem => "str" in item && Boolean(item.str.trim()));
+	} finally {
+		await loadingTask.destroy();
+	}
+};
+
 describe("Onyx headline width (#3339)", () => {
 	it.each([
 		{ locale: "en-US", hasPicture: true },
@@ -136,5 +189,10 @@ describe("Onyx profiles header (#2812)", () => {
 	it("does not render the network name as text in the header", async () => {
 		const lines = await renderOnyxWithProfiles();
 		expect(lines.some((line) => line.str === "GitHub")).toBe(false);
+	});
+
+	it("keeps visible profiles in the body when the header is hidden", async () => {
+		const lines = await renderOnyxWithProfilesOnSecondPage();
+		expect(lines.some((line) => line.str.includes("dkowalski-dev"))).toBe(true);
 	});
 });

--- a/packages/pdf/src/templates/onyx/OnyxPage.test.tsx
+++ b/packages/pdf/src/templates/onyx/OnyxPage.test.tsx
@@ -45,6 +45,56 @@ const renderHeader = async (locale: string, hasPicture: boolean) => {
 	}
 };
 
+const renderOnyxWithProfiles = async () => {
+	const data = structuredClone(defaultResumeData);
+	data.basics.name = "Name";
+	data.basics.headline = "Headline";
+	data.basics.email = "email@example.com";
+	data.picture.hidden = true;
+	data.summary = {
+		...data.summary,
+		hidden: false,
+		showHeading: false,
+		content: "<p>Summary body text</p>",
+	};
+	data.sections.profiles = {
+		...data.sections.profiles,
+		hidden: false,
+		showHeading: false,
+		items: [
+			{
+				id: "profile-1",
+				hidden: false,
+				icon: "github-logo",
+				iconColor: "",
+				network: "GitHub",
+				username: "dkowalski-dev",
+				website: { url: "https://github.com/dkowalski-dev", label: "", inlineLink: false },
+			},
+		],
+	};
+	data.metadata.page.locale = "en-US";
+	data.metadata.page.marginX = 14;
+	data.metadata.stylesheet = { mode: "semantic", source: { languageVersion: 1, text: "@version 1;" } };
+	data.metadata.layout.pages = [{ fullWidth: false, main: ["summary", "profiles"], sidebar: [] }];
+	const element = createElement(ResumeDocument, { data, template: "onyx" }) as unknown as Parameters<
+		typeof renderToBuffer
+	>[0];
+	let bytes: Uint8Array = new Uint8Array();
+	await act(async () => {
+		bytes = new Uint8Array(await renderToBuffer(element));
+	});
+	const loadingTask = getDocument({ data: bytes, useSystemFonts: true });
+	try {
+		const document = await loadingTask.promise;
+		const page = await document.getPage(1);
+		const content = await page.getTextContent();
+		return content.items.filter((item): item is TextItem => "str" in item && Boolean(item.str.trim()));
+	} finally {
+		await loadingTask.destroy();
+	}
+};
+
 describe("Onyx headline width (#3339)", () => {
 	it.each([
 		{ locale: "en-US", hasPicture: true },
@@ -70,4 +120,21 @@ describe("Onyx headline width (#3339)", () => {
 			}
 		},
 	);
+});
+
+describe("Onyx profiles header (#2812)", () => {
+	it("renders visible profile items in the header instead of the body", async () => {
+		const lines = await renderOnyxWithProfiles();
+		const profileLine = lines.find((line) => line.str.includes("dkowalski-dev"));
+		const summaryLine = lines.find((line) => line.str.includes("Summary body"));
+
+		expect(profileLine).toBeDefined();
+		expect(summaryLine).toBeDefined();
+		expect(profileLine?.transform[5]).toBeGreaterThan(summaryLine?.transform[5]);
+	});
+
+	it("does not render the network name as text in the header", async () => {
+		const lines = await renderOnyxWithProfiles();
+		expect(lines.some((line) => line.str === "GitHub")).toBe(false);
+	});
 });

--- a/packages/pdf/src/templates/onyx/OnyxPage.tsx
+++ b/packages/pdf/src/templates/onyx/OnyxPage.tsx
@@ -67,7 +67,7 @@ export const OnyxPage = ({ page, pageSize, pageMinHeightStyle, showHeader, pageN
 	const metrics = getTemplateMetrics(metadata.page);
 	const isProfilesInLayout = page.main.includes("profiles") || page.sidebar.includes("profiles");
 	const showProfiles = hasVisibleItems(data.sections.profiles, "profiles") && isProfilesInLayout;
-	const excludeFromBody = (section: string) => !showProfiles || section !== "profiles";
+	const excludeFromBody = (section: string) => !showHeader || !showProfiles || section !== "profiles";
 	const mainSections = useRenderedSectionIds(pageNodeKey, filterSections(page.main, data).filter(excludeFromBody));
 	const sidebarSections = useRenderedSectionIds(
 		pageNodeKey,

--- a/packages/pdf/src/templates/onyx/OnyxPage.tsx
+++ b/packages/pdf/src/templates/onyx/OnyxPage.tsx
@@ -1,11 +1,13 @@
 import type { Style } from "@react-pdf/types";
+import type { IconName } from "phosphor-icons-react-pdf/dynamic";
 import type { TemplatePageProps } from "../../document";
 import type { TemplateColorRoles, TemplateStyleContext, TemplateStyleSlots } from "../shared/types";
 import { useMemo } from "react";
+import { getNetworkIcon } from "@reactive-resume/resume/icons";
 import { rgbaStringToHex } from "@reactive-resume/utils/color";
 import { Page, StyleSheet, View } from "#react-pdf-renderer";
 import { useRender } from "../../context";
-import { useRenderedSectionIds, useResolvedNode } from "../../semantic/context";
+import { SemanticNodeKeyProvider, useRenderedSectionIds, useResolvedNode } from "../../semantic/context";
 import { semanticNodeKeys } from "../../semantic/node-keys";
 import { createBaseTemplateStyles } from "../shared/base-template-styles";
 import {
@@ -15,12 +17,14 @@ import {
 	PhoneContactItem,
 	WebsiteContactItem,
 } from "../shared/contact-item";
-import { TemplateProvider } from "../shared/context";
-import { filterSections } from "../shared/filtering";
+import { TemplateProvider, useTemplateStyle } from "../shared/context";
+import { filterItems, filterSections, hasVisibleItems } from "../shared/filtering";
 import { getTemplateMetrics } from "../shared/metrics";
 import { hasTemplatePicture } from "../shared/picture";
 import {
 	Heading,
+	Icon,
+	Link,
 	SemanticContactListView,
 	SemanticHeaderPicture,
 	SemanticHeaderView,
@@ -38,6 +42,7 @@ type OnyxStyles = Omit<TemplateStyleSlots, "page"> & {
 	headerTitle: Style;
 	headerIdentity: Style;
 	headerName: Style;
+	headerProfiles: Style;
 	contactList: Style;
 	contactItem: Style;
 	sectionGroup: Style;
@@ -50,6 +55,7 @@ type OnyxTemplate = {
 
 type OnyxHeaderProps = {
 	styles: OnyxStyles;
+	showProfiles: boolean;
 };
 
 export const OnyxPage = ({ page, pageSize, pageMinHeightStyle, showHeader, pageNumber }: TemplatePageProps) => {
@@ -59,8 +65,14 @@ export const OnyxPage = ({ page, pageSize, pageMinHeightStyle, showHeader, pageN
 	const { metadata } = data;
 	const { colors, styles } = useOnyxTemplate();
 	const metrics = getTemplateMetrics(metadata.page);
-	const mainSections = useRenderedSectionIds(pageNodeKey, filterSections(page.main, data));
-	const sidebarSections = useRenderedSectionIds(pageNodeKey, filterSections(page.sidebar, data));
+	const isProfilesInLayout = page.main.includes("profiles") || page.sidebar.includes("profiles");
+	const showProfiles = hasVisibleItems(data.sections.profiles, "profiles") && isProfilesInLayout;
+	const excludeFromBody = (section: string) => !showProfiles || section !== "profiles";
+	const mainSections = useRenderedSectionIds(pageNodeKey, filterSections(page.main, data).filter(excludeFromBody));
+	const sidebarSections = useRenderedSectionIds(
+		pageNodeKey,
+		filterSections(page.sidebar, data).filter(excludeFromBody),
+	);
 
 	return (
 		<Page
@@ -69,7 +81,7 @@ export const OnyxPage = ({ page, pageSize, pageMinHeightStyle, showHeader, pageN
 			style={composeStyles(styles.page, pageMinHeightStyle, semanticPageStyle)}
 		>
 			<TemplateProvider pageNodeKey={pageNodeKey} styles={styles} colors={colors}>
-				{showHeader && <Header styles={styles} />}
+				{showHeader && <Header styles={styles} showProfiles={showProfiles} />}
 
 				<SemanticRegionView region="main" style={composeStyles(styles.sectionGroup, { rowGap: metrics.sectionGap })}>
 					{mainSections.map((section) => (
@@ -92,9 +104,11 @@ export const OnyxPage = ({ page, pageSize, pageMinHeightStyle, showHeader, pageN
 	);
 };
 
-const Header = ({ styles }: OnyxHeaderProps) => {
-	const { basics, picture } = useRender();
+const Header = ({ styles, showProfiles }: OnyxHeaderProps) => {
+	const { basics, picture, sections } = useRender();
 	const hasPicture = hasTemplatePicture(picture);
+	const visibleProfiles = showProfiles ? filterItems(sections.profiles.items, "profiles") : [];
+	const inlineStyle = useTemplateStyle("inline");
 
 	return (
 		<SemanticHeaderView style={styles.header}>
@@ -116,6 +130,33 @@ const Header = ({ styles }: OnyxHeaderProps) => {
 					))}
 				</SemanticContactListView>
 			</View>
+
+			{showProfiles && (
+				<SemanticNodeKeyProvider nodeKey={undefined}>
+					<View style={styles.headerProfiles}>
+						{visibleProfiles.map((item) => {
+							const iconName = (item.icon as IconName) || (getNetworkIcon(item.network) as IconName);
+							const label = item.website.label || item.username;
+							const content = (
+								<>
+									<Icon name={iconName} {...(item.iconColor ? { color: item.iconColor } : {})} />
+									<Text>{label}</Text>
+								</>
+							);
+
+							return item.website.url ? (
+								<Link key={item.id} src={item.website.url} style={composeStyles(inlineStyle)}>
+									{content}
+								</Link>
+							) : (
+								<View key={item.id} style={composeStyles(inlineStyle)}>
+									{content}
+								</View>
+							);
+						})}
+					</View>
+				</SemanticNodeKeyProvider>
+			)}
 		</SemanticHeaderView>
 	);
 };
@@ -175,6 +216,11 @@ const useOnyxTemplate = (): OnyxTemplate => {
 			headerName: {
 				fontSize: metadata.typography.heading.fontSize * 1.5,
 				lineHeight: headerNameLineHeight,
+			},
+			headerProfiles: {
+				flexDirection: "column",
+				alignItems: r.rtl ? "flex-start" : "flex-end",
+				rowGap: metrics.gapY(0.125),
 			},
 			contactList: {
 				flexDirection: r.row,


### PR DESCRIPTION
## Problem

In Onyx v3/v4, LinkedIn/GitHub profile icons rendered in a right-aligned column inside the header, next to the name and contact info. In v5, the Onyx `Header` only renders picture, name/headline, and contact items. `sections.profiles` is rendered only as a body section, so profile links moved below the header or disappeared from the header entirely.

Issue: #2812

## Root cause

`packages/pdf/src/templates/onyx/OnyxPage.tsx` has a `Header` component that destructures only `{ basics, picture }`. It never reads `sections.profiles`, and `ProfileSection` is rendered through the shared body-section path in `packages/pdf/src/templates/shared/sections.tsx`.

## Fix

- `OnyxPage` now checks whether `profiles` is visible and included in the current page layout (`page.main` or `page.sidebar`).
- When true, `Header` renders the visible profile items in a right-aligned flex column using the existing `Icon`, `Link`, and `Text` primitives.
- The body section list filters out `profiles` so the same items do not render twice.
- If `profiles` is hidden, has no visible items, or is not in the layout, the header keeps its current single-column behavior.

## Verification

- `pnpm --filter @reactive-resume/pdf typecheck` passes
- `pnpm --filter @reactive-resume/pdf test` (packages/pdf): 1079 tests passed
- `pnpm exec biome check packages/pdf/src/templates/onyx/OnyxPage.tsx packages/pdf/src/templates/onyx/OnyxPage.test.tsx` passes
- `pnpm exec turbo boundaries` passes
- Added a focused regression test in `packages/pdf/src/templates/onyx/OnyxPage.test.tsx` that confirms a visible profile appears above the body summary and the network name is not duplicated.

## Risks/notes

- Scope is limited to the Onyx PDF template; no schema or other templates changed.
- Profile rendering is gated on the page layout to avoid surprising duplication and to stay consistent with how other sections are shown/hidden.
- The fallback path uses `getNetworkIcon` when a profile item has no explicit icon.

AI-assisted. I wrote and verified this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume profiles appear in the page header when visible profile links are available.
  * Profile entries display network icons and labels, with links applied when a profile URL is provided.

* **Bug Fixes**
  * Profile information is positioned above the resume summary content.
  * Network names are no longer duplicated as plain text in the header.
  * Profiles remain visible in the resume body when their section appears on a separate page.
  * Empty profile sections no longer appear in the layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores visible Onyx profile links to the first-page header while preserving body rendering on headerless later pages.
- Adds right-aligned profile links using existing PDF primitives and network-icon fallback.
- Removes profiles from body only when current page header renders them.
- Adds regression coverage for header placement, omitted network text, and second-page rendering.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

PR appears safe to merge; previous later-page profile-loss finding is fixed.

Headerless pages now retain profiles in body section lists, while first-page profiles are removed from body only when rendered in header. Previous finding was also manually resolved.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pdf/src/templates/onyx/OnyxPage.tsx | Renders eligible profiles in header and correctly retains them in body when header is hidden. |
| packages/pdf/src/templates/onyx/OnyxPage.test.tsx | Covers header profile placement, network-label omission, and later-page profile preservation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(pdf/onyx): keep visible profiles in ..."](https://github.com/amruthpillai/reactive-resume/commit/97071e611328e587ce604118a6c93948f619780a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62875595)</sub>

<!-- /greptile_comment -->