### PR TITLE
fix(web): cache dashboard resume thumbnails

### DIFF
--- a/apps/web/src/routes/dashboard/resumes/-components/cards/resume-thumbnail.test.tsx
+++ b/apps/web/src/routes/dashboard/resumes/-components/cards/resume-thumbnail.test.tsx
@@ -44,6 +44,7 @@ let resize: () => void;
 let media: EventTarget;
 let width = 270;
 let height = 382;
+let currentResume = resume;
 
 beforeEach(() => {
 	mocks.inView = true;
@@ -51,6 +52,7 @@ beforeEach(() => {
 	mocks.toImage.mockClear();
 	width = 270;
 	height = 382;
+	currentResume = resume;
 	vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(() => width);
 	vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(() => height);
 	vi.stubGlobal("devicePixelRatio", 2);
@@ -82,12 +84,12 @@ function setup() {
 	});
 	const ui = () => (
 		<QueryClientProvider client={client}>
-			<ResumeThumbnail resume={resume} isLocked={false} />
+			<ResumeThumbnail resume={currentResume} isLocked={false} />
 		</QueryClientProvider>
 	);
 	const result = render(ui());
 	const image = () => result.container.querySelector<HTMLElement>("[style*='background-image']")?.style.backgroundImage;
-	return { ...result, image, refresh: () => result.rerender(ui()) };
+	return { ...result, client, image, refresh: () => result.rerender(ui()) };
 }
 
 it("upgrades a cached image after growth and keeps it visible until replacement is ready", async () => {
@@ -121,7 +123,36 @@ it("upgrades a cached image after growth and keeps it visible until replacement 
 	expect(view.image()).toContain("blob:1216x1728");
 	expect(mocks.toImage).toHaveBeenCalledTimes(2);
 	view.unmount();
-	expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:1216x1728");
+	expect(URL.revokeObjectURL).not.toHaveBeenCalledWith("blob:1216x1728");
+});
+
+it("reuses rendered image after card hide and remount", async () => {
+	const view = setup();
+	await waitFor(() => expect(view.image()).toContain("blob:576x768"));
+	view.unmount();
+
+	const remounted = render(
+		<QueryClientProvider client={view.client}>
+			<ResumeThumbnail resume={resume} isLocked={false} />
+		</QueryClientProvider>,
+	);
+	await waitFor(() => expect(remounted.container.querySelector<HTMLElement>("[style*='background-image']")?.style.backgroundImage).toContain("blob:576x768"));
+	expect(mocks.toPdf).toHaveBeenCalledTimes(1);
+	expect(mocks.toImage).toHaveBeenCalledTimes(1);
+	remounted.unmount();
+});
+
+it("revokes rendered images when query is evicted or replaced", async () => {
+	const view = setup();
+	await waitFor(() => expect(view.image()).toContain("blob:576x768"));
+	currentResume = { ...resume, updatedAt: new Date(1000) };
+	view.refresh();
+	await waitFor(() => expect(view.image()).toContain("blob:576x768"));
+	expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:576x768");
+
+	view.client.removeQueries({ queryKey: ["resume-thumbnail"] });
+	expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:576x768");
+	view.unmount();
 });
 
 it("upgrades after a DPR change even when CSS dimensions do not change", async () => {

--- a/apps/web/src/routes/dashboard/resumes/-components/cards/resume-thumbnail.tsx
+++ b/apps/web/src/routes/dashboard/resumes/-components/cards/resume-thumbnail.tsx
@@ -3,7 +3,7 @@ import type { RefObject } from "react";
 import type { ResumeThumbnailSize } from "@/features/resume/preview/resume-thumbnail.shared";
 import type { RouterOutput } from "@/libs/orpc/client";
 import { FileTextIcon } from "@phosphor-icons/react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useInView } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { Spinner } from "@reactive-resume/ui/components/spinner";
@@ -25,6 +25,21 @@ type ResumeThumbnailProps = {
 const throwIfAborted = (signal: AbortSignal) => {
 	if (signal.aborted) throw new DOMException("Thumbnail generation aborted.", "AbortError");
 };
+
+const THUMBNAIL_CACHE_TIME = 5 * 60 * 1000;
+const thumbnailQueryCaches = new WeakSet<object>();
+
+function ensureThumbnailCacheLifecycle(queryClient: ReturnType<typeof useQueryClient>) {
+	const queryCache = queryClient.getQueryCache();
+	if (thumbnailQueryCaches.has(queryCache)) return;
+
+	thumbnailQueryCaches.add(queryCache);
+	queryCache.subscribe((event) => {
+		if (event.type !== "removed") return;
+		const url = event.query.state.data;
+		if (typeof url === "string") URL.revokeObjectURL(url);
+	});
+}
 
 const createResumeThumbnailUrl = async (data: ResumeData, size: ResumeThumbnailSize, signal: AbortSignal) => {
 	const pdf = await createResumePdfBlob(data);
@@ -90,6 +105,24 @@ function useResumeThumbnail(
 	size: ResumeThumbnailSize,
 	enabled: boolean,
 ): ThumbnailState {
+	const queryClient = useQueryClient();
+
+	useEffect(() => {
+		ensureThumbnailCacheLifecycle(queryClient);
+	}, [queryClient]);
+
+	useEffect(() => {
+		const queryCache = queryClient.getQueryCache();
+		const resumePrefix = `${cacheKey.slice(0, cacheKey.lastIndexOf(":"))}:`;
+
+		for (const query of queryCache.findAll({ queryKey: ["resume-thumbnail"] })) {
+			const queryCacheKey = query.queryKey[1];
+			if (typeof queryCacheKey === "string" && queryCacheKey.startsWith(resumePrefix) && queryCacheKey !== cacheKey) {
+				queryCache.remove(query);
+			}
+		}
+	}, [cacheKey, queryClient]);
+
 	const {
 		data: thumbnailData,
 		error: thumbnailError,
@@ -103,20 +136,25 @@ function useResumeThumbnail(
 		enabled: Boolean(enabled && data && size.width && size.height),
 		placeholderData: (previous, query) => (query?.queryKey[1] === cacheKey ? previous : undefined),
 		staleTime: Number.POSITIVE_INFINITY,
-		gcTime: 0,
+		gcTime: THUMBNAIL_CACHE_TIME,
 	});
+	const previousThumbnailData = useRef<string | undefined>(undefined);
 
 	useEffect(() => {
 		if (thumbnailError) console.error("Failed to generate resume thumbnail", thumbnailError);
 	}, [thumbnailError]);
 
 	useEffect(() => {
-		const url = thumbnailData;
-
-		return () => {
-			if (url) URL.revokeObjectURL(url);
-		};
-	}, [thumbnailData]);
+		const previousUrl = previousThumbnailData.current;
+		if (previousUrl && previousUrl !== thumbnailData) {
+			const previousQuery = queryClient
+				.getQueryCache()
+				.findAll({ queryKey: ["resume-thumbnail"] })
+				.find((query) => query.state.data === previousUrl);
+			if (previousQuery) queryClient.getQueryCache().remove(previousQuery);
+		}
+		previousThumbnailData.current = thumbnailData;
+	}, [queryClient, thumbnailData]);
 
 	if (!data || !cacheKey) return { status: "idle" };
 	if (thumbnailIsError) return { status: "error" };


### PR DESCRIPTION
## Summary
- Cache rendered dashboard resume thumbnail images across card unmounts and remounts.
- Revoke blob URLs on query eviction and revision/size replacement.
- Add lifecycle coverage for remount reuse and cleanup.

## Test plan
- `pnpm --filter web exec vitest run --passWithNoTests src/routes/dashboard/resumes/-components/cards/resume-thumbnail.test.tsx` (5 passed)
- `pnpm test` (12/17 tasks passed; unrelated API statistics test failed because PostgreSQL password authentication failed for user `postgres`.)