### PR TITLE
fix: stop application search session refetches

### DIFF
--- a/apps/web/src/routes/dashboard/applications/index.tsx
+++ b/apps/web/src/routes/dashboard/applications/index.tsx
@@ -67,6 +67,7 @@ function RouteComponent() {
 	const { search, view, tags, sort, archived, create, applicationId } = Route.useSearch();
 	const navigate = useNavigate({ from: Route.fullPath });
 
+	const [textSearch, setTextSearch] = useState(search);
 	const [addOpen, setAddOpen] = useState(false);
 	const [importOpen, setImportOpen] = useState(false);
 	const [exportOpen, setExportOpen] = useState(false);
@@ -98,7 +99,7 @@ function RouteComponent() {
 
 	// Board & table hide archived; tag/search filters + sort are applied client-side.
 	const filtered = useMemo(() => {
-		const query = search.trim().toLowerCase();
+		const query = textSearch.trim().toLowerCase();
 		const rows = (applications ?? [])
 			.filter((app) => archived || !app.archived)
 			.filter((app) => tags.length === 0 || tags.every((tag: string) => app.tags.includes(tag)))
@@ -111,13 +112,13 @@ function RouteComponent() {
 			role: (a, b) => a.role.localeCompare(b.role),
 		};
 		return rows.sort(compare[sort as SortKey]);
-	}, [applications, search, tags, sort, archived]);
+	}, [applications, textSearch, tags, sort, archived]);
 
 	const archivedCount = (applications ?? []).filter((app) => app.archived).length;
 
 	const isEmpty = (applications?.length ?? 0) === 0;
 
-	const setSearch = (patch: Partial<Search>) => void navigate({ search: (prev: Search) => ({ ...prev, ...patch }) });
+	const setUrlSearch = (patch: Partial<Search>) => void navigate({ search: (prev: Search) => ({ ...prev, ...patch }) });
 
 	return (
 		<div className="flex h-[calc(100dvh-2rem)] flex-col gap-4">
@@ -158,9 +159,9 @@ function RouteComponent() {
 								<MagnifyingGlassIcon />
 							</InputGroupAddon>
 							<InputGroupInput
-								value={search}
+								value={textSearch}
 								placeholder={t`Search applications…`}
-								onChange={(event) => setSearch({ search: event.target.value })}
+								onChange={(event) => setTextSearch(event.target.value)}
 							/>
 						</InputGroup>
 
@@ -172,7 +173,7 @@ function RouteComponent() {
 								value={tags}
 								placeholder={t`Filter by tags`}
 								options={(allTags ?? []).map((tag) => ({ value: tag, label: tag }))}
-								onValueChange={(value) => setSearch({ tags: value ?? [] })}
+								onValueChange={(value) => setUrlSearch({ tags: value ?? [] })}
 							/>
 						)}
 
@@ -182,7 +183,7 @@ function RouteComponent() {
 								value={sort}
 								placeholder={t`Sort by…`}
 								options={SORT_OPTIONS.map((option) => ({ value: option.value, label: i18n.t(option.label) }))}
-								onValueChange={(value) => value && setSearch({ sort: value as SortKey })}
+								onValueChange={(value) => value && setUrlSearch({ sort: value as SortKey })}
 							/>
 						)}
 
@@ -191,7 +192,7 @@ function RouteComponent() {
 								size="sm"
 								variant={archived ? "secondary" : "outline"}
 								className="shrink-0 max-sm:hidden"
-								onClick={() => setSearch({ archived: !archived })}
+								onClick={() => setUrlSearch({ archived: !archived })}
 							>
 								<ArchiveIcon />
 								<Trans>Archived</Trans> ({archivedCount})
@@ -223,7 +224,7 @@ function RouteComponent() {
 												value={tags}
 												placeholder={t`Any tag`}
 												options={(allTags ?? []).map((tag) => ({ value: tag, label: tag }))}
-												onValueChange={(value) => setSearch({ tags: value ?? [] })}
+												onValueChange={(value) => setUrlSearch({ tags: value ?? [] })}
 											/>
 										</div>
 									)}
@@ -235,7 +236,7 @@ function RouteComponent() {
 											className="w-full"
 											value={sort}
 											options={SORT_OPTIONS.map((option) => ({ value: option.value, label: i18n.t(option.label) }))}
-											onValueChange={(value) => value && setSearch({ sort: value as SortKey })}
+											onValueChange={(value) => value && setUrlSearch({ sort: value as SortKey })}
 										/>
 									</div>
 									{archivedCount > 0 && (
@@ -243,7 +244,7 @@ function RouteComponent() {
 											size="sm"
 											variant={archived ? "secondary" : "outline"}
 											className="w-full"
-											onClick={() => setSearch({ archived: !archived })}
+											onClick={() => setUrlSearch({ archived: !archived })}
 										>
 											<ArchiveIcon />
 											<Trans>Archived</Trans> ({archivedCount})
@@ -295,7 +296,10 @@ function RouteComponent() {
 								<Button
 									size="sm"
 									variant="outline"
-									onClick={() => setSearch({ search: "", tags: [], archived: false })}
+									onClick={() => {
+										setTextSearch("");
+										setUrlSearch({ tags: [], archived: false });
+									}}
 								>
 									<Trans>Clear filters</Trans>
 								</Button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.3.4
-        version: 12.3.4
       pnpm:
         specifier: 12.3.4
         version: 12.3.4
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.3.4':
-    resolution: {integrity: sha512-Rq7JokWAyYF9IFfn8zofB/q2AgnZlmoMuH5fMHB2+Ta61I9aD7sNm+woZpx6iH+5vb38chdSoYRvOtSqlH72YQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.3.4:
     resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.3.4':
     optional: true
-
-  '@pnpm/exe@12.3.4':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.3.4
-      '@pnpm/exe.darwin-x64': 12.3.4
-      '@pnpm/exe.linux-arm64': 12.3.4
-      '@pnpm/exe.linux-arm64-musl': 12.3.4
-      '@pnpm/exe.linux-x64': 12.3.4
-      '@pnpm/exe.linux-x64-musl': 12.3.4
-      '@pnpm/exe.win32-arm64': 12.3.4
-      '@pnpm/exe.win32-x64': 12.3.4
 
   pnpm@12.3.4:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.3.4
+        version: 12.3.4
       pnpm:
         specifier: 12.3.4
         version: 12.3.4
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.3.4':
+    resolution: {integrity: sha512-Rq7JokWAyYF9IFfn8zofB/q2AgnZlmoMuH5fMHB2+Ta61I9aD7sNm+woZpx6iH+5vb38chdSoYRvOtSqlH72YQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.3.4:
     resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.3.4':
     optional: true
+
+  '@pnpm/exe@12.3.4':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
 
   pnpm@12.3.4:
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Keep application text search in local React state.
- Preserve URL-backed view, tags, sort, archive, create, and applicationId state.
- Prevent navigation and `/api/auth/get-session` refetches while typing.

## Test Plan
- `git diff --check` passed.
- Biome, typecheck, and focused application tests were attempted but blocked by pnpm dependency bootstrap timeouts against the local registry.